### PR TITLE
Add GameLoader Autoload to handle global loading data

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -23,6 +23,7 @@ config/project_settings_override.template="user://settings.cfg"
 
 ArgumentParser="*res://src/Game/Autoload/Argument/ArgumentParser.tscn"
 Events="*res://src/Game/Autoload/Events.gd"
+GameLoader="*res://src/Game/Autoload/GameLoader.gd"
 Resolution="*res://src/Game/Autoload/Resolution.gd"
 SoundManager="*res://src/Game/Autoload/SoundManager.gd"
 MusicConductor="*res://src/Game/MusicConductor/MusicConductor.tscn"

--- a/game/src/Game/Autoload/Argument/ArgumentParser.gd
+++ b/game/src/Game/Autoload/Argument/ArgumentParser.gd
@@ -312,6 +312,7 @@ Options:
 func _ready():
 	if Engine.is_editor_hint(): return
 	_set_argument_setting()
+	GameDebug._singleton = GameDebug.new()
 	if get_argument(&"help"):
 		_print_help()
 		get_tree().quit()

--- a/game/src/Game/Autoload/Events.gd
+++ b/game/src/Game/Autoload/Events.gd
@@ -1,56 +1,11 @@
+## Events are exclusively for the purpose of handling global signals
+## This is to reduce "signal bubbling" which is when a signal callback is used to "bubble" the signal callbacks up the scene tree.
+## It does such by providing a global interface of signals that are connected to and emitted by that are garunteed to exist.
 extends Node
 
-var GameDebug: GameDebugSingleton
-var Options: OptionsSingleton
-var Localisation: LocalisationSingleton
-var ShaderManager: ShaderManagerSingleton
+var Loader: LoaderEventsObject
+var Options: OptionsEventsObject
 
-var _define_filepaths_dict : Dictionary = {
-	GameSingleton.get_province_identifier_file_key(): "res://common/map/provinces.json",
-	GameSingleton.get_water_province_file_key(): "res://common/map/water.json",
-	GameSingleton.get_region_file_key(): "res://common/map/regions.json",
-	GameSingleton.get_terrain_variant_file_key(): "res://common/map/terrain.json",
-	GameSingleton.get_terrain_texture_dir_key(): "res://art/terrain/",
-	GameSingleton.get_province_image_file_key(): "res://common/map/provinces.png",
-	GameSingleton.get_terrain_image_file_key(): "res://common/map/terrain.png",
-	GameSingleton.get_goods_file_key(): "res://common/goods.json",
-	GameSingleton.get_good_icons_dir_key(): "res://art/economy/goods"
-}
-
-# REQUIREMENTS
-# * FS-333, FS-334, FS-335, FS-341
-func load_events(loading_screen: LoadingScreen):
-	GameSingleton.setup_logger()
-	loading_screen.update_loading_screen(5)
-	
-	# Set this to your Vic2 install dir or a mod's dir to enable compatibility mode
-	# (this won't work for mods which rely on vanilla map assets, copy missing assets
-	# into the mod's dir for a temporary fix)
-	# Usage: OpenVic --compatibility-mode <path>
-
-	var compatibility_mode_path : String = ArgumentParser.get_argument(&"compatibility-mode")
-
-	var start := Time.get_ticks_usec()
-	
-	GameDebug = GameDebugSingleton.new()
-	loading_screen.update_loading_screen(15)
-	Options = OptionsSingleton.new()
-	loading_screen.update_loading_screen(25)
-	Localisation = LocalisationSingleton.new()
-	loading_screen.update_loading_screen(45)
-	ShaderManager = ShaderManagerSingleton.new()
-	loading_screen.update_loading_screen(50, true)
-	
-	if compatibility_mode_path:
-		if GameSingleton.load_defines_compatibility_mode(compatibility_mode_path) != OK:
-			push_error("Errors loading game defines!")
-	else:
-		if GameSingleton.load_defines(_define_filepaths_dict) != OK:
-			push_error("Errors loading game defines!")
-	
-	loading_screen.update_loading_screen(100)
-	var end := Time.get_ticks_usec()
-	print("Loading took ", float(end - start) / 1000000, " seconds")
-	
-	# change scene in a thread-safe way
-	get_tree().call_deferred("change_scene_to_file", "res://src/Game/GameMenu.tscn")
+func _init():
+	Loader = LoaderEventsObject.new()
+	Options = OptionsEventsObject.new()

--- a/game/src/Game/Autoload/Events/GameDebug.gd
+++ b/game/src/Game/Autoload/Events/GameDebug.gd
@@ -1,9 +1,0 @@
-extends RefCounted
-class_name GameDebugSingleton
-
-func set_debug_mode(value : bool) -> void:
-	ArgumentParser.set_argument(&"game-debug", value)
-	print("Set debug mode to: ", value)
-
-func is_debug_mode() -> bool:
-	return ArgumentParser.get_argument(&"game-debug", false)

--- a/game/src/Game/Autoload/Events/Loader.gd
+++ b/game/src/Game/Autoload/Events/Loader.gd
@@ -1,0 +1,6 @@
+class_name LoaderEventsObject
+extends RefCounted
+
+signal startup_load_begun()
+signal startup_load_changed(percentage : float)
+signal startup_load_ended()

--- a/game/src/Game/Autoload/Events/Options.gd
+++ b/game/src/Game/Autoload/Events/Options.gd
@@ -1,5 +1,5 @@
+class_name OptionsEventsObject
 extends RefCounted
-class_name OptionsSingleton
 
 signal save_settings(save_file: ConfigFile)
 signal load_settings(load_file: ConfigFile)

--- a/game/src/Game/Autoload/GameLoader.gd
+++ b/game/src/Game/Autoload/GameLoader.gd
@@ -1,0 +1,18 @@
+extends Node
+
+var define_filepaths_dict : Dictionary = {
+	GameSingleton.get_province_identifier_file_key(): "res://common/map/provinces.json",
+	GameSingleton.get_water_province_file_key(): "res://common/map/water.json",
+	GameSingleton.get_region_file_key(): "res://common/map/regions.json",
+	GameSingleton.get_terrain_variant_file_key(): "res://common/map/terrain.json",
+	GameSingleton.get_terrain_texture_dir_key(): "res://art/terrain/",
+	GameSingleton.get_province_image_file_key(): "res://common/map/provinces.png",
+	GameSingleton.get_terrain_image_file_key(): "res://common/map/terrain.png",
+	GameSingleton.get_goods_file_key(): "res://common/goods.json",
+	GameSingleton.get_good_icons_dir_key(): "res://art/economy/goods"
+}
+
+var ShaderManager : ShaderManagerClass
+
+func _init():
+	ShaderManager = ShaderManagerClass.new()

--- a/game/src/Game/GameSession/MapControlPanel/Minimap.gd
+++ b/game/src/Game/GameSession/MapControlPanel/Minimap.gd
@@ -12,7 +12,7 @@ var _viewport_points : PackedVector2Array
 func _ready():
 	_minimap_texture.custom_minimum_size = Vector2(GameSingleton.get_aspect_ratio(), 1.0) * 150
 	var minimap_material := _minimap_texture.get_material()
-	if Events.ShaderManager.set_up_shader(minimap_material, false) != OK:
+	if GameLoader.ShaderManager.set_up_shader(minimap_material, false) != OK:
 		push_error("Failed to set up minimap shader")
 	else:
 		_minimap_shader = minimap_material
@@ -20,7 +20,7 @@ func _ready():
 
 func _on_province_selected(index : int) -> void:
 	if _minimap_shader != null:
-		_minimap_shader.set_shader_parameter(Events.ShaderManager.param_selected_index, index)
+		_minimap_shader.set_shader_parameter(GameLoader.ShaderManager.param_selected_index, index)
 
 # REQUIREMENTS
 # * SS-80

--- a/game/src/Game/GameSession/MapView.gd
+++ b/game/src/Game/GameSession/MapView.gd
@@ -58,7 +58,7 @@ func _ready():
 
 	# Shader Material
 	var map_material := _map_mesh_instance.get_active_material(0)
-	if Events.ShaderManager.set_up_shader(map_material, true) != OK:
+	if GameLoader.ShaderManager.set_up_shader(map_material, true) != OK:
 		push_error("Failed to set up map shader")
 		return
 	_map_shader_material = map_material
@@ -70,7 +70,7 @@ func _ready():
 
 	# Set map mesh size and get bounds
 	const pixels_per_terrain_tile : float = 32.0
-	_map_shader_material.set_shader_parameter(Events.ShaderManager.param_terrain_tile_factor,
+	_map_shader_material.set_shader_parameter(GameLoader.ShaderManager.param_terrain_tile_factor,
 		float(GameSingleton.get_height()) / pixels_per_terrain_tile)
 	var map_mesh_aabb := _map_mesh.get_core_aabb() * _map_mesh_instance.transform
 	_map_mesh_corner = Vector2(
@@ -114,7 +114,7 @@ func zoom_out() -> void:
 	_zoom_target += _zoom_target_step
 
 func _on_province_selected(index : int) -> void:
-	_map_shader_material.set_shader_parameter(Events.ShaderManager.param_selected_index, index)
+	_map_shader_material.set_shader_parameter(GameLoader.ShaderManager.param_selected_index, index)
 
 # REQUIREMENTS
 # * SS-31
@@ -218,14 +218,14 @@ func _update_mouse_map_position() -> void:
 	_mouse_pos_map = _viewport_to_map_coords(_mouse_pos_viewport)
 	var hover_index := GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map)
 	if _mouse_over_viewport:
-		_map_shader_material.set_shader_parameter(Events.ShaderManager.param_hover_index, hover_index)
+		_map_shader_material.set_shader_parameter(GameLoader.ShaderManager.param_hover_index, hover_index)
 
 func _on_mouse_entered_viewport():
 	_mouse_over_viewport = true
 
 func _on_mouse_exited_viewport():
 	_mouse_over_viewport = false
-	_map_shader_material.set_shader_parameter(Events.ShaderManager.param_hover_index, 0)
+	_map_shader_material.set_shader_parameter(GameLoader.ShaderManager.param_hover_index, 0)
 
 func _on_minimap_clicked(pos_clicked : Vector2):
 	pos_clicked *= _map_mesh_dims

--- a/game/src/Game/GameSession/ProvinceOverviewPanel/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel/ProvinceOverviewPanel.gd
@@ -107,7 +107,7 @@ func _update_info() -> void:
 
 		_life_rating_bar.value = _province_info.get(GameSingleton.get_province_info_life_rating_key(), 0)
 		_life_rating_bar.tooltip_text = tr("LIFE_RATING_TOOLTIP").format({
-			"life_rating": Events.Localisation.tr_number(_life_rating_bar.value)
+			"life_rating": Localisation.tr_number(_life_rating_bar.value)
 		})
 
 		_rgo_name_label.text = _province_info.get(GameSingleton.get_province_info_rgo_key(),

--- a/game/src/Game/GameStart.gd
+++ b/game/src/Game/GameStart.gd
@@ -1,0 +1,60 @@
+extends Control
+
+const LoadingScreen = preload("res://src/Game/LoadingScreen.gd")
+
+@export_subgroup("Nodes")
+@export var loading_screen : LoadingScreen
+
+func _ready() -> void:
+	loading_screen.start_loading_screen(_initialize_game)
+
+# REQUIREMENTS
+# * FS-333, FS-334, FS-335, FS-341
+func _initialize_game() -> void:
+	GameSingleton.setup_logger()
+	loading_screen.try_update_loading_screen(5)
+
+	# Set this to your Vic2 install dir or a mod's dir to enable compatibility mode
+	# (this won't work for mods which rely on vanilla map assets, copy missing assets
+	# into the mod's dir for a temporary fix)
+	# Usage: OpenVic --compatibility-mode <path>
+
+	var compatibility_mode_path : String = ArgumentParser.get_argument(&"compatibility-mode")
+
+	var start := Time.get_ticks_usec()
+
+	loading_screen.try_update_loading_screen(15)
+	loading_screen.try_update_loading_screen(25)
+	Localisation.initialize()
+	loading_screen.try_update_loading_screen(45)
+	loading_screen.try_update_loading_screen(50, true)
+
+	# TODO: Loading takes way too long to keep the LoadingScreen at 50%
+	# Should either split this up or seperately multithread the compatibility mode loader
+	# Or both and emit a signal that allows us to add percentages to the LoadingScreen
+	if compatibility_mode_path:
+		if GameSingleton.load_defines_compatibility_mode(compatibility_mode_path) != OK:
+			push_error("Errors loading game defines!")
+	else:
+		GameLoader.define_filepaths_dict.make_read_only()
+		if GameSingleton.load_defines(GameLoader.define_filepaths_dict) != OK:
+			push_error("Errors loading game defines!")
+
+	loading_screen.try_update_loading_screen(100)
+	var end := Time.get_ticks_usec()
+	print("Loading took ", float(end - start) / 1000000, " seconds")
+
+	# change scene in a thread-safe way
+	get_tree().call_deferred("change_scene_to_file", "res://src/Game/GameMenu.tscn")
+
+func _on_splash_container_splash_end():
+	loading_screen.show()
+
+func _on_loading_screen_load_started():
+	Events.Loader.startup_load_begun.emit()
+
+func _on_loading_screen_load_changed(percentage : float) -> void:
+	Events.Loader.startup_load_changed.emit(percentage)
+
+func _on_loading_screen_load_ended():
+	Events.Loader.startup_load_ended.emit()

--- a/game/src/Game/GameStart.tscn
+++ b/game/src/Game/GameStart.tscn
@@ -1,18 +1,21 @@
-[gd_scene load_steps=6 format=3 uid="uid://1udsn4mggep2"]
+[gd_scene load_steps=7 format=3 uid="uid://1udsn4mggep2"]
 
+[ext_resource type="Script" path="res://src/Game/GameStart.gd" id="1_e0cos"]
 [ext_resource type="PackedScene" uid="uid://3kktdpfnc0sn" path="res://src/Game/LoadingScreen.tscn" id="2_h0oiw"]
 [ext_resource type="Script" path="res://src/Game/SplashContainer.gd" id="2_xmcgv"]
 [ext_resource type="Texture2D" uid="uid://deef5hufq0j61" path="res://splash_assets/splash_end.png" id="3_qfv12"]
 [ext_resource type="Texture2D" uid="uid://cgdnixsyh7bja" path="res://splash_assets/splash_image.png" id="4_5b6yq"]
 [ext_resource type="VideoStream" path="res://splash_assets/splash_startup.ogv" id="5_8euyy"]
 
-[node name="GameStartup" type="Control"]
+[node name="GameStartup" type="Control" node_paths=PackedStringArray("loading_screen")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_e0cos")
+loading_screen = NodePath("LoadingScreen")
 
 [node name="LoadingScreen" parent="." instance=ExtResource("2_h0oiw")]
 visible = false
@@ -48,5 +51,8 @@ stream = ExtResource("5_8euyy")
 autoplay = true
 expand = true
 
-[connection signal="splash_end" from="SplashContainer" to="LoadingScreen" method="_on_splash_container_splash_end"]
+[connection signal="load_changed" from="LoadingScreen" to="." method="_on_loading_screen_load_changed"]
+[connection signal="load_ended" from="LoadingScreen" to="." method="_on_loading_screen_load_ended"]
+[connection signal="load_started" from="LoadingScreen" to="." method="_on_loading_screen_load_started"]
+[connection signal="splash_end" from="SplashContainer" to="." method="_on_splash_container_splash_end"]
 [connection signal="finished" from="SplashContainer/SplashVideo" to="SplashContainer" method="_on_splash_startup_finished"]

--- a/game/src/Game/GlobalClass/GameDebug.gd
+++ b/game/src/Game/GlobalClass/GameDebug.gd
@@ -1,0 +1,26 @@
+class_name GameDebug
+extends RefCounted
+
+static var _singleton : GameDebug
+
+static var debug_mode : bool:
+	get = is_debug_mode, set = set_debug_mode
+
+static func set_debug_mode(value : bool) -> void:
+	if _singleton == null:
+		push_warning("Debug mode could not be set.")
+		return
+	_singleton._set_debug_mode(value)
+
+static func is_debug_mode() -> bool:
+	if _singleton == null:
+		push_warning("Could not get debug mode, returning false.")
+		return false
+	return _singleton._is_debug_mode()
+
+func _set_debug_mode(value : bool) -> void:
+	ArgumentParser.set_argument(&"game-debug", value)
+	print("Set debug mode to: ", value)
+
+func _is_debug_mode() -> bool:
+	return ArgumentParser.get_argument(&"game-debug", false)

--- a/game/src/Game/GlobalClass/Localisation.gd
+++ b/game/src/Game/GlobalClass/Localisation.gd
@@ -1,9 +1,9 @@
+class_name Localisation
 extends RefCounted
-class_name LocalisationSingleton
 
 # REQUIREMENTS
 # * SS-59, SS-60, SS-61
-func get_default_locale() -> String:
+static func get_default_locale() -> String:
 	var locales := TranslationServer.get_loaded_locales()
 	var default_locale := OS.get_locale()
 	if default_locale in locales:
@@ -14,7 +14,7 @@ func get_default_locale() -> String:
 			return default_language
 	return ProjectSettings.get_setting("internationalization/locale/fallback", "en_GB")
 
-func load_localisation(dir_path : String) -> void:
+static func load_localisation(dir_path : String) -> void:
 	if LoadLocalisation.load_localisation_dir(dir_path) != OK:
 		push_error("Error loading localisation directory: ", dir_path)
 	var loaded_locales : PackedStringArray = TranslationServer.get_loaded_locales()
@@ -23,12 +23,12 @@ func load_localisation(dir_path : String) -> void:
 # REQUIREMENTS
 # * SS-57
 # * FS-17
-func _init():
+static func initialize():
 	var localisation_dir_path : String = ProjectSettings.get_setting("internationalization/locale/localisation_path", "")
 	if localisation_dir_path.is_empty():
-		push_error("Missing localisation_path setting!")
+		push_error("internationalization/locale/localisation_path setting is empty!")
 	else:
-		load_localisation(localisation_dir_path)
+		Localisation.load_localisation(localisation_dir_path)
 
-func tr_number(num) -> String:
+static func tr_number(num) -> String:
 	return TextServerManager.get_primary_interface().format_number(str(num))

--- a/game/src/Game/GlobalClass/ShaderManager.gd
+++ b/game/src/Game/GlobalClass/ShaderManager.gd
@@ -1,5 +1,5 @@
+class_name ShaderManagerClass
 extends RefCounted
-class_name ShaderManagerSingleton
 
 const param_province_shape_tex : StringName = &"province_shape_tex"
 const param_province_shape_subdivisions : StringName = &"province_shape_subdivisions"

--- a/game/src/Game/LoadingScreen.gd
+++ b/game/src/Game/LoadingScreen.gd
@@ -1,32 +1,52 @@
 extends Control
-class_name LoadingScreen
 
+signal load_started()
+signal load_changed(percentage : float)
+signal load_ended()
+
+@export var quote_file_path : String = "res://common/quotes.txt"
+
+@export_subgroup("Nodes")
 @export var progress_bar: ProgressBar
 @export var quote_label: Label
 
-var loadthread: Thread
+var thread: Thread
 var quotes: PackedStringArray = []
 
-func update_loading_screen(percent_complete: int, quote_should_change = false):
+func start_loading_screen(thread_safe_function : Callable) -> void:
+	if not is_node_ready():
+		await ready
+	# set first quote
+	progress_bar.value = 0
+	quote_label.text = quotes[randi() % quotes.size()]
+
+	if thread != null and thread.is_started():
+		thread.wait_to_finish()
+
+	thread.start(thread_safe_function)
+	load_started.emit()
+
+func try_update_loading_screen(percent_complete: float, quote_should_change = false):
 	# forces the function to behave as if deferred
 	await get_tree().process_frame
 	progress_bar.value = percent_complete
 	if quote_should_change:
 		quote_label.text = quotes[randi() % quotes.size()]
-
-func _on_splash_container_splash_end():
-	show()
+	if is_equal_approx(percent_complete, 100):
+		thread.wait_to_finish()
+		load_ended.emit()
+	else:
+		load_changed.emit(percent_complete)
 
 func _ready():
+	if Engine.is_editor_hint(): return
+	thread = Thread.new()
 	# FS-3, UI-30, UIFUN-35
-	loadthread = Thread.new()
-	loadthread.start(Events.load_events.bind(self))
-	var quotes_file = FileAccess.open("res://common/quotes.txt", FileAccess.READ).get_as_text()
+	var quotes_file := FileAccess.open(quote_file_path, FileAccess.READ).get_as_text()
 	quotes = quotes_file.split("\n",false)
 	if quotes.is_empty():
 		quotes = [""]
-	# set first quote
-	quote_label.text = quotes[randi() % quotes.size()]
 
 func _exit_tree():
-	loadthread.wait_to_finish()
+	if thread != null and thread.is_started():
+		thread.wait_to_finish()

--- a/game/src/Game/LocaleButton.gd
+++ b/game/src/Game/LocaleButton.gd
@@ -9,7 +9,7 @@ func _ready():
 	var locales_country_rename : Dictionary = ProjectSettings.get_setting("internationalization/locale/country_short_name", {})
 
 	var locales_list = TranslationServer.get_loaded_locales()
-	var default_locale := Events.Localisation.get_default_locale()
+	var default_locale := Localisation.get_default_locale()
 	if default_locale not in locales_list:
 		locales_list.push_back(default_locale)
 
@@ -43,7 +43,7 @@ func _valid_index(index : int) -> bool:
 
 func load_setting(file : ConfigFile) -> void:
 	if file == null: return
-	var load_value = file.get_value(section_name, setting_name, Events.Localisation.get_default_locale())
+	var load_value = file.get_value(section_name, setting_name, Localisation.get_default_locale())
 	match typeof(load_value):
 		TYPE_STRING, TYPE_STRING_NAME:
 			if _select_locale_by_string(load_value as String):

--- a/game/src/Game/Menu/OptionMenu/MonitorDisplaySelector.gd
+++ b/game/src/Game/Menu/OptionMenu/MonitorDisplaySelector.gd
@@ -15,7 +15,7 @@ func _notification(what : int):
 
 func _update_monitor_options_text() -> void:
 	for index in get_item_count():
-		set_item_text(index, tr("OPTIONS_VIDEO_MONITOR").format({ "index": Events.Localisation.tr_number(index + 1) }))
+		set_item_text(index, tr("OPTIONS_VIDEO_MONITOR").format({ "index": Localisation.tr_number(index + 1) }))
 
 func _on_option_selected(index : int, by_user : bool) -> void:
 	if _valid_index(index):

--- a/game/src/Game/Menu/OptionMenu/ResolutionSelector.gd
+++ b/game/src/Game/Menu/OptionMenu/ResolutionSelector.gd
@@ -53,8 +53,8 @@ func _update_resolution_options_text() -> void:
 			display_name += "_NAMED"
 		if resolution_value == default_value:
 			display_name += "_DEFAULT"
-		format_dict["width"] = Events.Localisation.tr_number(resolution_value.x)
-		format_dict["height"] = Events.Localisation.tr_number(resolution_value.y)
+		format_dict["width"] = Localisation.tr_number(resolution_value.x)
+		format_dict["height"] = Localisation.tr_number(resolution_value.y)
 		display_name = tr(display_name).format(format_dict)
 		set_item_text(index, display_name)
 

--- a/game/src/Game/Menu/OptionMenu/SettingRevertDialog.gd
+++ b/game/src/Game/Menu/OptionMenu/SettingRevertDialog.gd
@@ -22,7 +22,7 @@ func _notification(what):
 		if not visible: _revert_node = null
 
 func _process(_delta) -> void:
-	dialog_text = tr(dialog_text_key).format({ "time": Events.Localisation.tr_number(int(timer.time_left)) })
+	dialog_text = tr(dialog_text_key).format({ "time": Localisation.tr_number(int(timer.time_left)) })
 
 func _on_canceled_or_close_requested() -> void:
 	timer.stop()


### PR DESCRIPTION
Remove GameDebug, Localization, and ShaderManager from Events.gd
Renamed OptionsSingleton class_name to OptionsEventsObject
Add Events.Loader to handle Loader events (which are global signals)
Make GameDebug singleton with static functions and property
Make Localization functions static
Move ShaderManager variable to GameLoader
Move Events._define_filepaths_dict to GameLoader.define_filepaths_dict
Move game initialization from LoadingScreen.gd and Events.gd to GameStart.gd
Attach GameStart.gd to GameStart.tscn root
Make LoadingScreen generalized and so it is reusable
Remove class_name from LoaderingScreen.gd