### PR TITLE
Fix ArgumentParser excluding last character for arg key

### DIFF
--- a/game/src/Game/Autoload/Argument/ArgumentParser.tscn
+++ b/game/src/Game/Autoload/Argument/ArgumentParser.tscn
@@ -14,7 +14,7 @@ default_value = false
 [sub_resource type="Resource" id="Resource_j1to4"]
 script = ExtResource("2_4hguj")
 name = &"game-debug"
-aliases = Array[StringName]([&"d", &"-debug", &"-debug-mode"])
+aliases = Array[StringName]([&"d", &"debug", &"debug-mode"])
 type = 1
 description = "Start in debug mode."
 default_value = false
@@ -22,11 +22,12 @@ default_value = false
 [sub_resource type="Resource" id="Resource_tiax1"]
 script = ExtResource("2_4hguj")
 name = &"compatibility-mode"
-aliases = Array[StringName]([&"-compat"])
+aliases = Array[StringName]([&"compat"])
 type = 4
 description = "Load Victoria 2 assets from this path."
 default_value = ""
 
 [node name="ArgumentParser" type="Node"]
+editor_description = "SS-56"
 script = ExtResource("1_pc7xr")
 option_array = Array[ExtResource("2_4hguj")]([SubResource("Resource_tq3y4"), SubResource("Resource_j1to4"), SubResource("Resource_tiax1")])

--- a/game/src/Game/Autoload/Events.gd
+++ b/game/src/Game/Autoload/Events.gd
@@ -27,10 +27,7 @@ func _ready():
 	# into the mod's dir for a temporary fix)
 	# Usage: OpenVic --compatibility-mode <path>
 
-	var compatibility_mode_path : String
-	if ProjectSettings.has_setting(ArgumentParser.argument_setting_path):
-		var arg_dictionary : Dictionary = ProjectSettings.get_setting(ArgumentParser.argument_setting_path)
-		compatibility_mode_path = arg_dictionary.get(&"compatibility-mode", compatibility_mode_path)
+	var compatibility_mode_path : String = ArgumentParser.get_argument(&"compatibility-mode")
 
 	var start := Time.get_ticks_usec()
 

--- a/game/src/Game/Autoload/Events/GameDebug.gd
+++ b/game/src/Game/Autoload/Events/GameDebug.gd
@@ -1,21 +1,8 @@
 extends RefCounted
 
-# REQUIREMENTS:
-# * SS-56
-func _init():
-	for engine_args in OS.get_cmdline_args():
-		match(engine_args):
-			"--game-debug":
-				set_debug_mode(true)
-
-	for engine_args in OS.get_cmdline_user_args():
-		match(engine_args):
-			"--game-debug", "-d", "--debug", "--debug-mode":
-				set_debug_mode(true)
-
 func set_debug_mode(value : bool) -> void:
-	ProjectSettings.set_setting("openvic/debug/enabled", value)
+	ArgumentParser.set_argument(&"game-debug", value)
 	print("Set debug mode to: ", value)
 
 func is_debug_mode() -> bool:
-	return ProjectSettings.get_setting("openvic/debug/enabled", false)
+	return ArgumentParser.get_argument(&"game-debug", false)


### PR DESCRIPTION
Fix ArgumentParser ignoring full name boolean arguments
Add warning for ArgumentParser parsing a non-boolean standalone argument
Move SS-56 requirement to ArgumentParser scene
Add has_argument_support, get_argument, and set_argument to ArgumentParser
Update `GameDebug.gd` to rely on `ArgumentParser.get_argument`
Update `Events.gd` to rely on `ArgumentParser.get_argument`