### PR TITLE
Basic Nation Management Screen framework

### DIFF
--- a/extension/src/openvic-extension/classes/GFXIconTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXIconTexture.cpp
@@ -3,7 +3,6 @@
 #include <godot_cpp/variant/utility_functions.hpp>
 
 #include "openvic-extension/singletons/AssetManager.hpp"
-#include "openvic-extension/singletons/GameSingleton.hpp"
 #include "openvic-extension/utility/ClassBindings.hpp"
 #include "openvic-extension/utility/UITools.hpp"
 #include "openvic-extension/utility/Utilities.hpp"
@@ -11,7 +10,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
 using OpenVic::Utilities::std_view_to_godot_string;
 using OpenVic::Utilities::std_view_to_godot_string_name;
 

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
@@ -1,16 +1,14 @@
 #include "GFXPieChartTexture.hpp"
 
-#include "openvic-extension/singletons/AssetManager.hpp"
-#include "openvic-extension/singletons/GameSingleton.hpp"
+#include <numbers>
+
 #include "openvic-extension/utility/ClassBindings.hpp"
 #include "openvic-extension/utility/UITools.hpp"
 
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
 using OpenVic::Utilities::std_view_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string_name;
 
 StringName const& GFXPieChartTexture::_slice_identifier_key() {
 	static StringName const slice_identifier_key = "identifier";

--- a/extension/src/openvic-extension/classes/GUINode.hpp
+++ b/extension/src/openvic-extension/classes/GUINode.hpp
@@ -25,12 +25,14 @@ namespace OpenVic {
 		GUINode();
 
 		static godot::Control* generate_gui_element(
-			godot::String const& gui_file, godot::String const& gui_element, godot::String const& name = ""
+			godot::String const& gui_scene, godot::String const& gui_element, godot::String const& name = ""
 		);
 
 		godot::Error add_gui_element(
-			godot::String const& gui_file, godot::String const& gui_element, godot::String const& name = ""
+			godot::String const& gui_scene, godot::String const& gui_element, godot::String const& name = ""
 		);
+
+		static godot::Vector2 get_gui_position(godot::String const& gui_scene, godot::String const& gui_position);
 
 		static godot::Button* get_button_from_node(godot::Node* node);
 		static godot::CheckBox* get_check_box_from_node(godot::Node* node);

--- a/extension/src/openvic-extension/utility/UITools.hpp
+++ b/extension/src/openvic-extension/utility/UITools.hpp
@@ -7,12 +7,13 @@
 
 namespace OpenVic::UITools {
 	GFX::Sprite const* get_gfx_sprite(godot::String const& gfx_sprite);
-	GUI::Element const* get_gui_element(godot::String const& gui_file, godot::String const& gui_element);
+	GUI::Element const* get_gui_element(godot::String const& gui_scene, godot::String const& gui_element);
+	GUI::Position const* get_gui_position(godot::String const& gui_scene, godot::String const& gui_position);
 
 	bool generate_gui_element(
 		GUI::Element const* element, godot::String const& name, godot::Control*& result
 	);
 	bool generate_gui_element(
-		godot::String const& gui_file, godot::String const& gui_element, godot::String const& name, godot::Control*& result
+		godot::String const& gui_scene, godot::String const& gui_element, godot::String const& name, godot::Control*& result
 	);
 }

--- a/extension/src/openvic-extension/utility/Utilities.cpp
+++ b/extension/src/openvic-extension/utility/Utilities.cpp
@@ -1,7 +1,5 @@
 #include "Utilities.hpp"
 
-#include <numbers>
-
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/classes/translation_server.hpp>

--- a/extension/src/openvic-extension/utility/Utilities.hpp
+++ b/extension/src/openvic-extension/utility/Utilities.hpp
@@ -11,23 +11,23 @@
 
 namespace OpenVic::Utilities {
 
-	inline std::string godot_to_std_string(godot::String const& str) {
+	_FORCE_INLINE_ std::string godot_to_std_string(godot::String const& str) {
 		return str.ascii().get_data();
 	}
 
-	inline godot::String std_to_godot_string(std::string const& str) {
+	_FORCE_INLINE_ godot::String std_to_godot_string(std::string const& str) {
 		return str.c_str();
 	}
 
-	inline godot::String std_view_to_godot_string(std::string_view str) {
+	_FORCE_INLINE_ godot::String std_view_to_godot_string(std::string_view const& str) {
 		return std_to_godot_string(static_cast<std::string>(str));
 	}
 
-	inline godot::StringName std_to_godot_string_name(std::string const& str) {
+	_FORCE_INLINE_ godot::StringName std_to_godot_string_name(std::string const& str) {
 		return str.c_str();
 	}
 
-	inline godot::StringName std_view_to_godot_string_name(std::string_view str) {
+	_FORCE_INLINE_ godot::StringName std_view_to_godot_string_name(std::string_view const& str) {
 		return std_to_godot_string_name(static_cast<std::string>(str));
 	}
 
@@ -37,15 +37,15 @@ namespace OpenVic::Utilities {
 
 	godot::String date_to_formatted_string(Date date);
 
-	inline godot::Color to_godot_color(IsColour auto colour) {
+	_FORCE_INLINE_ godot::Color to_godot_color(IsColour auto colour) {
 		return { colour.redf(), colour.greenf(), colour.bluef(), colour.alphaf() };
 	}
 
-	inline godot::Vector2i to_godot_ivec2(ivec2_t vec) {
+	_FORCE_INLINE_ godot::Vector2i to_godot_ivec2(ivec2_t vec) {
 		return { vec.x, vec.y };
 	}
 
-	inline godot::Vector2 to_godot_fvec2(fvec2_t vec) {
+	_FORCE_INLINE_ godot::Vector2 to_godot_fvec2(fvec2_t vec) {
 		return { vec.x, vec.y };
 	}
 

--- a/game/src/Game/Autoload/Events.gd
+++ b/game/src/Game/Autoload/Events.gd
@@ -1,9 +1,11 @@
 ## Events are exclusively for the purpose of handling global signals
 ## This is to reduce "signal bubbling" which is when a signal callback is used to "bubble" the signal callbacks up the scene tree.
-## It does such by providing a global interface of signals that are connected to and emitted by that are garunteed to exist.
+## It does such by providing a global interface of signals that are connected to and emitted by that are guaranteed to exist.
 extends Node
 
-var Options: OptionsEventsObject
+var Options : OptionsEventsObject
+var NationManagementScreens : NationManagementScreensEventsObject
 
 func _init() -> void:
 	Options = OptionsEventsObject.new()
+	NationManagementScreens = NationManagementScreensEventsObject.new()

--- a/game/src/Game/Autoload/Events/NationManagementScreens.gd
+++ b/game/src/Game/Autoload/Events/NationManagementScreens.gd
@@ -1,0 +1,25 @@
+class_name NationManagementScreensEventsObject
+extends RefCounted
+
+signal update_active_nation_management_screen(screen : NationManagement.Screen)
+
+var _current_screen : NationManagement.Screen = NationManagement.Screen.NONE
+
+# Set the current nation management screen. This emits an update signal to force
+# the argument screen to update, even if it was already the current screen.
+# Used by miscellaneous screen opening buttons (e.g. in province overview panel)
+# and by the close and toggle functions below.
+func open_nation_management_screen(screen : NationManagement.Screen) -> void:
+	_current_screen = screen
+	update_active_nation_management_screen.emit(_current_screen)
+
+# Close the screen if it is already open. Used for screens' close buttons.
+func close_nation_management_screen(screen : NationManagement.Screen) -> void:
+	if screen == _current_screen:
+		open_nation_management_screen(NationManagement.Screen.NONE)
+
+# Either switch to the screen or close it if it is already open. Used for topbar's buttons.
+func toggle_nation_management_screen(screen : NationManagement.Screen) -> void:
+	if screen == _current_screen:
+		screen = NationManagement.Screen.NONE
+	open_nation_management_screen(screen)

--- a/game/src/Game/GameSession/GameSession.tscn
+++ b/game/src/Game/GameSession/GameSession.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://bgnupcshe1m7r"]
+[gd_scene load_steps=18 format=3 uid="uid://bgnupcshe1m7r"]
 
 [ext_resource type="Script" path="res://src/Game/GameSession/GameSession.gd" id="1_eklvp"]
 [ext_resource type="PackedScene" uid="uid://cvl76duuym1wq" path="res://src/Game/MusicConductor/MusicPlayer.tscn" id="2_kt6aa"]
@@ -6,9 +6,17 @@
 [ext_resource type="PackedScene" uid="uid://dvdynl6eir40o" path="res://src/Game/GameSession/GameSessionMenu.tscn" id="3_bvmqh"]
 [ext_resource type="Script" path="res://src/Game/GameSession/Topbar.gd" id="4_2kbih"]
 [ext_resource type="PackedScene" uid="uid://dkehmdnuxih2r" path="res://src/Game/GameSession/MapView.tscn" id="4_xkg5j"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/ProductionMenu.gd" id="5_16755"]
 [ext_resource type="Script" path="res://src/Game/GameSession/ProvinceOverviewPanel.gd" id="5_lfv8l"]
 [ext_resource type="PackedScene" uid="uid://cnbfxjy1m6wja" path="res://src/Game/Menu/OptionMenu/OptionsMenu.tscn" id="6_p5mnx"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/BudgetMenu.gd" id="6_vninv"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/TechnologyMenu.gd" id="7_r712c"]
 [ext_resource type="PackedScene" uid="uid://d3g6wbvwflmyk" path="res://src/Game/Menu/SaveLoadMenu/SaveLoadMenu.tscn" id="8_4g7ko"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/PoliticsMenu.gd" id="8_ppdek"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/PopulationMenu.gd" id="10_laee7"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/TradeMenu.gd" id="10_mv1r6"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/DiplomacyMenu.gd" id="11_fu7ys"]
+[ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/MilitaryMenu.gd" id="12_6h6nc"]
 
 [node name="GameSession" type="Control" node_paths=PackedStringArray("_game_session_menu")]
 editor_description = "SS-102, UI-546"
@@ -33,6 +41,46 @@ script = ExtResource("5_lfv8l")
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("4_2kbih")
+
+[node name="ProductionMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("5_16755")
+
+[node name="BudgetMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("6_vninv")
+
+[node name="TechnologyMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("7_r712c")
+
+[node name="PoliticsMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("8_ppdek")
+
+[node name="PopulationMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("10_laee7")
+
+[node name="TradeMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("10_mv1r6")
+
+[node name="DiplomacyMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("11_fu7ys")
+
+[node name="MilitaryMenu" type="GUINode" parent="Topbar"]
+layout_mode = 1
+anchors_preset = 15
+script = ExtResource("12_6h6nc")
 
 [node name="MapControlPanel" parent="." instance=ExtResource("3_afh6d")]
 layout_mode = 1

--- a/game/src/Game/GameSession/NationManagementScreen/BudgetMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/BudgetMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.BUDGET
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_budget", "country_budget")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_budget/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/DiplomacyMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/DiplomacyMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.DIPLOMACY
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_diplomacy", "country_diplomacy")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_diplomacy/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/MilitaryMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/MilitaryMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.MILITARY
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_military", "country_military")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_military/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/PoliticsMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/PoliticsMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.POLITICS
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_politics", "country_politics")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_politics/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.POPULATION
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_pops", "country_pop")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_pop/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/ProductionMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/ProductionMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.PRODUCTION
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_production", "country_production")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_production/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/TechnologyMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/TechnologyMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.TECHNOLOGY
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_technology", "country_technology")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_technology/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/NationManagementScreen/TradeMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/TradeMenu.gd
@@ -1,0 +1,34 @@
+extends GUINode
+
+var _active : bool = false
+
+const _screen : NationManagement.Screen = NationManagement.Screen.TRADE
+
+func _ready() -> void:
+	GameSingleton.gamestate_updated.connect(_update_info)
+
+	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
+
+	add_gui_element("country_trade", "country_trade")
+
+	var close_button : Button = get_button_from_nodepath(^"./country_trade/close_button")
+	if close_button:
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+
+	_update_info()
+
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_update_info()
+
+func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
+	_active = active_screen == _screen
+	_update_info()
+
+func _update_info() -> void:
+	if _active:
+		# TODO - update UI state
+		show()
+	else:
+		hide()

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -121,7 +121,7 @@ func _ready() -> void:
 	GameSingleton.province_selected.connect(_on_province_selected)
 	GameSingleton.gamestate_updated.connect(_update_info)
 
-	if add_gui_element("province_interface.gui", "province_view") != OK:
+	if add_gui_element("province_interface", "province_view") != OK:
 		push_error("Failed to generate province overview panel!")
 		return
 
@@ -144,7 +144,7 @@ func _ready() -> void:
 	_administrative_percentage_label = get_label_from_nodepath(^"./province_view/province_view_header/admin_efficiency")
 	_owner_percentage_label = get_label_from_nodepath(^"./province_view/province_view_header/owner_presence")
 	_province_modifiers_overlapping_elements_box = get_gui_overlapping_elements_box_from_nodepath(^"./province_view/province_view_header/province_modifiers")
-	if _province_modifiers_overlapping_elements_box and _province_modifiers_overlapping_elements_box.set_gui_child_element_name("province_interface.gui", "prov_state_modifier") != OK:
+	if _province_modifiers_overlapping_elements_box and _province_modifiers_overlapping_elements_box.set_gui_child_element_name("province_interface", "prov_state_modifier") != OK:
 		_province_modifiers_overlapping_elements_box = null # hide province modifiers box since we can't do anything with it
 	_terrain_type_texture = get_gfx_icon_texture_from_nodepath(^"./province_view/province_view_header/prov_terrain")
 	_life_rating_bar = get_progress_bar_from_nodepath(^"./province_view/province_view_header/liferating")
@@ -168,7 +168,7 @@ func _ready() -> void:
 	_pop_cultures_piechart = get_gfx_pie_chart_texture_from_nodepath(^"./province_view/province_statistics/culture_chart")
 	_supply_limit_label = get_label_from_nodepath(^"./province_view/province_statistics/supply_limit_label")
 	_cores_overlapping_elements_box = get_gui_overlapping_elements_box_from_nodepath(^"./province_view/province_statistics/core_icons")
-	if _cores_overlapping_elements_box and _cores_overlapping_elements_box.set_gui_child_element_name("province_interface.gui", "province_core") != OK:
+	if _cores_overlapping_elements_box and _cores_overlapping_elements_box.set_gui_child_element_name("province_interface", "province_core") != OK:
 		_cores_overlapping_elements_box = null # hide cores box since we can't do anything with it
 
 	_buildings_panel = get_panel_from_nodepath(^"./province_view/province_buildings")
@@ -176,7 +176,7 @@ func _ready() -> void:
 		var target_slot_count : int = GameSingleton.get_province_building_count()
 		var slot_y : float = 0.0
 		for current_slot_count : int in target_slot_count:
-			var slot := GUINode.generate_gui_element("province_interface.gui", "building", "building_slot_%d" % current_slot_count)
+			var slot := GUINode.generate_gui_element("province_interface", "building", "building_slot_%d" % current_slot_count)
 			if slot:
 				_buildings_panel.add_child(slot)
 				slot.set_position(Vector2(0.0, slot_y))

--- a/game/src/Game/GameStart.gd
+++ b/game/src/Game/GameStart.gd
@@ -48,7 +48,7 @@ func _save_setting(file : ConfigFile) -> void:
 
 func _setup_compatibility_mode_paths() -> void:
 	# To test mods, set your base path to Victoria II and then pass mods in reverse order with --mod="mod" for each mod.
-	
+
 	var arg_base_path : String = ArgumentParser.get_argument(&"base-path", "")
 	var arg_search_path : String = ArgumentParser.get_argument(&"search-path", "")
 

--- a/game/src/Game/GlobalClass/NationManagement.gd
+++ b/game/src/Game/GlobalClass/NationManagement.gd
@@ -1,0 +1,13 @@
+class_name NationManagement
+
+enum Screen {
+	NONE,
+	PRODUCTION,
+	BUDGET,
+	TECHNOLOGY,
+	POLITICS,
+	POPULATION,
+	TRADE,
+	DIPLOMACY,
+	MILITARY
+}


### PR DESCRIPTION
- Added support for getting `GUI::Position`s from GDScript.
- Added placeholder UI elements (semi-transparent `godot::ColorRect`s) for:
  - `GUI::ListBox` - blue
  - `GUI::TextEditBox` - green
  - `GUI::Scrollbar` - red

- Added `NationManagement` global class containing `Screen` enum, accessed as `NationManagement.Screen`.
- Added `NationManagementScreensEventsObject` for handling current active screen, update signal and open, close, toggle functions.
- Added nation mangement screen `GUINode`s as children of `Topbar` for easier organisation. Each currently generates its base scene and connects its close button. They have basic scripts (which would've used a shared base class, but Godot doesn't like double-extending GDExtension classes for some reason), each will need more work to be fully wired up. They can be opened/closed using the `Topbar` buttons, but some sub-elements can block the mouse clicks.
- Listboxes and scrollbars (both in and out of listboxes) need to be generated properly.
- Windows-1252 character `¤ (A4)` needs to be converted to the golden `£` icon.
- Mouse filter settings need to be sorted out, some might be automatically changed, others will probably need custom code, e.g. colony status alert button either passes through to the Diplomacy button or opens the province view for the upgradable state.