### PR TITLE
Add GameInfo button to MainMenu

### DIFF
--- a/game/assets/graphics/theme/main_menu.tres
+++ b/game/assets/graphics/theme/main_menu.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=32 format=3 uid="uid://qoi3oec48jp0"]
+[gd_resource type="Theme" load_steps=37 format=3 uid="uid://qoi3oec48jp0"]
 
 [ext_resource type="Script" path="res://src/Game/Theme/StyleBoxCombinedTexture.gd" id="1_axke7"]
 [ext_resource type="Script" path="res://src/Game/Theme/TextureSetting.gd" id="2_7bwl2"]
@@ -80,6 +80,16 @@ texture_settings = Array[ExtResource("2_7bwl2")]([SubResource("Resource_hxpog"),
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_kmfi1"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_1qcrh"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_yfar7"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_m16nl"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_exmmj"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_k4wq5"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_nm664"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_dd2b8"]
 content_margin_left = 20.0
@@ -169,6 +179,15 @@ CommitLabel/styles/focus = SubResource("StyleBoxEmpty_1qwxu")
 CommitLabel/styles/hover = SubResource("StyleBoxEmpty_myxhv")
 CommitLabel/styles/normal = SubResource("StyleBoxEmpty_kmfi1")
 CommitLabel/styles/pressed = SubResource("StyleBoxEmpty_1qcrh")
+GameInfoButton/base_type = &"Button"
+GameInfoButton/colors/font_hover_color = Color(0.360784, 0.360784, 0.360784, 1)
+GameInfoButton/colors/font_hover_pressed_color = Color(0.215686, 0.215686, 0.215686, 1)
+GameInfoButton/colors/font_pressed_color = Color(0.215686, 0.215686, 0.215686, 1)
+GameInfoButton/styles/disabled = SubResource("StyleBoxEmpty_yfar7")
+GameInfoButton/styles/focus = SubResource("StyleBoxEmpty_m16nl")
+GameInfoButton/styles/hover = SubResource("StyleBoxEmpty_exmmj")
+GameInfoButton/styles/normal = SubResource("StyleBoxEmpty_k4wq5")
+GameInfoButton/styles/pressed = SubResource("StyleBoxEmpty_nm664")
 TitleButton/base_type = &"Button"
 TitleButton/colors/font_color = Color(0.87451, 0.87451, 0.87451, 1)
 TitleButton/colors/font_disabled_color = Color(0.87451, 0.87451, 0.87451, 0.501961)

--- a/game/assets/localisation/locales/en_GB/menus.csv
+++ b/game/assets/localisation/locales/en_GB/menus.csv
@@ -11,7 +11,11 @@ MAINMENU_MULTIPLAYER;Multiplayer
 MAINMENU_OPTIONS;Options
 MAINMENU_CREDITS;Credits
 MAINMENU_EXIT;Exit
-MAINMENU_CHECKSUM;Checksum {checksum}
+MAIMENU_LATEST_RELEASE_NAME;Latest Release Name: {release_name}
+MAIMENU_COMMIT;Commit: {short_hash}
+MAINMENU_CHECKSUM;Checksum: {short_checksum}
+MAINMENU_CHECKSUM_TOOLTIP;Checksum {checksum}
+MAINMENU_GAME_INFO;Game Info
 
 ;; Options
 OPTIONS_RESET;R

--- a/game/assets/localisation/locales/en_US/menus.csv
+++ b/game/assets/localisation/locales/en_US/menus.csv
@@ -7,7 +7,11 @@ MAINMENU_MULTIPLAYER;Multiplayer
 MAINMENU_OPTIONS;Options
 MAINMENU_CREDITS;Credits
 MAINMENU_EXIT;Exit
-MAINMENU_CHECKSUM;Checksum {checksum}
+MAIMENU_LATEST_RELEASE_NAME;Latest Release Name: {release_name}
+MAIMENU_COMMIT;Commit: {short_hash}
+MAINMENU_CHECKSUM;Checksum: {short_checksum}
+MAINMENU_CHECKSUM_TOOLTIP;Checksum {checksum}
+MAINMENU_GAME_INFO;Game Info
 
 ;; Options
 OPTIONS_RESET;R

--- a/game/src/Game/Menu/MainMenu/ReleaseInfoBox.gd
+++ b/game/src/Game/Menu/MainMenu/ReleaseInfoBox.gd
@@ -15,9 +15,9 @@ var _checksum : String = "????"
 # * SS-104, SS-105, SS-106, SS-107
 # * UIFUN-97, UIFUN-297, UIFUN-299
 func _ready() -> void:
-	_version_label.text = _GIT_INFO_.release_name
+	_version_label.text = tr("MAIMENU_LATEST_RELEASE_NAME").format({ "release_name": _GIT_INFO_.release_name })
 	_version_label.tooltip_text = _GIT_INFO_.tag
-	_commit_label.text = _GIT_INFO_.short_hash
+	_commit_label.text = tr("MAIMENU_COMMIT").format({ "short_hash": _GIT_INFO_.short_hash })
 	_commit_label.tooltip_text = _GIT_INFO_.commit_hash
 	# UI-111
 	_checksum = Checksum.get_checksum_text()
@@ -29,8 +29,8 @@ func _notification(what : int) -> void:
 			_update_checksum_label_text()
 
 func _update_checksum_label_text() -> void:
-	_checksum_label.tooltip_text = tr("MAINMENU_CHECKSUM").format({ "checksum": _checksum })
-	_checksum_label.text = "(%s)" % _checksum.substr(0, 4)
+	_checksum_label.tooltip_text = tr("MAINMENU_CHECKSUM_TOOLTIP").format({ "checksum": _checksum })
+	_checksum_label.text = tr("MAINMENU_CHECKSUM").format({ "short_checksum": _checksum.substr(0, 4) })
 
 func _on_version_label_pressed() -> void:
 	DisplayServer.clipboard_set(_GIT_INFO_.tag)
@@ -40,3 +40,18 @@ func _on_commit_label_pressed() -> void:
 
 func _on_checksum_label_pressed() -> void:
 	DisplayServer.clipboard_set(_checksum)
+
+func _on_game_info_button_pressed() -> void:
+	var project_name := ProjectSettings.get_setting("application/config/name") as String
+	var tag_name := _GIT_INFO_.tag
+	var commit_sha := _GIT_INFO_.short_hash
+	var godot_version := Engine.get_version_info().string as String
+	var os_name := OS.get_distribution_name()
+	var date_str := Time.get_datetime_string_from_system(true)
+	var display_server := DisplayServer.get_name()
+	var gpu_name := RenderingServer.get_video_adapter_name()
+	var gpu_api_version := RenderingServer.get_video_adapter_api_version()
+	var cpu_name := OS.get_processor_name()
+	var cpu_processor_count := OS.get_processor_count()
+	DisplayServer.clipboard_set("%s %s (%s) [Godot %s] - %s %s - %s - %s (API: %s) - %s (%s Threads)"
+	% [project_name, tag_name, commit_sha, godot_version, os_name, date_str, display_server, gpu_name, gpu_api_version, cpu_name, cpu_processor_count])

--- a/game/src/Game/Menu/MainMenu/ReleaseInfoBox.tscn
+++ b/game/src/Game/Menu/MainMenu/ReleaseInfoBox.tscn
@@ -1,15 +1,34 @@
-[gd_scene load_steps=2 format=3 uid="uid://cen7wkmn6og66"]
+[gd_scene load_steps=4 format=3 uid="uid://cen7wkmn6og66"]
 
 [ext_resource type="Script" path="res://src/Game/Menu/MainMenu/ReleaseInfoBox.gd" id="1_y2djw"]
 
+[sub_resource type="StyleBoxLine" id="StyleBoxLine_07plf"]
+content_margin_right = 2.0
+color = Color(1, 1, 1, 1)
+thickness = 2
+vertical = true
+
+[sub_resource type="Theme" id="Theme_une4m"]
+VSeparator/styles/separator = SubResource("StyleBoxLine_07plf")
+
 [node name="ReleaseInfoBox" type="HBoxContainer" node_paths=PackedStringArray("_version_label", "_commit_label", "_checksum_label")]
 editor_description = "UI-31"
+theme = SubResource("Theme_une4m")
 script = ExtResource("1_y2djw")
-_version_label = NodePath("VersionLabel")
-_commit_label = NodePath("CommitLabel")
-_checksum_label = NodePath("ChecksumLabel")
+_version_label = NodePath("VersionButton")
+_commit_label = NodePath("CommitButton")
+_checksum_label = NodePath("ChecksumButton")
 
-[node name="VersionLabel" type="Button" parent="."]
+[node name="GameInfoButton" type="Button" parent="."]
+layout_mode = 2
+theme_type_variation = &"GameInfoButton"
+text = "MAINMENU_GAME_INFO"
+flat = true
+
+[node name="VSeparator" type="VSeparator" parent="."]
+layout_mode = 2
+
+[node name="VersionButton" type="Button" parent="."]
 editor_description = "UI-869, UI-870"
 layout_mode = 2
 tooltip_text = "VERSION_MISSING"
@@ -19,7 +38,10 @@ text = "VERSION_MISSING"
 flat = true
 alignment = 0
 
-[node name="CommitLabel" type="Button" parent="."]
+[node name="VSeparator2" type="VSeparator" parent="."]
+layout_mode = 2
+
+[node name="CommitButton" type="Button" parent="."]
 editor_description = "UI-871, UI-872"
 layout_mode = 2
 focus_mode = 0
@@ -28,7 +50,10 @@ text = "????????"
 flat = true
 alignment = 0
 
-[node name="ChecksumLabel" type="Button" parent="."]
+[node name="VSeparator3" type="VSeparator" parent="."]
+layout_mode = 2
+
+[node name="ChecksumButton" type="Button" parent="."]
 editor_description = "UI-111"
 layout_mode = 2
 tooltip_text = "CHECKSUM_MISSING"
@@ -38,6 +63,7 @@ text = "(????)"
 flat = true
 alignment = 0
 
-[connection signal="pressed" from="VersionLabel" to="." method="_on_version_label_pressed"]
-[connection signal="pressed" from="CommitLabel" to="." method="_on_commit_label_pressed"]
-[connection signal="pressed" from="ChecksumLabel" to="." method="_on_checksum_label_pressed"]
+[connection signal="pressed" from="GameInfoButton" to="." method="_on_game_info_button_pressed"]
+[connection signal="pressed" from="VersionButton" to="." method="_on_version_label_pressed"]
+[connection signal="pressed" from="CommitButton" to="." method="_on_commit_label_pressed"]
+[connection signal="pressed" from="ChecksumButton" to="." method="_on_checksum_label_pressed"]


### PR DESCRIPTION
Add clarifications to ReleaseInfoBox buttons

Will be used to correct some of the TODOs in #203

Clicking game info for the PR action CI will result in:
```
OpenVic v0.02_Mappa_Mundi (14be1eb) [Godot 4.2.1-stable (official)] - Arch Linux 2024-02-05T19:09:33 - X11 - ...
```
for me