### PR TITLE
Add Visual Studio project and solution generator to scons as a build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ Main Repo for the OpenVic2 Project
 2. Build with `scons dev_build=yes`.
 3. [Setup your IDE](https://godotengine.org/qa/108346/how-can-i-debug-runtime-errors-of-native-library-in-godot) so your Command/Host/Launching App is your Godot 4 binary and the Working Directory is the `game` directory.
 4. Start the debugger.
+
+## Generate Visual Studio Files
+Run `scons vsproj=yes` and a project and solution file should be generated for you.

--- a/SConstruct
+++ b/SConstruct
@@ -113,14 +113,20 @@ if env["vsproj"]:
         env["MSVS"]["PROJECTSUFFIX"] = ".vcxproj"
         env["MSVS"]["SOLUTIONSUFFIX"] = ".sln"
 
-    env.MSVSProject(target=['#openvic2' + env['MSVSPROJECTSUFFIX']],
+    project = env.MSVSProject(target=['#openvic2' + env['MSVSPROJECTSUFFIX']],
         srcs=[str(source_file) for source_file in sources],
         incs=includes,
         buildtarget=library,
         variant=variant,
         cpppaths=env["CPPPATH"],
         cppdefines=env["CPPDEFINES"],
-        auto_build_solution=1
+        auto_build_solution=0
+    )
+
+    env.MSVSSolution(
+        target=['#openvic2' + env['MSVSSOLUTIONSUFFIX']],
+        projects=[project],
+        variant=variant
     )
 
 Default(library)

--- a/SConstruct
+++ b/SConstruct
@@ -113,10 +113,12 @@ if env["vsproj"]:
         env["MSVS"]["PROJECTSUFFIX"] = ".vcxproj"
         env["MSVS"]["SOLUTIONSUFFIX"] = ".sln"
 
+    buildtarget = [s for s in library if str(s).endswith('dll')]
+
     project = env.MSVSProject(target=['#openvic2' + env['MSVSPROJECTSUFFIX']],
         srcs=[str(source_file) for source_file in sources],
         incs=includes,
-        buildtarget=library,
+        buildtarget=buildtarget,
         variant=variant,
         cpppaths=env["CPPPATH"],
         cppdefines=env["CPPDEFINES"],


### PR DESCRIPTION
Called via `scons vsproj=yes`. Also updated README.md in reference to it.

This requires validation that the generator properly works on Windows with Microsoft's Visual Studio installed.