### PR TITLE
Add environment variables for trivial Godot updates

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,6 +2,12 @@ name: Builds
 
 on: [push, pull_request]
 
+env:
+  GODOT_DOWNLOAD_URL: https://downloads.tuxfamily.org/godotengine
+  GODOT_VERSION_PREFIX: Godot_v
+  GODOT_VERSION_SUFFIX: stable
+  GODOT_VERSION: 4.0.3
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
   cancel-in-progress: true
@@ -148,8 +154,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_export_templates.tpz
+          godot_executable_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_linux.x86_64.zip
+          godot_export_templates_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_export_templates.tpz
           relative_project_path: ./game
           export_as_pack: true
           export_debug: true
@@ -196,8 +202,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_export_templates.tpz
+          godot_executable_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_linux.x86_64.zip
+          godot_export_templates_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_export_templates.tpz
           relative_project_path: ./game
           archive_output: true
           wine_path: ${{ steps.wine_install.outputs.WINE_PATH }}


### PR DESCRIPTION
Should make changing the Godot version, even for dev, alpha, beta, and release candidates trivial.

As an example to support the current 4.1 dev version all we need to do is:
```
GODOT_VERSION_PREFIX: dev4/Godot_v
GODOT_VERSION_SUFFIX: dev4
GODOT_VERSION: 4.1
```

When 4.1 comes out would only need to make it:
```
GODOT_VERSION: 4.1
```