### PR TITLE
Fix SettingHSlider not loading properly on default values

### DIFF
--- a/game/src/MusicConductor/MusicConductor.tscn
+++ b/game/src/MusicConductor/MusicConductor.tscn
@@ -8,6 +8,6 @@ music_directory = "res://audio/music"
 first_song_name = "The_Crown"
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-bus = &"Music"
+bus = &"MUSIC_BUS"
 
 [connection signal="finished" from="AudioStreamPlayer" to="." method="_on_audio_stream_player_finished"]

--- a/game/src/OptionMenu/SettingNodes/SettingHSlider.gd
+++ b/game/src/OptionMenu/SettingNodes/SettingHSlider.gd
@@ -20,12 +20,15 @@ func load_setting(file : ConfigFile):
 	var load_value = file.get_value(section_name, setting_name, default_value)
 	match typeof(load_value):
 		TYPE_FLOAT, TYPE_INT:
+			if value == load_value: value_changed.emit(value)
 			value = load_value
 			return
 		TYPE_STRING, TYPE_STRING_NAME:
 			var load_string := load_value as String
 			if load_string.is_valid_float():
-				value = load_string.to_float()
+				load_value = load_string.to_float()
+				if value == load_value: value_changed.emit(value)
+				value = load_value
 				return
 	push_error("Setting value '%s' invalid for setting [%s] \"%s\"" % [load_value, section_name, setting_name])
 	value = default_value


### PR DESCRIPTION
Fix MusicConductor ignoring MUSIC_BUS

This fixes volume sliders being ignored when loaded at zero, which means if you set the slider to zero and reloaded the game, it would act as if the volume was at 100.
