### PR TITLE
Tidying: missing req comments, submodules, hotkeys, user data folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "godot-cpp"]
 	path = godot-cpp
 	url = https://github.com/godotengine/godot-cpp
-[submodule "extension/deps/OV-compiler"]
-	path = extension/deps/OV-compiler
-	url = https://github.com/OpenVicProject/OV-compiler
 [submodule "extension/deps/openvic-simulation"]
 	path = extension/deps/openvic-simulation
 	url = https://github.com/OpenVicProject/OpenVic-Simulation
+[submodule "extension/deps/openvic-dataloader"]
+	path = extension/deps/openvic-dataloader
+	url = https://github.com/OpenVicProject/OpenVic-Dataloader

--- a/extension/src/GameSingleton.cpp
+++ b/extension/src/GameSingleton.cpp
@@ -83,7 +83,7 @@ void GameSingleton::_on_state_updated() {
 }
 
 /* REQUIREMENTS:
- * MAP-21, MAP-23, MAP-25
+ * MAP-21, MAP-23, MAP-25, MAP-32
  */
 GameSingleton::GameSingleton() : game_manager { [this]() { _on_state_updated(); } },
 								 terrain_variants { "terrain variants" } {

--- a/game/addons/openvic-plugin/ReleaseExportEditorPlugin.gd
+++ b/game/addons/openvic-plugin/ReleaseExportEditorPlugin.gd
@@ -25,6 +25,8 @@ func _export_file(path: String, type: String, features: PackedStringArray) -> vo
 
 # Based on
 # https://github.com/godotengine/godot/blob/6ef2f358c741c993b5cdc9680489e2c4f5da25cc/methods.py#L102-L133
+# REQUIREMENTS:
+# * UIFUN-298
 var _cached_hash : StringName = &""
 func _get_commit_hash() -> StringName:
 	if not _cached_hash.is_empty(): return _cached_hash
@@ -68,6 +70,8 @@ func _get_commit_hash() -> StringName:
 
 	return git_hash
 
+# REQUIREMENTS:
+# * UIFUN-296
 func _try_get_tag() -> StringName:
 	var result : StringName = OS.get_environment("OPENVIC_TAG")
 	if result.is_empty():
@@ -84,6 +88,8 @@ func _get_commit_long():
 		_repo_hash = result
 	print("Hash: " + _repo_hash)
 
+# REQUIREMENTS:
+# * UIFUN-300
 func _get_commit_short():
 	var result := _get_commit_hash().substr(0,7)
 	if not result.is_empty():
@@ -96,6 +102,8 @@ func _get_tag():
 		_repo_tag = result
 	print("Tag: " + _repo_tag)
 
+# REQUIREMENTS:
+# * UIFUN-295
 func _get_release_name():
 	var result : StringName = OS.get_environment("OPENVIC_RELEASE")
 	if result.is_empty():

--- a/game/project.godot
+++ b/game/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="OpenVic"
 config/description="A faithful recreation of Victoria 2: Heart of Darkness with a focus on enhancing performance, multiplayer stability, and modability for modern machines."
 run/main_scene="res://src/Game/GameStart.tscn"
+config/use_custom_user_dir=true
 config/features=PackedStringArray("4.1", "Forward Plus")
 boot_splash/bg_color=Color(0.380392, 0.145098, 0.14902, 1)
 boot_splash/image="res://splash_assets/splash_image.png"
@@ -58,8 +59,8 @@ map_north={
 }
 map_east={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"key_label":0,"unicode":100,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":4194321,"key_label":4194321,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":68,"key_label":68,"unicode":100,"echo":false,"script":null)
 ]
 }
 map_south={
@@ -70,8 +71,8 @@ map_south={
 }
 map_west={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"key_label":0,"unicode":97,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":4194319,"key_label":4194319,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":65,"key_label":65,"unicode":97,"echo":false,"script":null)
 ]
 }
 map_zoom_in={
@@ -96,6 +97,23 @@ map_click={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+time_pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+time_speed_increase={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":61,"physical_keycode":61,"key_label":61,"unicode":43,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194437,"physical_keycode":0,"key_label":0,"unicode":43,"echo":false,"script":null)
+]
+}
+time_speed_decrease={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":45,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194435,"physical_keycode":0,"key_label":0,"unicode":45,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 
@@ -116,6 +134,7 @@ limits/message_queue/max_size_kb=16384
 
 settings/settings_file_path="user://settings.cfg"
 data/saves_directory="user://saves"
+project_file_req_comment.editor="FS-2, FS-20, FS-21, FS-22"
 
 [rendering]
 

--- a/game/src/Game/Autoload/Events/Options.gd
+++ b/game/src/Game/Autoload/Events/Options.gd
@@ -10,6 +10,8 @@ func load_settings_from_file() -> void:
 
 # REQUIREMENTS
 # * SS-11
+# * UIFUN-13
+# * FS-563
 func save_settings_to_file() -> void:
 	save_settings.emit(_settings_file)
 	_settings_file.save(_settings_file_path)
@@ -18,6 +20,8 @@ func try_reset_settings() -> void:
 	reset_settings.emit()
 
 const settings_file_path_setting : String = "openvic/settings/settings_file_path"
+# REQUIREMENTS
+# * FS-561
 const settings_file_path_default : String = "user://settings.cfg"
 
 var _settings_file_path : String = ProjectSettings.get_setting(settings_file_path_setting, settings_file_path_default)
@@ -25,7 +29,8 @@ var _settings_file := ConfigFile.new()
 
 # REQUIREMENTS
 # * SS-9
-# * UIFUN-7
+# * UIFUN-7, UIFUN-12
+# * FS-562
 func _init():
 	if FileAccess.file_exists(_settings_file_path):
 		_settings_file.load(_settings_file_path)

--- a/game/src/Game/Autoload/Resolution.gd
+++ b/game/src/Game/Autoload/Resolution.gd
@@ -7,6 +7,8 @@ const error_resolution : Vector2i = Vector2i(-1,-1)
 @export
 var minimum_resolution : Vector2i = Vector2i(1,1)
 
+# REQUIREMENTS:
+# * SS-130, SS-131, SS-132, SS-133
 const _starting_resolutions : Array[Vector2i] = [
 	Vector2i(3840,2160),
 	Vector2i(2560,1080),

--- a/game/src/Game/GameSession/GameSession.gd
+++ b/game/src/Game/GameSession/GameSession.gd
@@ -7,7 +7,7 @@ func _ready():
 	if GameSingleton.setup_game() != OK:
 		push_error("Failed to setup game")
 
-func _process(delta : float):
+func _process(_delta : float):
 	GameSingleton.try_tick()
 
 # REQUIREMENTS:

--- a/game/src/Game/GameSession/GameSpeedPanel.gd
+++ b/game/src/Game/GameSession/GameSpeedPanel.gd
@@ -1,6 +1,7 @@
 extends PanelContainer
 
-#UI-74 UI-75 UI-76 UI-77
+# REQUIREMENTS:
+# * SS-37, SS-38, SS-39
 
 @export var _longform_date_button : Button
 @export var _play_pause_display_button : Button
@@ -19,15 +20,20 @@ func _update_buttons():
 
 	_longform_date_button.text = GameSingleton.get_longform_date()
 
-
+# REQUIREMENTS:
+# * UIFUN-73
 func _on_decrease_speed_button_pressed():
 	GameSingleton.decrease_speed()
 	_update_buttons()
 
+# REQUIREMENTS:
+# * UIFUN-72
 func _on_increase_speed_button_pressed():
 	GameSingleton.increase_speed()
 	_update_buttons()
 
+# REQUIREMENTS:
+# * UIFUN-71
 func _on_play_pause_display_button_pressed():
 	GameSingleton.toggle_paused()
 	_update_buttons()

--- a/game/src/Game/GameSession/GameSpeedPanel.tscn
+++ b/game/src/Game/GameSession/GameSpeedPanel.tscn
@@ -1,6 +1,24 @@
-[gd_scene load_steps=2 format=3 uid="uid://dd8k3p7r3huwc"]
+[gd_scene load_steps=8 format=3 uid="uid://dd8k3p7r3huwc"]
 
 [ext_resource type="Script" path="res://src/Game/GameSession/GameSpeedPanel.gd" id="1_pfs8t"]
+
+[sub_resource type="InputEventAction" id="InputEventAction_3k1tl"]
+action = &"time_pause"
+
+[sub_resource type="Shortcut" id="Shortcut_cg5xm"]
+events = [SubResource("InputEventAction_3k1tl")]
+
+[sub_resource type="InputEventAction" id="InputEventAction_w2rkb"]
+action = &"time_speed_decrease"
+
+[sub_resource type="Shortcut" id="Shortcut_ocrfe"]
+events = [SubResource("InputEventAction_w2rkb")]
+
+[sub_resource type="InputEventAction" id="InputEventAction_7sdhp"]
+action = &"time_speed_increase"
+
+[sub_resource type="Shortcut" id="Shortcut_gwofc"]
+events = [SubResource("InputEventAction_7sdhp")]
 
 [node name="GameSpeedPanel" type="PanelContainer" node_paths=PackedStringArray("_longform_date_button", "_play_pause_display_button", "_decrease_speed_button", "_increase_speed_button")]
 script = ExtResource("1_pfs8t")
@@ -13,27 +31,34 @@ _increase_speed_button = NodePath("ButtonList/IncreaseSpeedButton")
 layout_mode = 2
 
 [node name="LongformDateButton" type="Button" parent="ButtonList"]
+editor_description = "UI-74"
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 focus_mode = 0
 text = "LONGFORM DATE"
 
 [node name="PlayPauseDisplayButton" type="Button" parent="ButtonList"]
+editor_description = "UI-75, UIFUN-90"
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 focus_mode = 0
+shortcut = SubResource("Shortcut_cg5xm")
 text = "⏸  "
 
 [node name="DecreaseSpeedButton" type="Button" parent="ButtonList"]
+editor_description = "UI-77"
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 focus_mode = 0
+shortcut = SubResource("Shortcut_ocrfe")
 text = "-"
 
 [node name="IncreaseSpeedButton" type="Button" parent="ButtonList"]
+editor_description = "UI-76"
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 focus_mode = 0
+shortcut = SubResource("Shortcut_gwofc")
 text = "+"
 
 [connection signal="pressed" from="ButtonList/LongformDateButton" to="." method="_on_longform_date_label_pressed"]

--- a/game/src/Game/GameSession/MapControlPanel/MapControlPanel.gd
+++ b/game/src/Game/GameSession/MapControlPanel/MapControlPanel.gd
@@ -37,7 +37,7 @@ func _on_game_session_menu_button_pressed() -> void:
 
 # REQUIREMENTS:
 # * SS-76
-# * UIFUN-129, UIFUN-131, UIFUN-133
+# * UIFUN-129, UIFUN-131, UIFUN-133, UIFUN-140
 func _mapmode_pressed(button : BaseButton) -> void:
 	GameSingleton.set_mapmode(button.tooltip_text)
 

--- a/game/src/Game/GameSession/ProvinceOverviewPanel/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel/ProvinceOverviewPanel.gd
@@ -44,7 +44,7 @@ var _building_rows : Array[Dictionary]
 # * UI-191, UI-193, UI-194, UI-766, UI-195, UI-196, UI-197
 # * UI-199, UI-201, UI-202, UI-767, UI-203, UI-204, UI-205
 func _add_building_row() -> void:
-	var row : Dictionary
+	var row : Dictionary = {}
 
 	row.level = Label.new()
 	row.level.text = "X"

--- a/game/src/Game/LocaleButton.gd
+++ b/game/src/Game/LocaleButton.gd
@@ -71,6 +71,7 @@ func reset_setting() -> void:
 
 # REQUIREMENTS:
 # * SS-58
+# * UIFUN-323
 func _on_item_selected(index : int) -> void:
 	if _valid_index(index):
 		TranslationServer.set_locale(get_item_metadata(index))

--- a/game/src/Game/LocaleButton.tscn
+++ b/game/src/Game/LocaleButton.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://src/Game/LocaleButton.gd" id="1_ganev"]
 
 [node name="LocaleButton" type="OptionButton"]
+editor_description = "UI-600, UI-895, UI-896, UI-898, UI-899, UIFUN-322"
 custom_minimum_size = Vector2(150, 0)
 alignment = 2
 text_overrun_behavior = 2

--- a/game/src/Game/Menu/MainMenu/MainMenu.tscn
+++ b/game/src/Game/Menu/MainMenu/MainMenu.tscn
@@ -136,6 +136,7 @@ theme_type_variation = &"BottomMargin"
 layout_mode = 2
 
 [node name="LocaleButton" parent="MenuPanel/MenuList/BottomMargin" instance=ExtResource("3_amonp")]
+editor_description = "SS-87"
 layout_mode = 2
 size_flags_horizontal = 8
 alignment = 0

--- a/game/src/Game/Menu/MainMenu/ReleaseInfoBox.gd
+++ b/game/src/Game/Menu/MainMenu/ReleaseInfoBox.gd
@@ -12,7 +12,8 @@ var _checksum_label : Button
 var _checksum : String = "????"
 
 # REQUIREMENTS:
-# * UIFUN-97
+# * SS-104, SS-105, SS-106, SS-107
+# * UIFUN-97, UIFUN-297, UIFUN-299
 func _ready():
 	_version_label.text = _GIT_INFO_.release_name
 	_version_label.tooltip_text = _GIT_INFO_.tag

--- a/game/src/Game/Menu/MainMenu/ReleaseInfoBox.tscn
+++ b/game/src/Game/Menu/MainMenu/ReleaseInfoBox.tscn
@@ -10,6 +10,7 @@ _commit_label = NodePath("CommitLabel")
 _checksum_label = NodePath("ChecksumLabel")
 
 [node name="VersionLabel" type="Button" parent="."]
+editor_description = "UI-869, UI-870"
 layout_mode = 2
 tooltip_text = "VERSION_MISSING"
 focus_mode = 0
@@ -19,6 +20,7 @@ flat = true
 alignment = 0
 
 [node name="CommitLabel" type="Button" parent="."]
+editor_description = "UI-871, UI-872"
 layout_mode = 2
 focus_mode = 0
 theme_type_variation = &"CommitLabel"

--- a/game/src/Game/Menu/OptionMenu/OptionsMenu.gd
+++ b/game/src/Game/Menu/OptionMenu/OptionsMenu.gd
@@ -66,11 +66,12 @@ func _save_overrides() -> void:
 	if override_path.is_empty():
 		override_path = ProjectSettings.get_setting(Events.Options.settings_file_path_setting, Events.Options.settings_file_path_default)
 	var file := ConfigFile.new()
-	var err_ret := file.load(override_path)
-	if err_ret != OK: push_error("Failed to load overrides from %s" % override_path)
+	if FileAccess.file_exists(override_path):
+		if file.load(override_path) != OK:
+			push_error("Failed to load overrides from %s" % override_path)
 	file.set_value("display", "window/size/mode", Resolution.get_current_window_mode())
 	var resolution : Vector2i = Resolution.get_current_resolution()
 	file.set_value("display", "window/size/viewport_width", resolution.x)
 	file.set_value("display", "window/size/viewport_height", resolution.y)
-	err_ret = file.save(override_path)
-	if err_ret != OK: push_error("Failed to save overrides to %s" % override_path)
+	if file.save(override_path) != OK:
+		push_error("Failed to save overrides to %s" % override_path)

--- a/game/src/Game/Menu/OptionMenu/ResolutionSelector.gd
+++ b/game/src/Game/Menu/OptionMenu/ResolutionSelector.gd
@@ -1,10 +1,7 @@
 extends SettingRevertButton
 
 # REQUIREMENTS
-# * UIFUN-21
-# * UIFUN-28
-# * UIFUN-301
-# * UIFUN-302
+# * UIFUN-21, UIFUN-28, UIFUN-301, UIFUN-302
 
 @export var default_value : Vector2i = Resolution.error_resolution
 
@@ -14,7 +11,7 @@ func _find_resolution_index_by_value(value : Vector2i) -> int:
 			return item_index
 	return -1
 
-func _sync_resolutions(value : Vector2i = Resolution.error_resolution) -> void:
+func _sync_resolutions() -> void:
 	clear()
 	default_selected = -1
 	selected = -1
@@ -59,7 +56,7 @@ func _update_resolution_options_text() -> void:
 		set_item_text(index, display_name)
 
 func _setup_button() -> void:
-	Resolution.resolution_added.connect(_sync_resolutions)
+	Resolution.resolution_added.connect(func (_value : Vector2i): _sync_resolutions())
 	if default_value.x <= 0:
 		default_value.x = ProjectSettings.get_setting("display/window/size/viewport_width")
 	if default_value.y <= 0:
@@ -75,6 +72,8 @@ func _get_value_for_file(select_value : int) -> Variant:
 	else:
 		return null
 
+# REQUIREMENTS:
+# * SS-25
 func _set_value_from_file(load_value) -> void:
 	var target_resolution := Resolution.error_resolution
 	match typeof(load_value):

--- a/game/src/Game/Menu/OptionMenu/ScreenModeSelector.gd
+++ b/game/src/Game/Menu/OptionMenu/ScreenModeSelector.gd
@@ -1,6 +1,7 @@
 extends SettingRevertButton
 
 # REQUIREMENTS
+# * SS-26, SS-127, SS-128
 # * UIFUN-42
 
 enum ScreenMode { Unknown = -1, Fullscreen, Borderless, Windowed }

--- a/game/src/Game/Menu/OptionMenu/SettingNodes/SettingOptionButton.gd
+++ b/game/src/Game/Menu/OptionMenu/SettingNodes/SettingOptionButton.gd
@@ -57,9 +57,9 @@ func _ready():
 	item_selected.connect(func(index : int): option_selected.emit(index, true))
 	_setup_button()
 	if not _valid_index(default_selected) or selected == -1:
-		var msg := "Failed to generate %s %s options." % [setting_name, section_name]
+		var msg := "Failed to generate any valid %s %s options." % [setting_name, section_name]
 		push_error(msg)
-		OS.alert(msg, "%s Options Error" % section_name)
+		OS.alert(msg, "Options Error: %s / %s" % [section_name, setting_name])
 		get_tree().quit()
 
 func load_setting(file : ConfigFile) -> void:

--- a/game/src/Game/Menu/OptionMenu/SoundTab.gd
+++ b/game/src/Game/Menu/OptionMenu/SoundTab.gd
@@ -1,6 +1,6 @@
 extends HBoxContainer
 
-@export var _startup_music_button : Button
+@export var _startup_music_button : SettingCheckBox
 
 func _ready():
-	_startup_music_button.option_selected.connect(func (pressed : bool, by_user : bool): MusicConductor.set_startup_music(pressed))
+	_startup_music_button.option_selected.connect(func (pressed : bool, _by_user : bool): MusicConductor.set_startup_music(pressed))

--- a/game/src/Game/MusicConductor/MusicConductor.gd
+++ b/game/src/Game/MusicConductor/MusicConductor.gd
@@ -66,7 +66,7 @@ func select_previous_song() -> void:
 	start_current_song()
 
 # REQUIREMENTS
-# * SND-2
+# * SND-2, SND-3
 func _ready():
 	var dir = DirAccess.open(music_directory)
 	for fname in dir.get_files():

--- a/game/src/Game/MusicConductor/MusicPlayer.gd
+++ b/game/src/Game/MusicConductor/MusicPlayer.gd
@@ -31,18 +31,22 @@ func _on_play_pause_button_pressed():
 	MusicConductor.toggle_play_pause()
 	_update_play_pause_button()
 
+# REQUIREMENTS
+# * UIFUN-93
 func _on_next_song_button_pressed():
 	MusicConductor.select_next_song()
 	_update_song_name_visual()
 	_update_play_pause_button()
 
+# REQUIREMENTS
+# * UIFUN-94
 func _on_previous_song_button_pressed():
 	MusicConductor.select_previous_song()
 	_update_song_name_visual()
 	_update_play_pause_button()
 
 # REQUIREMENTS
-# * UIFUN-92
+# * UIFUN-95
 func _on_option_button_item_selected(index):
 	MusicConductor.start_song_by_index(index)
 	_update_song_name_visual()

--- a/game/src/Game/MusicConductor/MusicPlayer.tscn
+++ b/game/src/Game/MusicConductor/MusicPlayer.tscn
@@ -17,7 +17,7 @@ _next_song_button = NodePath("ButtonList/NextSongButton")
 _visbility_button = NodePath("MusicUIVisibilityButton")
 
 [node name="SongSelectorButton" type="OptionButton" parent="."]
-editor_description = "UI-107"
+editor_description = "UI-105, UI-107, UI-110, UIFUN-92"
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 focus_mode = 0
@@ -37,6 +37,7 @@ size_flags_horizontal = 4
 mouse_filter = 2
 
 [node name="PreviousSongButton" type="Button" parent="ButtonList"]
+editor_description = "UI-109"
 layout_mode = 2
 focus_mode = 0
 text = "<"
@@ -48,6 +49,7 @@ focus_mode = 0
 text = "▶"
 
 [node name="NextSongButton" type="Button" parent="ButtonList"]
+editor_description = "UI-108"
 layout_mode = 2
 focus_mode = 0
 text = ">"


### PR DESCRIPTION
- Fixed some unused arg warnings
- Added key shortcuts for pausing (UIFUN-90) and changing speed
- Fixed error on missing `settings.cfg`, e.g. when starting the game for the first time/with no OpenVic `app_data` folder
- Moved `user://` from `Godot/app_userdata/OpenVic` into a custom folder `OpenVic` folder (FS-2, FS-20, FS-21, FS-22)
- Updated `openvic-dataloader` submodule folder

Added comments for already implemented requirements:
- SS-25, SS-26, SS-37, SS-38, SS-39, SS-87, SS-104, SS-105, SS-106, SS-107, SS-127, SS-128, SS-130, SS-131, SS-132, SS-133
- UI-105, UI-108, UI-109, UI-110, UI-600, UI-869, UI-870, UI-871, UI-872, UI-895, UI-896, UI-898, UI-899
- UIFUN-13, UIFUN-71, UIFUN-72, UIFUN-73, UIFUN-93, UIFUN-94, UIFUN-95, UIFUN-140, UIFUN-295, UIFUN-296, UIFUN-297, UIFUN-298, UIFUN-299, UIFUN-300, UIFUN-322, UIFUN-323
- FS-561, FS-562, FS-563
- MAP-32, SND-3