### PR TITLE
Changing "OpenVic2" to "OpenVic" in documentation

### DIFF
--- a/docs/contribution-quickstart-guide.md
+++ b/docs/contribution-quickstart-guide.md
@@ -50,17 +50,17 @@
 
 # Project Setup
 
-1. [Go to the main repository](https://github.com/OpenVic2Project/OpenVic2) page on Github
+1. [Go to the main repository](https://github.com/OpenVic2Project/OpenVic) page on Github
 
 2. Get the link to clone the repo
 
 ![](images/proj-setup/01-git-clone-link.png)
 
-3. Using Git, clone the repo: `git clone git@github.com:OpenVic2Project/OpenVic2.git`
+3. Using Git, clone the repo: `git clone https://github.com/OpenVicProject/OpenVic.git`
 
 ![](images/proj-setup/02-git-clone.png)
 
-4. Move into the OpenVic2 directory: `cd OpenVic2`
+4. Move into the OpenVic2 directory: `cd OpenVic`
 
 5. Retrieve submodules: `git submodule update --init --recursive`
 
@@ -82,7 +82,7 @@
 
 ![](images/proj-setup/06-import.png)
 
-10. Navigate to the `OpenVic2/game/` directory and select the `project.godot` file
+10. Navigate to the `OpenVic/game/` directory and select the `project.godot` file
 
 ![](images/proj-setup/07-select-project.png)
 

--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -2,13 +2,13 @@
 
 ## CPP Structure
 
-All C++ files are in the OpenVic2/extension/ directory
+All C++ files are in the OpenVic/extension/ directory
 
 Please see the [C++ Styleguide](./styleguide-cpp.md) for more details
 
 ## Godot Structure
 
-All godot files are in the OpenVic2/game directory
+All godot files are in the OpenVic/game directory
 
 ### Directories
 
@@ -16,9 +16,9 @@ All godot files are in the OpenVic2/game directory
     * The root directory of the Godot Project
 * u/, user/, user://
     * The user directory used by the project (Platform specific)
-    * Windows u/ - %APPDATA%/OpenVic2/
-    * MacOS u/ - ~/Library/Application Support/OpenVic2/
-    * Linux u/ - ~/.local/share/OpenVic2/
+    * Windows u/ - %APPDATA%/OpenVic/
+    * MacOS u/ - ~/Library/Application Support/OpenVic/
+    * Linux u/ - ~/.local/share/OpenVic/
 * d/, data/, common/ - The data directory used to store data files
     * can be a subdirectory of root/ - root/common/
     * can be a subdirectory of user/ - user/common/
@@ -26,8 +26,8 @@ All godot files are in the OpenVic2/game directory
 
 ### Definitions
 
-* core - OpenVic2 without modification
-* mod - OpenVic2 with changes in files to modify the gameplay experience
+* core - OpenVic without modification
+* mod - OpenVic with changes in files to modify the gameplay experience
 * scene - godot engine scene object
 * script - godot engine gdscript object
 * resource - godot engine resource object
@@ -36,8 +36,8 @@ All godot files are in the OpenVic2/game directory
 
 ### OpenVic2 File Extensions
 
-* ov2d - OpenVic2 data file
-* ov2b - OpenVic2 binary file
+* ov2d - OpenVic data file
+* ov2b - OpenVic binary file
 
 ### When to use root/
 

--- a/docs/styleguide-cpp.md
+++ b/docs/styleguide-cpp.md
@@ -34,9 +34,9 @@ Source code files should adhere to the following:
 - Any `#include` directives should be at the top of the file
 - Any header files have the `.hpp` file extension
 - Any implementation files have the `.cpp` file extension
-- Code should be within the `OpenVic2` namespace (or a nested namespace)
-- Any submodules or third-party utilities should be in the `OpenVic2/extension/deps` directory
-- Groups of related source files should be kept in a sub-directory of `OpenVic2/extension/src`
+- Code should be within the `OpenVic` namespace (or a nested namespace)
+- Any submodules or third-party utilities should be in the `OpenVic/extension/deps` directory
+- Groups of related source files should be kept in a sub-directory of `OpenVic/extension/src`
 - Any lines that are longer than 120 characters in length should be split across multiple lines
 
 ## 2. Conventions


### PR DESCRIPTION
Changing instances of the term "OpenVic2" to just "OpenVic" within the documentation.