### PR TITLE
Add Keep Resolution Dialog

### DIFF
--- a/game/localisation/en_GB/menus.csv
+++ b/game/localisation/en_GB/menus.csv
@@ -36,6 +36,8 @@ OPTIONS_VIDEO_REFRESH_RATE,Refresh Rate
 OPTIONS_VIDEO_REFRESH_RATE_TOOLTIP,Only change from VSYNC if you are having issues with screen tearing.
 OPTIONS_VIDEO_QUALITY,Quality Preset
 OPTIONS_VIDEO_GUI_SCALE,Gui Scaling Factor
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TITLE,Keep Resolution?
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TEXT,Reverting resolution in ({time})
 
 ,, Sound Tab
 MASTER_BUS,Master Volume

--- a/game/localisation/en_US/menus.csv
+++ b/game/localisation/en_US/menus.csv
@@ -36,6 +36,8 @@ OPTIONS_VIDEO_REFRESH_RATE,Refresh Rate
 OPTIONS_VIDEO_REFRESH_RATE_TOOLTIP,Only change from VSYNC if you are having issues with screen tearing.
 OPTIONS_VIDEO_QUALITY,Quality Preset
 OPTIONS_VIDEO_GUI_SCALE,Gui Scaling Factor
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TITLE,Keep Resolution?
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TEXT,Reverting resolution in ({time})
 
 ,, Sound Tab
 MASTER_BUS,Master Volume

--- a/game/localisation/fr_FR/menus.csv
+++ b/game/localisation/fr_FR/menus.csv
@@ -36,6 +36,8 @@ OPTIONS_VIDEO_REFRESH_RATE,Taux de Rafraîchissement
 OPTIONS_VIDEO_REFRESH_RATE_TOOLTIP,Ne changez de VSYNC que si vous rencontrez des problèmes de déchirement d'écran.
 OPTIONS_VIDEO_QUALITY,Préréglage de la Qualité
 OPTIONS_VIDEO_GUI_SCALE,Mise à échelle de l'Interface Graphique
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TITLE,Maintenir la résolution?
+OPTIONS_VIDEO_RESOLUTION_DIALOG_TEXT,Reverserai la résolution en ({time})
 
 ,, Sound Tab
 MASTER_BUS,Volume Principal

--- a/game/src/GameSession/GameSession.tscn
+++ b/game/src/GameSession/GameSession.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://byq323jbel48u" path="res://src/GameSession/ProvinceOverviewPanel/ProvinceOverviewPanel.tscn" id="5_osjnn"]
 [ext_resource type="PackedScene" uid="uid://cnbfxjy1m6wja" path="res://src/OptionMenu/OptionsMenu.tscn" id="6_p5mnx"]
 [ext_resource type="PackedScene" uid="uid://dd8k3p7r3huwc" path="res://src/GameSession/GameSpeedPanel.tscn" id="7_myy4q"]
-[ext_resource type="PackedScene" uid="uid://dayy28gn8kq34" path="res://src/SaveLoadMenu/SaveLoadMenu.tscn" id="8_4g7ko"]
+[ext_resource type="PackedScene" uid="uid://d3g6wbvwflmyk" path="res://src/SaveLoadMenu/SaveLoadMenu.tscn" id="8_4g7ko"]
 
 [node name="GameSession" type="Control" node_paths=PackedStringArray("_game_session_menu")]
 editor_description = "SS-102, UI-546"
@@ -23,17 +23,6 @@ script = ExtResource("1_eklvp")
 _game_session_menu = NodePath("GameSessionMenu")
 
 [node name="MapView" parent="." instance=ExtResource("4_xkg5j")]
-
-[node name="GameSessionMenu" parent="." instance=ExtResource("3_bvmqh")]
-visible = false
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MapControlPanel" parent="." instance=ExtResource("3_afh6d")]
 layout_mode = 1
@@ -52,6 +41,21 @@ layout_mode = 1
 layout_mode = 0
 offset_right = 302.0
 offset_bottom = 31.0
+
+[node name="GameSessionMenu" parent="." instance=ExtResource("3_bvmqh")]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -159.0
+offset_top = -165.0
+offset_right = 159.0
+offset_bottom = 165.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="OptionsMenu" parent="." instance=ExtResource("6_p5mnx")]
 visible = false
@@ -76,9 +80,6 @@ offset_right = 0.0
 grow_horizontal = 0
 
 [connection signal="map_view_camera_changed" from="MapView" to="MapControlPanel" method="_on_map_view_camera_changed"]
-[connection signal="load_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_load"]
-[connection signal="options_button_pressed" from="GameSessionMenu" to="OptionsMenu" method="show"]
-[connection signal="save_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_save"]
 [connection signal="game_session_menu_button_pressed" from="MapControlPanel" to="." method="_on_game_session_menu_button_pressed"]
 [connection signal="minimap_clicked" from="MapControlPanel" to="MapView" method="_on_minimap_clicked"]
 [connection signal="mouse_entered" from="MapControlPanel" to="MapView" method="_on_mouse_exited_viewport"]
@@ -87,5 +88,8 @@ grow_horizontal = 0
 [connection signal="zoom_out_button_pressed" from="MapControlPanel" to="MapView" method="zoom_out"]
 [connection signal="mouse_entered" from="ProvinceOverviewPanel" to="MapView" method="_on_mouse_exited_viewport"]
 [connection signal="mouse_exited" from="ProvinceOverviewPanel" to="MapView" method="_on_mouse_entered_viewport"]
+[connection signal="load_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_load"]
+[connection signal="options_button_pressed" from="GameSessionMenu" to="OptionsMenu" method="show"]
+[connection signal="save_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_save"]
 [connection signal="back_button_pressed" from="OptionsMenu" to="MapView" method="enable_processing"]
 [connection signal="back_button_pressed" from="OptionsMenu" to="OptionsMenu" method="hide"]

--- a/game/src/OptionMenu/VideoTab.tscn
+++ b/game/src/OptionMenu/VideoTab.tscn
@@ -31,7 +31,7 @@ columns = 2
 layout_mode = 2
 text = "OPTIONS_VIDEO_RESOLUTION"
 
-[node name="ResolutionSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
+[node name="ResolutionSelector" type="OptionButton" parent="VBoxContainer/GridContainer" node_paths=PackedStringArray("revert_dialog", "timer")]
 editor_description = "UI-19"
 layout_mode = 2
 focus_neighbor_bottom = NodePath("../ScreenModeSelector")
@@ -40,8 +40,22 @@ selected = 0
 popup/item_0/text = "MISSING"
 popup/item_0/id = 0
 script = ExtResource("1_i8nro")
+revert_dialog = NodePath("ConfirmationDialog")
+timer = NodePath("Timer")
 section_name = "video"
 setting_name = "resolution"
+
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="VBoxContainer/GridContainer/ResolutionSelector"]
+editor_description = "UI-873"
+disable_3d = true
+title = "OPTIONS_VIDEO_RESOLUTION_DIALOG_TITLE"
+size = Vector2i(730, 100)
+ok_button_text = "DIALOG_OK"
+cancel_button_text = "DIALOG_CANCEL"
+
+[node name="Timer" type="Timer" parent="VBoxContainer/GridContainer/ResolutionSelector"]
+wait_time = 5.0
+one_shot = true
 
 [node name="GuiScaleLabel" type="Label" parent="VBoxContainer/GridContainer"]
 layout_mode = 2
@@ -155,6 +169,9 @@ setting_name = "quality_preset"
 default_selected = 1
 
 [connection signal="item_selected" from="VBoxContainer/GridContainer/ResolutionSelector" to="VBoxContainer/GridContainer/ResolutionSelector" method="_on_item_selected"]
+[connection signal="canceled" from="VBoxContainer/GridContainer/ResolutionSelector/ConfirmationDialog" to="VBoxContainer/GridContainer/ResolutionSelector" method="_cancel_changes"]
+[connection signal="confirmed" from="VBoxContainer/GridContainer/ResolutionSelector/ConfirmationDialog" to="VBoxContainer/GridContainer/ResolutionSelector" method="_on_confirmed"]
+[connection signal="timeout" from="VBoxContainer/GridContainer/ResolutionSelector/Timer" to="VBoxContainer/GridContainer/ResolutionSelector" method="_cancel_changes"]
 [connection signal="item_selected" from="VBoxContainer/GridContainer/GuiScaleSelector" to="VBoxContainer/GridContainer/GuiScaleSelector" method="_on_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/GridContainer/ScreenModeSelector" to="VBoxContainer/GridContainer/ScreenModeSelector" method="_on_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/GridContainer/MonitorDisplaySelector" to="VBoxContainer/GridContainer/MonitorDisplaySelector" method="_on_item_selected"]


### PR DESCRIPTION
Fix GameSession UI node order

- Fulfills requirements UI-873, UIFUN-301, UIFUN-302
- Adds a dialog popup to the videotab under the options menu. This dialog appears when the user selects a new resolution, asking them if they want to keep the resolution. Selecting 'No' or letting the dialog's timer expire will revert the resolution, while selecting 'yes' will keep the newly selecting resolution.
- Localized, but french isn't my native language so it needs to be double checked.
- Motivation: if the user messes up their resolution, they can now recover gracefully.
- Also: Changed GameSessionMenu to be lower in GameSession's hierarchy so that it appears on-top of any overlapping UI elements (achievable with a bad UI-scaling setting).
- The KeepChangesDialog.tscn is designed to be somewhat reusable if needed.