### PR TITLE
Update to Godot 4.1.1 Stable Release

### DIFF
--- a/.github/actions/openvic-env/action.yml
+++ b/.github/actions/openvic-env/action.yml
@@ -1,33 +1,13 @@
 name: Setup OpenVic Environment
 description: Setup OpenVic Environment
 runs:
-    using: "composite"
-    steps:
-        - name: Setup Environment
-          uses: actions/github-script@v6
-          with:
-            script: |
-                const commit_name = 'OPENVIC_COMMIT';
-                const tag_name = 'OPENVIC_TAG';
-                const release_name = 'OPENVIC_RELEASE';
-                var commit_sha = process.env["GITHUB_SHA"];
-                if(context.eventName === 'pull_request') {
-                    commit_sha = context.payload.pull_request.head.sha;
-                }
-                core.exportVariable(commit_name, commit_sha);
-                try {
-                  const release = await github.rest.repos.getLatestRelease({owner: context.repo.owner, repo: context.repo.repo});
-                  core.exportVariable(tag_name, release.data["tag_name"]);
-                  core.exportVariable(release_name, release.data["name"]);
-                } catch(error) {
-                  if (error.response.status != 404) throw error;
-                  const tagList = await github.rest.repos.listTags({owner: context.repo.owner, repo: context.repo.repo});
-                  if (tagList.data.length == 0) {
-                    core.warning("Could not list tags, this repo has no tags on it, setting tag_name and release_name environment variables to '<UserRepo-NoTag>' and '<UserRepo-NoRelease>', you can fetch tags with 'git fetch --tags' <remote-name>' and push tags with 'git push --tags");
-                    core.exportVariable(tag_name, `<${context.repo.owner}/${context.repo.repo}-NoTag>`);
-                    core.exportVariable(release_name, `<${context.repo.owner}/${context.repo.repo}-NoRelease>`);
-                  } else {
-                    core.exportVariable(tag_name, tagList.data[0].name);
-                    core.exportVariable(release_name, tagList.data[0].name);
-                  }
-                }
+  using: "composite"
+  steps:
+    - name: Setup URL Environment
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/url-environment.sh
+
+    - name: Setup Commit Environment
+      uses: actions/github-script@v6
+      with:
+        script: require(`${process.env.GITHUB_ACTION_PATH}/commit-environment.js`)({github, context, core})

--- a/.github/actions/openvic-env/commit-environment.js
+++ b/.github/actions/openvic-env/commit-environment.js
@@ -1,0 +1,30 @@
+module.exports = async ({github, context, core}) => {
+    const commit_name = 'OPENVIC_COMMIT';
+    const tag_name = 'OPENVIC_TAG';
+    const release_name = 'OPENVIC_RELEASE';
+    var commit_sha = process.env["GITHUB_SHA"];
+
+    if(context.eventName === 'pull_request') {
+        commit_sha = context.payload.pull_request.head.sha;
+    }
+
+    core.exportVariable(commit_name, commit_sha);
+
+    try {
+        const release = await github.rest.repos.getLatestRelease({owner: context.repo.owner, repo: context.repo.repo});
+        core.exportVariable(tag_name, release.data["tag_name"]);
+        core.exportVariable(release_name, release.data["name"]);
+    } catch(error) {
+        if (error.response.status != 404) throw error;
+
+        const tagList = await github.rest.repos.listTags({owner: context.repo.owner, repo: context.repo.repo});
+        if (tagList.data.length == 0) {
+            core.warning("Could not list tags, this repo has no tags on it, setting tag_name and release_name environment variables to '<UserRepo-NoTag>' and '<UserRepo-NoRelease>', you can fetch tags with 'git fetch --tags' <remote-name>' and push tags with 'git push --tags");
+            core.exportVariable(tag_name, `<${context.repo.owner}/${context.repo.repo}-NoTag>`);
+            core.exportVariable(release_name, `<${context.repo.owner}/${context.repo.repo}-NoRelease>`);
+        } else {
+            core.exportVariable(tag_name, tagList.data[0].name);
+            core.exportVariable(release_name, tagList.data[0].name);
+        }
+    }
+}

--- a/.github/actions/openvic-env/url-environment.sh
+++ b/.github/actions/openvic-env/url-environment.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# $1 = environment name
+# $2 = value to set environment
+set_var() {
+    if [[ -z ${!1+set} ]]; then
+        export $1=$2
+    fi
+}
+
+# $1 = left side
+# $2 = right side
+# returns $1 and $2 joined together with a single '/''
+join_path() {
+    result=$1
+    if [[ $result == *"/" && $2 == "/"* ]]; then
+        result=${result%/}
+    fi
+    if [[ $result != *"/" && $2 != "/"* ]]; then
+        result="$result/"
+    fi
+    echo "$result$2"
+}
+
+# $1 = environment name
+set_github_var() {
+    if [ "${!1}" == "" ]; then
+        echo "::error::$1 environment variable has not been set."
+    elif ! curl -o /dev/null --head --silent --fail "${!1}"; then
+        echo "::error::${!1} does not exist."
+    else
+        echo "$1=${!1}" >> $GITHUB_ENV
+    fi
+}
+
+if [[ $GODOT_BASE_DOWNLOAD_URL == *"downloads.tuxfamily.org/godotengine"* ]]; then
+    if [[ $GODOT_BASE_DOWNLOAD_URL != *"${GODOT_VERSION}"* ]]; then
+        GODOT_BASE_DOWNLOAD_URL="$(join_path ${GODOT_BASE_DOWNLOAD_URL} ${GODOT_VERSION})"
+    fi
+    if [[ $GODOT_VERSION_TYPE != "stable" ]]; then
+        GODOT_BASE_DOWNLOAD_URL="$(join_path ${GODOT_BASE_DOWNLOAD_URL} ${GODOT_VERSION_TYPE})"
+    fi
+    set_var GODOT_LINUX_URL "$(join_path ${GODOT_BASE_DOWNLOAD_URL} "Godot_v${GODOT_VERSION}-${GODOT_VERSION_TYPE}_linux.x86_64.zip")"
+    set_var GODOT_TEMPLATE_URL "$(join_path ${GODOT_BASE_DOWNLOAD_URL} "Godot_v${GODOT_VERSION}-${GODOT_VERSION_TYPE}_export_templates.tpz")"
+elif [[ $GODOT_BASE_DOWNLOAD_URL == *"github.com/godotengine"* ]]; then
+    if [[ $GODOT_BASE_DOWNLOAD_URL != *"/releases"* ]]; then
+        GODOT_BASE_DOWNLOAD_URL=$(join_path $GODOT_BASE_DOWNLOAD_URL "releases")
+    fi
+    if [[ $GODOT_BASE_DOWNLOAD_URL != *"/download"* ]]; then
+        GODOT_BASE_DOWNLOAD_URL=$(join_path $GODOT_BASE_DOWNLOAD_URL "download")
+    fi
+    set_var GODOT_LINUX_URL "$(join_path ${GODOT_BASE_DOWNLOAD_URL} "${GODOT_VERSION}-${GODOT_VERSION_TYPE}/Godot_v${GODOT_VERSION}-${GODOT_VERSION_TYPE}_linux.x86_64.zip")"
+    set_var GODOT_TEMPLATE_URL "$(join_path ${GODOT_BASE_DOWNLOAD_URL} "${GODOT_VERSION}-${GODOT_VERSION_TYPE}/Godot_v${GODOT_VERSION}-${GODOT_VERSION_TYPE}_export_templates.tpz")"
+fi
+
+set_github_var GODOT_LINUX_URL
+set_github_var GODOT_TEMPLATE_URL

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,10 +3,9 @@ name: Builds
 on: [push, pull_request]
 
 env:
-  GODOT_DOWNLOAD_URL: https://downloads.tuxfamily.org/godotengine
-  GODOT_VERSION_PREFIX: Godot_v
-  GODOT_VERSION_SUFFIX: stable
-  GODOT_VERSION: 4.1
+  GODOT_BASE_DOWNLOAD_URL: https://github.com/godotengine/godot
+  GODOT_VERSION: 4.1.1
+  GODOT_VERSION_TYPE: stable
   OPENVIC_BASE_BRANCH: master
 
 concurrency:
@@ -15,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on:  ${{matrix.os}}
+    runs-on: ${{matrix.os}}
     name: ${{matrix.name}}
     permissions: write-all
     strategy:
@@ -62,7 +61,6 @@ jobs:
             arch: x86_64
 
     steps:
-
       - name: Checkout project
         uses: actions/checkout@v3.3.0
         with:
@@ -80,7 +78,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Set up SCons
         shell: bash
@@ -125,9 +123,9 @@ jobs:
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.1
         with:
-          type: 'zip'
-          filename: '../../../libopenvic.${{ matrix.platform }}.${{ matrix.arch }}.zip'
-          directory: '${{ github.workspace }}/game/bin/openvic/'
+          type: "zip"
+          filename: "../../../libopenvic.${{ matrix.platform }}.${{ matrix.arch }}.zip"
+          directory: "${{ github.workspace }}/game/bin/openvic/"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Create and upload asset
@@ -146,7 +144,6 @@ jobs:
 
     name: Peform Godot Debug Checks
     steps:
-
       - name: Checkout project
         uses: actions/checkout@v3.3.0
 
@@ -163,8 +160,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_linux.x86_64.zip
-          godot_export_templates_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_export_templates.tpz
+          godot_executable_download_url: ${{env.GODOT_LINUX_URL}}
+          godot_export_templates_download_url: ${{env.GODOT_TEMPLATE_URL}}
           relative_project_path: ./game
           export_as_pack: true
           export_debug: true
@@ -180,7 +177,6 @@ jobs:
           path: |
             ./game/export/${{ github.event.repository.name }}.pck
 
-
   export:
     runs-on: ubuntu-latest
     needs: [build]
@@ -188,7 +184,6 @@ jobs:
 
     name: Export
     steps:
-
       - name: Checkout project
         uses: actions/checkout@v3.3.0
 
@@ -212,8 +207,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_linux.x86_64.zip
-          godot_export_templates_download_url: ${{env.GODOT_DOWNLOAD_URL}}/${{env.GODOT_VERSION}}/${{env.GODOT_VERSION_PREFIX}}${{env.GODOT_VERSION}}-${{env.GODOT_VERSION_SUFFIX}}_export_templates.tpz
+          godot_executable_download_url: ${{env.GODOT_LINUX_URL}}
+          godot_export_templates_download_url: ${{env.GODOT_TEMPLATE_URL}}
           relative_project_path: ./game
           archive_output: true
           cache: true

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Main Repo for the OpenVic Project
 For detailed instructions, view the Contributor Quickstart Guide [here](docs/contribution-quickstart-guide.md)
 
 ## Required
-* [Godot 4.1](https://github.com/godotengine/godot/releases/tag/4.1-stable)
+* [Godot 4.1.1](https://github.com/godotengine/godot/releases/tag/4.1.1-stable)
 * [scons](https://scons.org/)
 
 ## [Godot Documentation](https://docs.godotengine.org/en/latest/)
 
 ## Build/Run Instructions
-1. Install [Godot 4.1](https://github.com/godotengine/godot/releases/tag/4.1-stable) and [scons](https://scons.org/) for your system.
+1. Install [Godot 4.1.1](https://github.com/godotengine/godot/releases/tag/4.1.1-stable) and [scons](https://scons.org/) for your system.
 2. Run the command `git submodule update --init --recursive` to retrieve all related submodules.
 3. Run `scons` in the project root, you should see a libopenvic file in `game/bin/openvic`.
 4. Open with Godot 4, click import and navigate to the `game` directory.


### PR DESCRIPTION
Add bash-based Godot URL environment variable handling to openvic-env action
Separate Commit environment variable handling in openvic-env to self-contained js file.

If `GODOT_BASE_DOWNLOAD_URL`, `GODOT_VERSION`, and `GODOT_VERSION_TYPE` are all set, this will then set a `GODOT_LINUX_URL` and `GODOT_TEMPLATE_URL` environment variable that points to the proper download path for the template and x86_64 linux version of the respective binaries.

`GODOT_BASE_DOWNLOAD_URL` must be either `downloads.tuxfamily.org/godotengine` or `github.com/godotengine` (must point to a repo, accounts for also pointing to releases or releases/download) for now.
Errors if either `GODOT_LINUX_URL` or `GODOT_TEMPLATE_URL` is not set.
If `GODOT_LINUX_URL` environment variable is already set to a non-empty value, it does not modify it. If it does not exist as a valid link, it does not set `GODOT_LINUX_URL`.
If `GODOT_TEMPLATE_URL` environment variable is already set to a non-empty value, it does not modify it. If it does not exist as a valid link, it does not set `GODOT_TEMPLATE_URL`.