### PR TITLE
Added mod command line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ bin/*
 
 # JetBrains
 .idea
+
+# scons stuff
+.cache
+compile_commands.json
+
+# ccls
+.ccls-cache

--- a/game/src/Game/Autoload/Argument/ArgumentOption.gd
+++ b/game/src/Game/Autoload/Argument/ArgumentOption.gd
@@ -14,6 +14,7 @@ extends Resource
 			TYPE_FLOAT: default_value = 0.0
 			TYPE_STRING: default_value = ""
 			TYPE_STRING_NAME: default_value = &""
+			TYPE_PACKED_STRING_ARRAY: default_value = PackedStringArray()
 			TYPE_COLOR: default_value = Color()
 			_: default_value = null
 		notify_property_list_changed()
@@ -38,6 +39,7 @@ func get_type_string() -> StringName:
 		TYPE_INT: return "integer"
 		TYPE_FLOAT: return "float"
 		TYPE_STRING, TYPE_STRING_NAME: return "string"
+		TYPE_PACKED_STRING_ARRAY: return "string array"
 		TYPE_COLOR: return "color"
 	return "<invalid type>"
 
@@ -52,7 +54,7 @@ func _set(property : StringName, value : Variant) -> bool:
 	return false
 
 func _get_property_list() -> Array[Dictionary]:
-	var properties := []
+	var properties := [] as Array[Dictionary]
 
 	properties.append({
 		"name": "default_value",

--- a/game/src/Game/Autoload/Argument/ArgumentParser.tscn
+++ b/game/src/Game/Autoload/Argument/ArgumentParser.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dayjmgc34tqo6"]
+[gd_scene load_steps=8 format=3 uid="uid://dayjmgc34tqo6"]
 
 [ext_resource type="Script" path="res://src/Game/Autoload/Argument/ArgumentParser.gd" id="1_pc7xr"]
 [ext_resource type="Script" path="res://src/Game/Autoload/Argument/ArgumentOption.gd" id="2_4hguj"]
@@ -22,7 +22,7 @@ default_value = false
 [sub_resource type="Resource" id="Resource_tiax1"]
 script = ExtResource("2_4hguj")
 name = &"base-path"
-aliases = Array[StringName]([])
+aliases = Array[StringName]([&"b"])
 type = 4
 description = "Load Victoria 2 assets from this exact path."
 default_value = ""
@@ -30,12 +30,20 @@ default_value = ""
 [sub_resource type="Resource" id="Resource_sh3m3"]
 script = ExtResource("2_4hguj")
 name = &"search-path"
-aliases = Array[StringName]([])
+aliases = Array[StringName]([&"s"])
 type = 4
 description = "Search for Victoria 2 assets at this path."
 default_value = ""
 
+[sub_resource type="Resource" id="Resource_8ab4j"]
+script = ExtResource("2_4hguj")
+name = &"mod"
+aliases = Array[StringName]([&"m"])
+type = 34
+description = "Load Victoria 2 mods with these names."
+default_value = PackedStringArray()
+
 [node name="ArgumentParser" type="Node"]
 editor_description = "SS-56"
 script = ExtResource("1_pc7xr")
-option_array = Array[ExtResource("2_4hguj")]([SubResource("Resource_tq3y4"), SubResource("Resource_j1to4"), SubResource("Resource_tiax1"), SubResource("Resource_sh3m3")])
+option_array = Array[ExtResource("2_4hguj")]([SubResource("Resource_tq3y4"), SubResource("Resource_j1to4"), SubResource("Resource_tiax1"), SubResource("Resource_sh3m3"), SubResource("Resource_8ab4j")])

--- a/game/src/Game/GameStart.gd
+++ b/game/src/Game/GameStart.gd
@@ -57,6 +57,7 @@ func _load_compatibility_mode() -> void:
 			push_warning("Exact base path and search base path arguments both used:\nBase: ", arg_base_path, "\nSearch: ", arg_search_path)
 		actual_base_path = arg_base_path
 	elif arg_search_path:
+		# This will also search for a Steam install if the hint doesn't help
 		actual_base_path = GameSingleton.search_for_game_path(arg_search_path)
 		if not actual_base_path:
 			push_warning("Failed to find assets using search hint: ", arg_search_path)
@@ -65,7 +66,9 @@ func _load_compatibility_mode() -> void:
 		if _settings_base_path:
 			actual_base_path = _settings_base_path
 		else:
-			actual_base_path = GameSingleton.search_for_game_path()
+			# Check if the program is being run from inside the install directory,
+			# and if not also search for a Steam install
+			actual_base_path = GameSingleton.search_for_game_path("..")
 		if not actual_base_path:
 			var title : String = "Failed to find game asset path!"
 			var msg : String = "The path can be specified with the \"base-path\" command line option."
@@ -80,8 +83,10 @@ func _load_compatibility_mode() -> void:
 
 	var paths : PackedStringArray = [actual_base_path]
 
-	# Example for adding mod paths
-	#paths.push_back(actual_base_path + "/mod/TGC")
+	# Add mod paths
+	var settings_mod_names : PackedStringArray = ArgumentParser.get_argument(&"mod", "")
+	for mod_name : String in settings_mod_names:
+		paths.push_back(actual_base_path + "/mod/" + mod_name)
 
 	if GameSingleton.load_defines_compatibility_mode(paths) != OK:
 		push_error("Errors loading game defines!")


### PR DESCRIPTION
- Added `TYPE_PACKED_STRING_ARRAY` command line option type, which is basically just a string option that can be used multiple times without overwriting.
- Added `--mod` or `-m` option, which can be used multiple times, each time adding a mod's name (not including the `/mod/` part of its path). Mods are loaded in reverse order, so the last mod added will have the highest priority when `Dataloader` looks up files.
- Updates the SIM submodule to the `registry-template-fun` branch because that removes a `"dataloader/NodeTools.hpp"` include which was breaking the Github Action builds.