### PR TITLE
Added overlay parchment map and refactored map shader

### DIFF
--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -73,7 +73,7 @@ namespace OpenVic {
 		float get_map_aspect_ratio() const;
 
 		/* The cosmetic terrain textures stored in a Texture2DArray. */
-		godot::Ref<godot::Texture> get_terrain_texture() const;
+		godot::Ref<godot::Texture2DArray> get_terrain_texture() const;
 
 		/* The flag image corresponding to the requested country / flag_type
 		 * combination, or nullptr if no such flag can be found. */
@@ -87,14 +87,15 @@ namespace OpenVic {
 		/* The map, encoded in RGB8 with RG representing province index and B representing terrain texture.
 		 * To support a wider range of GPUs, the image is divided so that no piece has a dimension
 		 * greater than 16383 and the pieces are stored in a Texture2DArray. */
-		godot::Ref<godot::Texture> get_province_shape_texture() const;
+		godot::Ref<godot::Texture2DArray> get_province_shape_texture() const;
 
 		/* The base and stripe colours for each province. */
-		godot::Ref<godot::Texture> get_province_colour_texture() const;
+		godot::Ref<godot::ImageTexture> get_province_colour_texture() const;
 
 		int32_t get_mapmode_count() const;
 		godot::String get_mapmode_identifier(int32_t index) const;
 		godot::Error set_mapmode(godot::String const& identifier);
+		bool is_parchment_mapmode_allowed() const;
 		int32_t get_selected_province_index() const;
 		void set_selected_province(int32_t index);
 

--- a/game/src/Game/GameSession/MapView.tscn
+++ b/game/src/Game/GameSession/MapView.tscn
@@ -9,8 +9,10 @@ shader = ExtResource("1_upocn")
 shader_parameter/province_shape_subdivisions = null
 shader_parameter/hover_index = null
 shader_parameter/selected_index = null
+shader_parameter/parchment_mix = null
 shader_parameter/terrain_tile_factor = null
 shader_parameter/stripe_tile_factor = null
+shader_parameter/overlay_tile_factor = null
 
 [sub_resource type="MapMesh" id="MapMesh_3gtsd"]
 

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -176,7 +176,7 @@ func _ready() -> void:
 		var target_slot_count : int = GameSingleton.get_province_building_count()
 		var slot_y : float = 0.0
 		for current_slot_count : int in target_slot_count:
-			var slot := generate_gui_element("province_interface.gui", "building", "building_slot_%d" % current_slot_count)
+			var slot := GUINode.generate_gui_element("province_interface.gui", "building", "building_slot_%d" % current_slot_count)
 			if slot:
 				_buildings_panel.add_child(slot)
 				slot.set_position(Vector2(0.0, slot_y))
@@ -220,7 +220,9 @@ enum ColonyStatus { STATE, PROTECTORATE, COLONY }
 
 # This assumes _cores_overlapping_elements_box is non-null
 func _set_core_flag(core_index : int, country : String) -> void:
-	var core_flag_texture : GFXMaskedFlagTexture = get_gfx_masked_flag_texture_from_node(_cores_overlapping_elements_box.get_child(core_index).get_node(^"./country_flag"))
+	var core_flag_texture : GFXMaskedFlagTexture = GUINode.get_gfx_masked_flag_texture_from_node(
+		_cores_overlapping_elements_box.get_child(core_index).get_node(^"./country_flag")
+	)
 	if core_flag_texture:
 		core_flag_texture.set_flag_country_name(country)
 
@@ -278,7 +280,9 @@ func _update_info() -> void:
 			# TODO - replace example icons with those from the province's list of modifier instances
 			_province_modifiers_overlapping_elements_box.set_child_count(8)
 			for i : int in _province_modifiers_overlapping_elements_box.get_child_count():
-				var icon : GFXIconTexture = get_gfx_icon_texture_from_node(_province_modifiers_overlapping_elements_box.get_child(i).get_node(^"./modifier"))
+				var icon : GFXIconTexture = GUINode.get_gfx_icon_texture_from_node(
+					_province_modifiers_overlapping_elements_box.get_child(i).get_node(^"./modifier")
+				)
 				if icon:
 					icon.set_icon_index(2 * i + (i & 1) + 1)
 

--- a/game/src/Game/GameSession/TerrainMap.gdshader
+++ b/game/src/Game/GameSession/TerrainMap.gdshader
@@ -13,100 +13,140 @@ uniform sampler2D province_colour_tex: repeat_enable, filter_nearest;
 uniform uint hover_index;
 // Index of the currently selected province
 uniform uint selected_index;
+// How much to mix between the near detailed map (0) and the far parchment map (1)
+uniform float parchment_mix;
 // Cosmetic terrain textures
 uniform sampler2DArray terrain_tex: repeat_enable, filter_linear;
-// The number of times the terrain textures should tile vertically
+// Factor converting pixels to terrain tile size
 uniform float terrain_tile_factor;
 // Map stripe mask texture
 uniform sampler2D stripe_tex: repeat_enable, filter_linear;
-// The number of times the stripe texture should tile vertically
+// Factor converting pixels to stripe tile size
 uniform float stripe_tile_factor;
+// Map parchment overlay texture
+uniform sampler2D overlay_tex: repeat_enable, filter_linear;
+// Factor converting pixels to overlay tile size
+uniform float overlay_tile_factor;
 // Land map tint
 uniform sampler2D colormap_land_tex: repeat_enable, filter_linear;
 // Water map tint
 uniform sampler2D colormap_water_tex: repeat_enable, filter_linear;
+// Overlay map tint
+uniform sampler2D colormap_overlay_tex: repeat_enable, filter_linear;
 
-const vec3 highlight_colour = vec3(1.0);
-// Rec.709 luma coefficients
-const vec3 luma_weights = vec3(0.2126, 0.7152, 0.0722);
-
-struct args_t {
-	vec2 uv, half_pixel_size; // Components for calculating province sampling UV
-	float stripe_mask; // Stripe mask value - between 0 (base) and 1 (stripe)
+struct terrain_args_t {
+	vec2 uv, half_pixel_size; // Components for calculating terrain sampling UV
 	vec2 terrain_uv; // UV coordinates scaled for terrain texture tiling
-	vec3 land_tint_colour, water_tint_colour; // Colours for tinting terrain
+	vec3 land_tint_colour, water_tint_colour; // Colours for tinting the terrain
 };
 
-// TODO - add parchment overlay, borders, coastlines, rivers, fog of war
-// (when borders are added we can move province colour calculations out of get_terrain_colour
-// and into get_map_colour, as we won't need to blend along the borders between provinces)
+// Calculate terrain colour at the specified corner of the current pixel
+vec3 get_terrain_colour(const terrain_args_t terrain_args, const vec2 corner) {
+	// Find the terrain index at the specified corner of the current pixel
+	uint terrain_index = read_uvec3(fma(corner, terrain_args.half_pixel_size, terrain_args.uv)).z;
 
-// This calculates the terrain and base-stripe province colours, blends them together, and then returns
-// either the blended colour or just the terrain colour depending on whether the province colour's alpha
-// value was set. It also highlights the result if the province is currently selected and/or hovered over.
-vec3 get_terrain_colour(const args_t args, const vec2 corner) {
-	// Find the province and terrain indices at the specified corner of a pixel centred on uv
-	uvec3 province_data = read_uvec3(fma(corner, args.half_pixel_size, args.uv));
-	uint province_index = uvec2_to_uint(province_data.rg);
-	uint terrain_index = province_data.b;
+	// Get the tinted land colour at the current position
+	vec3 land_colour = texture(terrain_tex, vec3(terrain_args.terrain_uv, float(terrain_index))).rgb;
+	land_colour = mix(land_colour, terrain_args.land_tint_colour, 0.3);
 
-	// Get the tinted terrain colour at the current position
-	vec3 terrain_colour = texture(terrain_tex, vec3(args.terrain_uv, float(terrain_index))).rgb;
-	vec3 tint_colour = mix(args.land_tint_colour, args.water_tint_colour, float(terrain_index == 0u));
-	vec3 tinted_terrain_colour = mix(terrain_colour, tint_colour, 0.3);
-	float terrain_luma = dot(tinted_terrain_colour, luma_weights);
+	// TODO - proper water texture
+	vec3 water_colour = terrain_args.water_tint_colour;
 
-	// Get base and stripe colours for province at the current position
-	province_data.r *= 2u; // Double "x coordinate" as colours come in (base, stripe) pairs
-	vec4 province_base_colour = texelFetch(province_colour_tex, ivec2(province_data.rg), 0);
-	province_data.r += 1u; // Add 1 to "x coordinate" to move from base to strip colour
-	vec4 province_stripe_colour = texelFetch(province_colour_tex, ivec2(province_data.rg), 0);
-	// Blend the base and stripe colours according to the current position's stripe mask value
-	vec4 province_colour = mix(province_base_colour, province_stripe_colour, args.stripe_mask);
+	// Select land or water colour based on the terrain index (0 is water, otherwise land)
+	vec3 terrain_colour = mix(land_colour, water_colour, float(terrain_index == 0u));
 
-	// Darken the province colour, use it to tint the monochrome terrain colour, and re-lighten the result
-	province_colour.rgb = mix(vec3(terrain_luma), province_colour.rgb - 0.7, 0.3) * 1.5;
-
-	// Show the terrain colour if the province colour has no alpha, otherwise show the province colour
-	vec3 mixed_colour = mix(tinted_terrain_colour, province_colour.rgb, float(province_colour.a != 0.0));
-
-	float highlight_mix_val = 0.4 * (float(province_index == hover_index) + float(province_index == selected_index)) * float(province_index != 0u);
-	return mix(mixed_colour, highlight_colour, highlight_mix_val);
+	return terrain_colour;
 }
 
-// Rescale UV coordinates to remove squashing caused by normalisation
-vec2 denormalise(const vec2 uv, const vec2 dims) {
-	return vec2(uv.x * dims.x / dims.y, uv.y);
-}
-
-// Calculate position-specific values and then calculate and blend map colours at the four corners
-// of a pixel centred at uv in order to have smooth transitions between terrain types.
-vec3 get_map_colour(vec2 uv) {
-	args_t args;
-	args.uv = uv;
-
-	vec2 map_size = vec2(textureSize(province_shape_tex, 0).xy) * province_shape_subdivisions;
-	vec2 uv_centred = fma(uv, map_size, vec2(0.5));
-	vec2 pixel_offset = fract(uv_centred);
-	args.half_pixel_size = 0.49 / map_size;
-
-	// UV coords adjusted to remove squashing caused by normalisation relative to map dimensions
-	vec2 unscaled_uv = denormalise(uv, map_size);
-
-	vec2 stripe_uv = unscaled_uv * stripe_tile_factor;
-	// Stripe mask value - between 0 (base) and 1 (stripe)
-	args.stripe_mask = texture(stripe_tex, stripe_uv).b;
-
-	args.terrain_uv = 0.5 - unscaled_uv * terrain_tile_factor;
-	vec2 colormap_uv = vec2(uv.x, 1.0 - uv.y);
-	args.land_tint_colour = texture(colormap_land_tex, colormap_uv).rgb;
-	args.water_tint_colour = texture(colormap_water_tex, colormap_uv).rgb;
-
+// Blend together terrain colours from the four corners of the current pixel
+vec3 mix_terrain_colour(const terrain_args_t terrain_args, const vec2 pixel_offset) {
 	return mix(
-		mix(get_terrain_colour(args, vec2(-1, -1)), get_terrain_colour(args, vec2(+1, -1)), pixel_offset.x),
-		mix(get_terrain_colour(args, vec2(-1, +1)), get_terrain_colour(args, vec2(+1, +1)), pixel_offset.x),
+		mix(get_terrain_colour(terrain_args, vec2(-1, -1)), get_terrain_colour(terrain_args, vec2(+1, -1)), pixel_offset.x),
+		mix(get_terrain_colour(terrain_args, vec2(-1, +1)), get_terrain_colour(terrain_args, vec2(+1, +1)), pixel_offset.x),
 		pixel_offset.y
 	);
+}
+
+// Mix overlay and base colours, used for the parchment map
+vec3 mix_overlay(const vec3 overlay_colour, const vec3 base_colour) {
+	return mix(
+		2.0 * overlay_colour * base_colour,
+		1.0 - 2.0 * (1.0 - overlay_colour) * (1.0 - base_colour),
+		greaterThanEqual(overlay_colour.rrb, vec3(0.5))
+	);
+}
+
+// Calculate map colour at specified UV coordinates, combining terrain, province base and stripe colour,
+// parchment overlay, and highlighting the result if it is a hovered over and/or selected province.
+vec3 get_map_colour(vec2 uv) {
+	vec2 map_size = vec2(textureSize(province_shape_tex, 0).xy) * province_shape_subdivisions;
+	vec2 uv_map_pixels = fma(uv, map_size, vec2(0.5));
+	// Offset of uv_map_pixels from the top left corner of the current pixel
+	vec2 pixel_offset = fract(uv_map_pixels);
+
+	terrain_args_t terrain_args;
+	terrain_args.uv = uv;
+	terrain_args.half_pixel_size = 0.49 / map_size;
+	// Terrain texture tiling UV
+	terrain_args.terrain_uv = 0.5 - uv_map_pixels * terrain_tile_factor;
+
+	vec2 colormap_uv = vec2(uv.x, 1.0 - uv.y);
+	// Terrain tinting colours
+	terrain_args.land_tint_colour = texture(colormap_land_tex, colormap_uv).rgb;
+	terrain_args.water_tint_colour = texture(colormap_water_tex, colormap_uv).rgb;
+	// Parchment tint colour
+	vec3 overlay_tint_colour = texture(colormap_overlay_tex, colormap_uv).rgb;
+
+	// Blended terrain colour (average of four corners of current pixel)
+	vec3 terrain_colour = mix_terrain_colour(terrain_args, pixel_offset);
+
+	vec2 stripe_uv = uv_map_pixels * stripe_tile_factor;
+	// Stripe mask value - between 0 (base) and 1 (stripe)
+	float stripe_mask = texture(stripe_tex, stripe_uv).b;
+
+	vec2 overlay_uv = vec2(uv_map_pixels.x, map_size.y - uv_map_pixels.y) * overlay_tile_factor;
+	// Parchment overlay colour
+	vec3 overlay_colour = texture(overlay_tex, overlay_uv).rgb;
+
+	// Current province index as a pair of byte coordinates and as a combined 16 bit value
+	uvec2 province_data = read_uvec3(uv).xy;
+	uint province_index = uvec2_to_uint(province_data);
+
+	// Get base and stripe colours for province at the current position
+	province_data.x *= 2u; // Double "x coordinate" as colours come in (base, stripe) pairs
+	vec4 province_base_colour = texelFetch(province_colour_tex, ivec2(province_data), 0);
+	province_data.x += 1u; // Add 1 to "x coordinate" to move from base to strip colour
+	vec4 province_stripe_colour = texelFetch(province_colour_tex, ivec2(province_data), 0);
+	// Blend the base and stripe colours according to the current position's stripe mask value
+	vec4 province_colour = mix(province_base_colour, province_stripe_colour, stripe_mask);
+	// Darken the province colour
+	province_colour.rgb -= 0.7;
+
+	// Rec.709 luma coefficients
+	const vec3 luma_weights = vec3(0.2126, 0.7152, 0.0722);
+	float terrain_luma = dot(terrain_colour, luma_weights);
+
+	// Near colour is either the terrain's luma component tinted with the province colour and brightened,
+	// or the normal terrain colour
+	vec3 near_province_colour = mix(vec3(terrain_luma), province_colour.rgb, 0.3) * 1.5;
+	vec3 near_colour = mix(near_province_colour, terrain_colour, float(province_colour.a == 0.0));
+
+	// Far colour is either the province colour mixed with the overlay texture, tinted with the overlay colormap and brightened,
+	// or the normal terrain colour mixed with the overlay texture (primarily for water)
+	vec3 far_province_colour = mix_overlay(overlay_colour, province_colour.rgb);
+	far_province_colour = mix(overlay_tint_colour, far_province_colour, 0.3) * 1.5;
+	vec3 far_terrain_colour = mix_overlay(overlay_colour, terrain_colour);
+	vec3 far_colour = mix(far_province_colour, far_terrain_colour, float(province_colour.a == 0.0));
+
+	// Blend the near (detailed terrain) and far (parchment) colours according to the parchment mix factor (0 for near, 1 for far)
+	vec3 final_colour = mix(near_colour, far_colour, parchment_mix);
+
+	// Significantly brighted the colour if it is hovered over and/or selected, but not if it has province index 0 (all invalid pixels)
+	const vec3 highlight_colour = vec3(1.0);
+	float highlight_mix_val = 0.4 * (float(province_index == hover_index) + float(province_index == selected_index)) * float(province_index != 0u);
+	vec3 highlighted_colour = mix(final_colour, highlight_colour, highlight_mix_val);
+
+	return highlighted_colour;
 }
 
 // Convert from standard RGB to linear colour space (Godot requires the output to be linear)
@@ -119,5 +159,8 @@ vec3 srgb_to_linear(vec3 srgb) {
 }
 
 void fragment() {
+
+	// TODO - add borders, coastlines, rivers, fog of war
+
 	ALBEDO = srgb_to_linear(get_map_colour(UV));
 }

--- a/game/src/Game/GameSession/Topbar.gd
+++ b/game/src/Game/GameSession/Topbar.gd
@@ -45,7 +45,7 @@ func _ready() -> void:
 	_speed_indicator_button = get_button_from_nodepath(^"./topbar/speed_indicator")
 	if _speed_indicator_button:
 		_speed_indicator_button.pressed.connect(_on_play_pause_button_pressed)
-		_speed_indicator_texture = get_gfx_icon_texture_from_node(_speed_indicator_button)
+		_speed_indicator_texture = GUINode.get_gfx_icon_texture_from_node(_speed_indicator_button)
 
 	_update_info()
 	_update_speed_controls()

--- a/game/src/Game/GlobalClass/ShaderManager.gd
+++ b/game/src/Game/GlobalClass/ShaderManager.gd
@@ -6,20 +6,41 @@ const param_province_shape_subdivisions : StringName = &"province_shape_subdivis
 const param_province_colour_tex : StringName = &"province_colour_tex"
 const param_hover_index : StringName = &"hover_index"
 const param_selected_index : StringName = &"selected_index"
+const param_parchment_mix : StringName = &"parchment_mix"
 const param_terrain_tex : StringName = &"terrain_tex"
 const param_terrain_tile_factor : StringName = &"terrain_tile_factor"
 const param_stripe_tex : StringName = &"stripe_tex"
 const param_stripe_tile_factor : StringName = &"stripe_tile_factor"
+const param_overlay_tex : StringName = &"overlay_tex"
+const param_overlay_tile_factor : StringName = &"overlay_tile_factor"
 const param_colormap_land_tex : StringName = &"colormap_land_tex"
 const param_colormap_water_tex : StringName = &"colormap_water_tex"
+const param_colormap_overlay_tex : StringName = &"colormap_overlay_tex"
 
-func _set_shader_texture(shader_material : ShaderMaterial, texture_path : StringName, texture_param : StringName) -> Error:
-	var texture := AssetManager.get_texture(texture_path)
-	if texture == null:
-		push_error("Failed to get texture: ", texture_path)
-		return FAILED
-	shader_material.set_shader_parameter(texture_param, texture)
-	return OK
+func _set_shader_texture(
+	shader_material : ShaderMaterial, texture_param : StringName, texture : Texture,
+	tile_factor_param : StringName = &"", pixels_per_tile : float = 0.0
+) -> Error:
+	var err : Error = OK
+	if texture != null:
+		shader_material.set_shader_parameter(texture_param, texture)
+	else:
+		push_error("Invalid texture for shader parameter ", texture_param, " - null!")
+		err = FAILED
+	if tile_factor_param:
+		# Set to 1.0 / pixels_per_tile as the shader can multiply faster than it can divide, and it will not automatically
+		# optimise to multiplication by a reciprocal for fear of losing precision. As pixels_per_tile is often a power of two,
+		# this doesn't actually lose any precision, and even if it did it would be insignificant.
+		shader_material.set_shader_parameter(tile_factor_param, 1.0 / pixels_per_tile)
+	return err
+
+func _set_shader_asset_texture(
+	shader_material : ShaderMaterial, texture_param : StringName, texture_path : StringName,
+	tile_factor_param : StringName = &"", pixels_per_tile : float = 0.0
+) -> Error:
+	return _set_shader_texture(
+		shader_material, texture_param, AssetManager.get_texture(texture_path), tile_factor_param, pixels_per_tile
+	)
 
 func set_up_shader(material : Material, add_cosmetic_textures : bool) -> Error:
 	# Shader Material
@@ -34,46 +55,65 @@ func set_up_shader(material : Material, add_cosmetic_textures : bool) -> Error:
 	var ret : Error = OK
 
 	# Province shape texture
-	var province_shape_texture := GameSingleton.get_province_shape_texture()
-	if province_shape_texture == null:
-		push_error("Failed to get province shape texture!")
+	if _set_shader_texture(shader_material, param_province_shape_tex, GameSingleton.get_province_shape_texture()) != OK:
+		push_error("Failed to set province shape shader texture array!")
 		ret = FAILED
+
+	var subdivisions : Vector2i = GameSingleton.get_province_shape_image_subdivisions()
+	if subdivisions.x >= 1 and subdivisions.y >= 1:
+		shader_material.set_shader_parameter(param_province_shape_subdivisions, Vector2(subdivisions))
 	else:
-		shader_material.set_shader_parameter(param_province_shape_tex, province_shape_texture)
-	var subdivisions := GameSingleton.get_province_shape_image_subdivisions()
-	if subdivisions.x < 1 or subdivisions.y < 1:
 		push_error("Invalid province shape image subdivision: ", subdivisions.x, "x", subdivisions.y)
 		ret = FAILED
-	else:
-		shader_material.set_shader_parameter(param_province_shape_subdivisions, Vector2(subdivisions))
 
 	if add_cosmetic_textures:
 
 		# Province colour texture
-		var map_province_colour_texture := GameSingleton.get_province_colour_texture()
-		if map_province_colour_texture == null:
-			push_error("Failed to get province colour texture!")
+		if _set_shader_texture(shader_material, param_province_colour_tex, GameSingleton.get_province_colour_texture()) != OK:
+			push_error("Failed to set province colour shader texture!")
 			ret = FAILED
-		else:
-			shader_material.set_shader_parameter(param_province_colour_tex, map_province_colour_texture)
 
 		# Terrain texture
-		var terrain_texture := GameSingleton.get_terrain_texture()
-		if terrain_texture == null:
-			push_error("Failed to get terrain texture!")
+		const pixels_per_terrain_tile : float = 16.0
+		if _set_shader_texture(
+			shader_material,
+			param_terrain_tex, GameSingleton.get_terrain_texture(),
+			param_terrain_tile_factor, pixels_per_terrain_tile
+		) != OK:
+			push_error("Failed to set terrain shader texture array!")
 			ret = FAILED
-		else:
-			shader_material.set_shader_parameter(param_terrain_tex, terrain_texture)
 
 		# Stripe texture
-		if _set_shader_texture(shader_material, &"map/terrain/stripes.dds", param_stripe_tex) != OK:
+		const pixels_per_stripe_tile : float = 8.0
+		if _set_shader_asset_texture(
+			shader_material,
+			param_stripe_tex, &"map/terrain/stripes.dds",
+			param_stripe_tile_factor, pixels_per_stripe_tile
+		) != OK:
+			push_error("Failed to set stripe shader texture!")
+			ret = FAILED
+
+		# Overlay texture
+		const pixels_per_overlay_tile : float = 512.0
+		if _set_shader_asset_texture(
+			shader_material,
+			param_overlay_tex, &"map/terrain/map_overlay_tile.dds",
+			param_overlay_tile_factor, pixels_per_overlay_tile
+		) != OK:
+			push_error("Failed to set overlay shader texture!")
 			ret = FAILED
 
 		# Land colormap
-		if _set_shader_texture(shader_material, &"map/terrain/colormap.dds", param_colormap_land_tex) != OK:
+		if _set_shader_asset_texture(shader_material, param_colormap_land_tex, &"map/terrain/colormap.dds") != OK:
+			push_error("Failed to set land colormap shader texture!")
 			ret = FAILED
 		# Water colormap
-		if _set_shader_texture(shader_material, &"map/terrain/colormap_water.dds", param_colormap_water_tex) != OK:
+		if _set_shader_asset_texture(shader_material, param_colormap_water_tex, &"map/terrain/colormap_water.dds") != OK:
+			push_error("Failed to set water colormap shader texture!")
+			ret = FAILED
+		# Overlay colormap
+		if _set_shader_asset_texture(shader_material, param_colormap_overlay_tex, &"map/terrain/colormap_political.dds") != OK:
+			push_error("Failed to set overlay colormap shader texture!")
 			ret = FAILED
 
 	return ret


### PR DESCRIPTION
- Changed water to use the water colormap rather than a solid blue texture. That texture is now red as a warning if it's ever accidentally used, it still needs to exist so we don't have to branch to avoid reading a terrain tile array texture for water pixels.
- Added overlay parchment/far view to the map shader, including a `parchment_mix` uniform float which controls the blending of the near (0) and far (1) map types.
- Refactored map shader to only blend terrain from the four corners of the pixel, but to only calculate a single province colour value. This creates a pixelated look along boundaries between different province colours, but that will be hidden by province/state/country borders in a future PR.
- Added `_zoom_parchment_threshold` to determine at what point to switch from the detailed terrain map type to the parchment-style map.
- Added `is_parchment_mapmode_allowed` to determine whether to allow the parchment overlay or not (when zoomed out), currently it is only false for the cosmetic terrain mapmode.
- Adjusted `MapView` zoom:
  - making the `_zoom_target_step` and `_zoom_parchment_threshold` based on the min and max.
  - making the orientation change upon zooming in kick in later and be steeper.
  - changing the Camera's `up` vector to forwards/towards the map's north, instead of straight up/out of the map, so that the Camera can face directly at the map without causing errors (`look_at` does not allow you to look along the `up` axis, as it wouldn't have a well defined rotation around that axis).
- Moved shader texture tile factor floats to `ShaderManager`, incorporating them into refactored `_set_shader_texture` and `_set_shader_asset_texture` functions.
- Updated SIM submodule to include search path fix #195, mapmode default colour adjustments, and other stuff not directly related to the Godot layer.
- Added `GUINode.` to some static function calls to stop Godot from emitting warnings.