### PR TITLE
Use `ERR_FAIL_*` macros where possible

### DIFF
--- a/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
@@ -76,11 +76,8 @@ Ref<GFXMaskedFlagTexture> GFXMaskedFlagTexture::make_gfx_masked_flag_texture(GFX
 	Ref<GFXMaskedFlagTexture> masked_flag_texture;
 	masked_flag_texture.instantiate();
 	ERR_FAIL_NULL_V(masked_flag_texture, nullptr);
-	if (masked_flag_texture->set_gfx_masked_flag(gfx_masked_flag) == OK) {
-		return masked_flag_texture;
-	} else {
-		return nullptr;
-	}
+	ERR_FAIL_COND_V(masked_flag_texture->set_gfx_masked_flag(gfx_masked_flag) != OK, nullptr);
+	return masked_flag_texture;
 }
 
 void GFXMaskedFlagTexture::clear() {

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
@@ -107,11 +107,8 @@ Ref<GFXPieChartTexture> GFXPieChartTexture::make_gfx_pie_chart_texture(GFX::PieC
 	Ref<GFXPieChartTexture> pie_chart_texture;
 	pie_chart_texture.instantiate();
 	ERR_FAIL_NULL_V(pie_chart_texture, nullptr);
-	if (pie_chart_texture->set_gfx_pie_chart(gfx_pie_chart) == OK) {
-		return pie_chart_texture;
-	} else {
-		return nullptr;
-	}
+	ERR_FAIL_COND_V(pie_chart_texture->set_gfx_pie_chart(gfx_pie_chart) != OK, nullptr);
+	return pie_chart_texture;
 }
 
 void GFXPieChartTexture::clear() {

--- a/extension/src/openvic-extension/singletons/AssetManager.cpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.cpp
@@ -32,66 +32,50 @@ AssetManager::~AssetManager() {
 	_singleton = nullptr;
 }
 
-Ref<Image> AssetManager::_load_image(StringName path) {
+Ref<Image> AssetManager::_load_image(StringName const& path) {
 	GameSingleton* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
 	const String lookedup_path =
 		std_to_godot_string(game_singleton->get_dataloader().lookup_image_file(godot_to_std_string(path)).string());
-	if (lookedup_path.is_empty()) {
-		UtilityFunctions::push_error("Failed to look up image: ", path);
-		return nullptr;
-	}
+	ERR_FAIL_COND_V_MSG(lookedup_path.is_empty(), nullptr, vformat("Failed to look up image: %s", path));
 	const Ref<Image> image = Utilities::load_godot_image(lookedup_path);
-	if (image.is_null() || image->is_empty()) {
-		UtilityFunctions::push_error("Failed to load image: ", lookedup_path, " (looked up from ", path, ")");
-		return nullptr;
-	} else {
-		return image;
-	}
+	ERR_FAIL_COND_V_MSG(
+		image.is_null() || image->is_empty(), nullptr, vformat("Failed to load image: %s (looked up: %s)", path, lookedup_path)
+	);
+	return image;
 }
 
-AssetManager::image_asset_map_t::iterator AssetManager::_get_image_asset(StringName path) {
+AssetManager::image_asset_map_t::iterator AssetManager::_get_image_asset(StringName const& path) {
 	const image_asset_map_t::iterator it = image_assets.find(path);
 	if (it != image_assets.end()) {
 		return it;
 	}
 	const Ref<Image> image = _load_image(path);
-	if (image.is_valid()) {
-		return image_assets.emplace(std::move(path), AssetManager::image_asset_t { image, nullptr }).first;
-	} else {
-		return image_assets.end();
-	}
+	ERR_FAIL_NULL_V(image, image_assets.end());
+	return image_assets.emplace(std::move(path), AssetManager::image_asset_t { image, nullptr }).first;
 }
 
-Ref<Image> AssetManager::get_image(StringName path, bool cache) {
+Ref<Image> AssetManager::get_image(StringName const& path, bool cache) {
 	if (cache) {
 		const image_asset_map_t::const_iterator it = _get_image_asset(path);
-		if (it != image_assets.end()) {
-			return it->second.image;
-		} else {
-			return nullptr;
-		}
+		ERR_FAIL_COND_V(it == image_assets.end(), nullptr);
+		return it->second.image;
 	} else {
 		return _load_image(path);
 	}
 }
 
-Ref<ImageTexture> AssetManager::get_texture(StringName path) {
+Ref<ImageTexture> AssetManager::get_texture(StringName const& path) {
 	const image_asset_map_t::iterator it = _get_image_asset(path);
-	if (it != image_assets.end()) {
-		if (it->second.texture.is_null()) {
-			it->second.texture = ImageTexture::create_from_image(it->second.image);
-			if (it->second.texture.is_null()) {
-				UtilityFunctions::push_error("Failed to turn image into texture: ", path);
-			}
-		}
-		return it->second.texture;
-	} else {
-		return nullptr;
+	ERR_FAIL_COND_V(it == image_assets.end(), nullptr);
+	if (it->second.texture.is_null()) {
+		it->second.texture = ImageTexture::create_from_image(it->second.image);
+		ERR_FAIL_NULL_V_MSG(it->second.texture, nullptr, vformat("Failed to turn image into texture: %s", path));
 	}
+	return it->second.texture;
 }
 
-Ref<Font> AssetManager::get_font(StringName name) {
+Ref<Font> AssetManager::get_font(StringName const& name) {
 	const font_map_t::const_iterator it = fonts.find(name);
 	if (it != fonts.end()) {
 		return it->second;
@@ -101,21 +85,19 @@ Ref<Font> AssetManager::get_font(StringName name) {
 	static const String font_ext = ".fnt";
 	static const String image_ext = ".tga";
 
-	const String image_path = font_dir + name + image_ext;
+	const StringName image_path = font_dir + name + image_ext;
 	const Ref<Image> image = get_image(image_path);
-	if (image.is_null()) {
-		UtilityFunctions::push_error("Failed to load font image: ", image_path, " for the font named ", name);
-		return nullptr;
-	}
+	ERR_FAIL_NULL_V_MSG(image, nullptr, vformat("Failed to load font image %s for the font named %s", image_path, name));
 	GameSingleton* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
+	const String font_path = font_dir + name + font_ext;
 	const String lookedup_font_path =
-		std_to_godot_string(game_singleton->get_dataloader().lookup_file(godot_to_std_string(font_dir + name + font_ext)).string());
+		std_to_godot_string(game_singleton->get_dataloader().lookup_file(godot_to_std_string(font_path)).string());
 	const Ref<Font> font = Utilities::load_godot_font(lookedup_font_path, image);
-	if (font.is_null()) {
-		UtilityFunctions::push_error("Failed to load font file ", lookedup_font_path, " for the font named ", name);
-		return nullptr;
-	}
+	ERR_FAIL_NULL_V_MSG(
+		font, nullptr,
+		vformat("Failed to load font file %s (looked up: %s) for the font named %s", font_path, lookedup_font_path, name)
+	);
 	fonts.emplace(std::move(name), font);
 	return font;
 }

--- a/extension/src/openvic-extension/singletons/AssetManager.hpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.hpp
@@ -23,8 +23,8 @@ namespace OpenVic {
 		image_asset_map_t image_assets;
 		font_map_t fonts;
 
-		static godot::Ref<godot::Image> _load_image(godot::StringName path);
-		image_asset_map_t::iterator _get_image_asset(godot::StringName path);
+		static godot::Ref<godot::Image> _load_image(godot::StringName const& path);
+		image_asset_map_t::iterator _get_image_asset(godot::StringName const& path);
 
 	protected:
 		static void _bind_methods();
@@ -37,15 +37,15 @@ namespace OpenVic {
 
 		/* Search for and load an image at the specified path relative to the game defines, first checking the AssetManager's
 		 * image cache (if cache is true) in case it has already been loaded, and returning nullptr if image loading fails. */
-		godot::Ref<godot::Image> get_image(godot::StringName path, bool cache = true);
+		godot::Ref<godot::Image> get_image(godot::StringName const& path, bool cache = true);
 
 		/* Create a texture from an image found at the specified path relative to the game defines, fist checking
 		 * AssetManager's texture cache in case it has already been loaded, and returning nullptr if image loading
 		 * or texture creation fails. */
-		godot::Ref<godot::ImageTexture> get_texture(godot::StringName path);
+		godot::Ref<godot::ImageTexture> get_texture(godot::StringName const& path);
 
 		/* Search for and load a font with the specified name from the game defines' font directory, first checking the
 		 * AssetManager's font cache in case it has already been loaded, and returning nullptr if font loading fails. */
-		godot::Ref<godot::Font> get_font(godot::StringName name);
+		godot::Ref<godot::Font> get_font(godot::StringName const& name);
 	};
 }

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -52,7 +52,7 @@ namespace OpenVic {
 		 * pointing to the defines folder. */
 		godot::Error load_defines_compatibility_mode(godot::PackedStringArray const& file_paths);
 
-		static godot::String search_for_game_path(godot::String hint_path = {});
+		static godot::String search_for_game_path(godot::String const& hint_path = {});
 
 		/* Post-load/restart game setup - reset the game to post-load state and load the specified bookmark. */
 		godot::Error setup_game(int32_t bookmark_index);

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -86,8 +86,7 @@ static T* new_control(GUI::Element const& element, String const& name) {
 	if (it != orientation_map.end()) {
 		node->set_anchors_and_offsets_preset(it->second);
 	} else {
-		UtilityFunctions::push_error("Invalid orientation for GUI element ",
-			std_view_to_godot_string(element.get_name()));
+		UtilityFunctions::push_error("Invalid orientation for GUI element ", std_view_to_godot_string(element.get_name()));
 	}
 	node->set_position(Utilities::to_godot_fvec2(element.get_position()));
 	node->set_h_size_flags(Control::SizeFlags::SIZE_SHRINK_BEGIN);
@@ -426,12 +425,10 @@ static bool generate_element(GUI::Element const* element, String const& name, As
 		{ GUI::Window::get_type_static(), &generate_window }
 	};
 	const decltype(type_map)::const_iterator it = type_map.find(element->get_type());
-	if (it != type_map.end()) {
-		return it->second({ *element, name, asset_manager, result });
-	} else {
-		UtilityFunctions::push_error("Invalid GUI element type: ", std_view_to_godot_string(element->get_type()));
-		return false;
-	}
+	ERR_FAIL_COND_V_MSG(
+		it == type_map.end(), false, vformat("Invalid GUI element type: %s", std_view_to_godot_string(element->get_type()))
+	);
+	return it->second({ *element, name, asset_manager, result });
 }
 
 bool UITools::generate_gui_element(


### PR DESCRIPTION
- Replace most instances of `return nullptr;` or `return FAILED;`, and accompanying `UtilityFunctions::push_error` messages, with `ERR_FAIL_*` macros. Most remaining uses of `FAILED` and `UtilityFunctions::push_error` are in contents where a local error variable is set to `FAILED`, rather than returning immediately, for example:
```c+++
	if (!dataloader.set_roots(roots)) {
		Logger::error("Failed to set dataloader roots!");
		err = FAILED;
	}
```
- Changed some `String` and `StringName` arguments to use const references, and changed `String` variables to `StringName`s when they will be used to fill a `StringName` function argument.