### PR TITLE
Add Window Override

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -15,17 +15,19 @@ config/description="A faithful recreation of Victoria 2: Heart of Darkness with 
 run/main_scene="res://src/Game/GameStart.tscn"
 config/use_custom_user_dir=true
 config/features=PackedStringArray("4.1", "Forward Plus")
-boot_splash/bg_color=Color(0.380392, 0.145098, 0.14902, 1)
+boot_splash/bg_color=Color(0, 0, 0, 0)
+boot_splash/show_image=false
 boot_splash/image="res://splash_assets/splash_image.png"
 config/icon="res://icon.svg"
 config/project_settings_override.template="user://settings.cfg"
 
 [autoload]
 
+Resolution="*res://src/Game/Autoload/Resolution.gd"
 ArgumentParser="*res://src/Game/Autoload/Argument/ArgumentParser.tscn"
+WindowOverride="*res://src/Game/Autoload/WindowOverride.gd"
 Events="*res://src/Game/Autoload/Events.gd"
 GameLoader="*res://src/Game/Autoload/GameLoader.gd"
-Resolution="*res://src/Game/Autoload/Resolution.gd"
 SoundManager="*res://src/Game/Autoload/SoundManager.gd"
 MusicConductor="*res://src/Game/MusicConductor/MusicConductor.tscn"
 Keychain="*res://addons/keychain/Keychain.gd"
@@ -36,10 +38,15 @@ SaveManager="*res://src/Game/Autoload/SaveManager.gd"
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
-window/size/mode=3
+window/size/mode=1
 window/size/resizable=false
+window/size/borderless=true
+window/size/transparent=true
+window/size/window_width_override=1
+window/size/window_height_override=1
 window/stretch/mode="canvas_items"
 window/stretch/aspect="ignore"
+window/per_pixel_transparency/allowed=true
 
 [editor_plugins]
 

--- a/game/src/Game/Autoload/Argument/ArgumentParser.gd
+++ b/game/src/Game/Autoload/Argument/ArgumentParser.gd
@@ -309,10 +309,8 @@ Options:
 			("Type: %s - Default Value: %s" % [option.get_type_string(), option.default_value]).rpad(45),
 			option.description
 		])
+
 func _ready():
 	if Engine.is_editor_hint(): return
 	_set_argument_setting()
 	GameDebug._singleton = GameDebug.new()
-	if get_argument(&"help"):
-		_print_help()
-		get_tree().quit()

--- a/game/src/Game/Autoload/WindowOverride.gd
+++ b/game/src/Game/Autoload/WindowOverride.gd
@@ -1,0 +1,27 @@
+extends Node
+
+const VideoOptions = preload("res://src/Game/Menu/OptionMenu/VideoTab.tscn")
+
+func _init():
+	var window_id := DisplayServer.get_window_list()[0]
+	DisplayServer.window_set_size(Vector2(1280.0, 720.0), window_id)
+
+func _ready():
+	if ArgumentParser.get_argument(&"help"): return
+	_on_SceneTree_idle()
+	# Hack to ensure Video Options load
+	var video := VideoOptions.instantiate()
+	video.visible = false
+	add_child(video)
+	video.queue_free()
+
+func _on_SceneTree_idle():
+	var window := get_window()
+	window.set_mode(Window.MODE_FULLSCREEN)
+	await get_tree().process_frame
+	window.transparent = false
+	window.borderless = false
+	var screen_pos := DisplayServer.screen_get_position(window.current_screen)
+	var screen_size := DisplayServer.screen_get_size(window.current_screen)
+	window.position = screen_pos + (screen_size - window.size) / 2
+	ProjectSettings.set_setting.call_deferred("display/window/per_pixel_transparency/allowed", false)

--- a/game/src/Game/GameStart.gd
+++ b/game/src/Game/GameStart.gd
@@ -7,6 +7,15 @@ const SoundTabScene = preload("res://src/Game/Menu/OptionMenu/SoundTab.tscn")
 @export var loading_screen : LoadingScreen
 
 func _ready() -> void:
+	if ArgumentParser.get_argument(&"help"):
+		ArgumentParser._print_help()
+		# For some reason this doesn't get freed properly
+		# Godot will always quit before it frees the active StreamPlayback resource
+		# This hack fixes that
+		MusicConductor.queue_free()
+		get_tree().quit()
+		return
+
 	# Hack to ensure Sound Options load
 	var sound_tab := SoundTabScene.instantiate()
 	sound_tab.visible = false


### PR DESCRIPTION
Hides window for help argument (`./Openvic -- --help`)
Hides window until video options loading is complete

Makes Window handling way more convenient, can delay a visible window until after everything has been processed and prepared to display it.
Needs Windows and Mac testing.