### PR TITLE
Add GUIListBox + UI improvements

### DIFF
--- a/extension/src/openvic-extension/classes/GUIListBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIListBox.cpp
@@ -1,0 +1,226 @@
+#include "GUIListBox.hpp"
+
+#include <godot_cpp/classes/input_event_mouse_button.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "openvic-extension/utility/ClassBindings.hpp"
+#include "openvic-extension/utility/UITools.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
+
+using namespace OpenVic;
+using namespace godot;
+
+using OpenVic::Utilities::std_view_to_godot_string;
+
+Error GUIListBox::_calculate_child_arrangement() {
+	ERR_FAIL_NULL_V(gui_listbox, FAILED);
+
+	const int32_t child_count = get_child_count();
+	const real_t max_height = get_size().height;
+
+	real_t height = 0.0f, height_under_max_scroll_index = 0.0f;
+
+	children_data.clear();
+	max_scroll_index = 0;
+
+	for (int32_t index = 0; index < child_count; ++index) {
+		Control* child = Object::cast_to<Control>(get_child(index));
+		if (child != nullptr && child != scrollbar && child->is_visible()) {
+			const real_t child_height = child->get_size().height; /* Spacing is ignored */
+			children_data.push_back({ child, height, child_height });
+
+			height += child_height;
+			height_under_max_scroll_index += child_height;
+
+			while (height_under_max_scroll_index > max_height && max_scroll_index + 1 < children_data.size()) {
+				height_under_max_scroll_index -= children_data[max_scroll_index++].height;
+			}
+		}
+	}
+
+	ERR_FAIL_NULL_V(scrollbar, FAILED);
+
+	scrollbar->set_limits(0, max_scroll_index, false);
+	scrollbar->emit_value_changed();
+	scrollbar->set_visible(max_scroll_index > 0);
+
+	return OK;
+}
+
+Error GUIListBox::_update_child_positions() {
+	ERR_FAIL_NULL_V(gui_listbox, FAILED);
+
+	if (children_data.empty()) {
+		return OK;
+	}
+
+	const real_t max_height = get_size().height;
+	const real_t scroll_pos = children_data[scroll_index].start_pos;
+
+	for (int32_t index = 0; index < children_data.size(); ++index) {
+		child_data_t const& data = children_data[index];
+		if (index < scroll_index || data.start_pos + data.height > scroll_pos + max_height) {
+			data.child->set_position({ 0.0f, max_height + 10.0f });
+		} else {
+			data.child->set_position({ 0.0f, data.start_pos - scroll_pos });
+		}
+	}
+
+	return OK;
+}
+
+void GUIListBox::_bind_methods() {
+	OV_BIND_METHOD(GUIListBox::clear);
+	OV_BIND_METHOD(GUIListBox::clear_children);
+
+	OV_BIND_METHOD(GUIListBox::get_scroll_index);
+	OV_BIND_METHOD(GUIListBox::set_scroll_index, { "new_scroll_index" });
+	OV_BIND_METHOD(GUIListBox::get_max_scroll_index);
+
+	OV_BIND_METHOD(GUIListBox::get_gui_listbox_name);
+	OV_BIND_METHOD(GUIListBox::get_scrollbar);
+}
+
+void GUIListBox::_notification(int what) {
+	switch (what) {
+	case NOTIFICATION_SORT_CHILDREN: {
+		_calculate_child_arrangement();
+	} break;
+	}
+}
+
+GUIListBox::GUIListBox()
+  : gui_listbox { nullptr }, scrollbar { nullptr }, children_data {}, scroll_index { 0 }, max_scroll_index { 0 } {
+	set_clip_contents(true);
+}
+
+Vector2 GUIListBox::_get_minimum_size() const {
+	if (gui_listbox != nullptr) {
+		Size2 size = Utilities::to_godot_fvec2(gui_listbox->get_size());
+
+		if (scrollbar != nullptr) {
+			size.width += scrollbar->get_minimum_size().width;
+		}
+
+		return size;
+	} else {
+		return {};
+	}
+}
+
+void GUIListBox::_gui_input(godot::Ref<godot::InputEvent> const& event) {
+	ERR_FAIL_NULL(event);
+
+	Ref<InputEventMouseButton> mb = event;
+
+	if (mb.is_valid()) {
+		if (mb->is_pressed()) {
+			if (mb->get_button_index() == MouseButton::MOUSE_BUTTON_WHEEL_UP) {
+				set_scroll_index(scroll_index - 1);
+			} else if (mb->get_button_index() == MouseButton::MOUSE_BUTTON_WHEEL_DOWN) {
+				set_scroll_index(scroll_index + 1);
+			} else {
+				return;
+			}
+			accept_event();
+		}
+	}
+}
+
+void GUIListBox::clear() {
+	gui_listbox = nullptr;
+	children_data.clear();
+	scroll_index = 0;
+	max_scroll_index = 0;
+	clear_children();
+	if (scrollbar != nullptr) {
+		remove_child(scrollbar);
+		scrollbar = nullptr;
+	}
+}
+
+void GUIListBox::clear_children() {
+	int32_t child_count = get_child_count();
+	while (child_count > 0) {
+		Node* child = get_child(--child_count);
+		if (child != scrollbar) {
+			remove_child(child);
+		}
+	}
+	if (scrollbar != nullptr) {
+		scrollbar->set_value(0);
+	}
+}
+
+void GUIListBox::set_scroll_index(int32_t new_scroll_index) {
+	scroll_index = std::clamp(new_scroll_index, 0, max_scroll_index);
+	if (scrollbar != nullptr && scrollbar->get_value() != scroll_index) {
+		scrollbar->set_value(scroll_index, false);
+	}
+	_update_child_positions();
+}
+
+Error GUIListBox::set_gui_listbox(GUI::ListBox const* new_gui_listbox) {
+	if (gui_listbox == new_gui_listbox) {
+		return OK;
+	}
+
+	if (new_gui_listbox == nullptr) {
+		clear();
+		return OK;
+	}
+
+	gui_listbox = new_gui_listbox;
+
+	const String scrollbar_name = std_view_to_godot_string(gui_listbox->get_scrollbar_name());
+
+	Error err = OK;
+
+	if (scrollbar_name.is_empty()) {
+		UtilityFunctions::push_error("GUIListBox ", get_name(), " has no scrollbar name!");
+		err = FAILED;
+		scrollbar = nullptr;
+	} else {
+		static const String scrollbar_scene = "core";
+
+		Control* scrollbar_control = nullptr;
+		if (!UITools::generate_gui_element(scrollbar_scene, scrollbar_name, "", scrollbar_control)) {
+			UtilityFunctions::push_error("Error generating scrollbar ", scrollbar_name, " for GUIListBox ", get_name());
+			err = FAILED;
+		}
+
+		if (scrollbar_control != nullptr) {
+			scrollbar = Object::cast_to<GUIScrollbar>(scrollbar_control);
+			if (scrollbar != nullptr) {
+				add_child(scrollbar);
+
+				const Size2 size = Utilities::to_godot_fvec2(gui_listbox->get_size());
+				scrollbar->set_position({ size.width, 0.0f });
+				scrollbar->set_length_override(size.height);
+
+				static const StringName set_scroll_index_func_name = "set_scroll_index";
+
+				scrollbar->connect(
+					GUIScrollbar::signal_value_changed(), Callable { this, set_scroll_index_func_name }, CONNECT_PERSIST
+				);
+			} else {
+				UtilityFunctions::push_error(
+					"Element ", scrollbar_name, " for GUIListBox ", get_name(), " is not a GUIScrollbar"
+				);
+				err = FAILED;
+			}
+		} else {
+			scrollbar = nullptr;
+		}
+	}
+
+	return err;
+}
+
+String GUIListBox::get_gui_listbox_name() const {
+	return gui_listbox != nullptr ? std_view_to_godot_string(gui_listbox->get_name()) : String {};
+}
+
+GUIScrollbar* GUIListBox::get_scrollbar() const {
+	return scrollbar;
+}

--- a/extension/src/openvic-extension/classes/GUIListBox.hpp
+++ b/extension/src/openvic-extension/classes/GUIListBox.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <godot_cpp/classes/container.hpp>
+
+#include <openvic-simulation/interface/GUI.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+
+namespace OpenVic {
+	class GUIListBox : public godot::Container {
+		GDCLASS(GUIListBox, godot::Container)
+
+		GUI::ListBox const* PROPERTY(gui_listbox);
+
+		GUIScrollbar* scrollbar;
+
+		struct child_data_t {
+			Control* child;
+			real_t start_pos, height;
+		};
+
+		std::vector<child_data_t> children_data;
+
+		/* The children_data index of the topmost visible child element. */
+		int32_t PROPERTY(scroll_index);
+		int32_t PROPERTY(max_scroll_index);
+
+		godot::Error _calculate_child_arrangement();
+		godot::Error _update_child_positions();
+
+	protected:
+		static void _bind_methods();
+
+		void _notification(int what);
+
+	public:
+		GUIListBox();
+
+		godot::Vector2 _get_minimum_size() const override;
+		void _gui_input(godot::Ref<godot::InputEvent> const& event) override;
+
+		/* Reset gui_listbox to nullptr, and remove all child elements. */
+		void clear();
+
+		/* Remove all child elements except for the scrollbar. */
+		void clear_children();
+
+		void set_scroll_index(int32_t new_scroll_index);
+
+		/* Set the GUI::ListBox. This does not affect any existing child elements. */
+		godot::Error set_gui_listbox(GUI::ListBox const* new_gui_listbox);
+
+		/* Return the name of the GUI::ListBox, or an empty String if it's null. */
+		godot::String get_gui_listbox_name() const;
+
+		GUIScrollbar* get_scrollbar() const;
+	};
+}

--- a/extension/src/openvic-extension/classes/GUINode.cpp
+++ b/extension/src/openvic-extension/classes/GUINode.cpp
@@ -48,6 +48,7 @@ void GUINode::_bind_methods() {
 
 	OV_BIND_SMETHOD(int_to_formatted_string, { "val" });
 	OV_BIND_SMETHOD(float_to_formatted_string, { "val", "decimal_places" });
+	OV_BIND_SMETHOD(format_province_name, { "province_identifier" });
 }
 
 GUINode::GUINode() {
@@ -188,4 +189,9 @@ String GUINode::int_to_formatted_string(int64_t val) {
 
 String GUINode::float_to_formatted_string(float val, int32_t decimal_places) {
 	return Utilities::float_to_formatted_string(val, decimal_places);
+}
+
+String GUINode::format_province_name(String const& province_identifier) {
+	static const String province_prefix = "PROV";
+	return province_prefix + province_identifier;
 }

--- a/extension/src/openvic-extension/classes/GUINode.cpp
+++ b/extension/src/openvic-extension/classes/GUINode.cpp
@@ -18,7 +18,8 @@ using namespace OpenVic;
 	F(TextureProgressBar, progress_bar) \
 	F(TextureRect, texture_rect) \
 	F(GUIOverlappingElementsBox, gui_overlapping_elements_box) \
-	F(GUIScrollbar, gui_scrollbar)
+	F(GUIScrollbar, gui_scrollbar) \
+	F(GUIListBox, gui_listbox)
 
 #define APPLY_TO_TEXTURE_TYPES(F) \
 	F(GFXSpriteTexture, gfx_sprite_texture) \

--- a/extension/src/openvic-extension/classes/GUINode.hpp
+++ b/extension/src/openvic-extension/classes/GUINode.hpp
@@ -12,6 +12,7 @@
 #include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GFXMaskedFlagTexture.hpp"
 #include "openvic-extension/classes/GFXPieChartTexture.hpp"
+#include "openvic-extension/classes/GUIListBox.hpp"
 #include "openvic-extension/classes/GUIOverlappingElementsBox.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 
@@ -43,6 +44,7 @@ namespace OpenVic {
 		static godot::TextureRect* get_texture_rect_from_node(godot::Node* node);
 		static GUIOverlappingElementsBox* get_gui_overlapping_elements_box_from_node(godot::Node* node);
 		static GUIScrollbar* get_gui_scrollbar_from_node(godot::Node* node);
+		static GUIListBox* get_gui_listbox_from_node(godot::Node* node);
 
 		godot::Button* get_button_from_nodepath(godot::NodePath const& path) const;
 		godot::CheckBox* get_check_box_from_nodepath(godot::NodePath const& path) const;
@@ -52,6 +54,7 @@ namespace OpenVic {
 		godot::TextureRect* get_texture_rect_from_nodepath(godot::NodePath const& path) const;
 		GUIOverlappingElementsBox* get_gui_overlapping_elements_box_from_nodepath(godot::NodePath const& path) const;
 		GUIScrollbar* get_gui_scrollbar_from_nodepath(godot::NodePath const& path) const;
+		GUIListBox* get_gui_listbox_from_nodepath(godot::NodePath const& path) const;
 
 		/* Helper functions to get textures from TextureRects and Buttons. */
 		static godot::Ref<godot::Texture2D> get_texture_from_node(godot::Node* node);

--- a/extension/src/openvic-extension/classes/GUINode.hpp
+++ b/extension/src/openvic-extension/classes/GUINode.hpp
@@ -69,5 +69,6 @@ namespace OpenVic {
 
 		static godot::String int_to_formatted_string(int64_t val);
 		static godot::String float_to_formatted_string(float val, int32_t decimal_places);
+		static godot::String format_province_name(godot::String const& province_identifier);
 	};
 }

--- a/extension/src/openvic-extension/classes/GUIScrollbar.hpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.hpp
@@ -11,8 +11,6 @@ namespace OpenVic {
 	class GUIScrollbar : public godot::Control {
 		GDCLASS(GUIScrollbar, godot::Control)
 
-		static godot::StringName const& _signal_value_changed();
-
 		GUI::Scrollbar const* PROPERTY(gui_scrollbar);
 
 		godot::Ref<GFXSpriteTexture> slider_texture;
@@ -33,6 +31,7 @@ namespace OpenVic {
 		godot::Rect2 range_limit_max_rect;
 
 		godot::Orientation PROPERTY(orientation);
+		real_t PROPERTY(length_override);
 
 		int32_t PROPERTY(value);
 		int32_t PROPERTY(min_value);
@@ -78,6 +77,8 @@ namespace OpenVic {
 		void _notification(int what);
 
 	public:
+		static godot::StringName const& signal_value_changed();
+
 		GUIScrollbar();
 
 		godot::Vector2 _get_minimum_size() const override;
@@ -98,5 +99,8 @@ namespace OpenVic {
 
 		godot::Error set_range_limits(int32_t new_range_limit_min, int32_t new_range_limit_max, bool signal = true);
 		godot::Error set_limits(int32_t new_min_value, int32_t new_max_value, bool signal = true);
+
+		/* Override the main dimension of gui_scollbar's size with the specified length. */
+		void set_length_override(real_t new_length_override);
 	};
 }

--- a/extension/src/openvic-extension/register_types.cpp
+++ b/extension/src/openvic-extension/register_types.cpp
@@ -6,6 +6,7 @@
 #include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GFXMaskedFlagTexture.hpp"
 #include "openvic-extension/classes/GFXPieChartTexture.hpp"
+#include "openvic-extension/classes/GUIListBox.hpp"
 #include "openvic-extension/classes/GUINode.hpp"
 #include "openvic-extension/classes/GUIOverlappingElementsBox.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
@@ -56,6 +57,7 @@ void initialize_openvic_types(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<GFXMaskedFlagTexture>();
 
 	ClassDB::register_class<GFXPieChartTexture>();
+	ClassDB::register_class<GUIListBox>();
 	ClassDB::register_class<GUINode>();
 	ClassDB::register_class<GUIOverlappingElementsBox>();
 	ClassDB::register_class<GUIScrollbar>();

--- a/extension/src/openvic-extension/singletons/AssetManager.hpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.hpp
@@ -25,7 +25,7 @@ namespace OpenVic {
 		font_map_t fonts;
 
 		static godot::Ref<godot::Image> _load_image(godot::StringName const& path);
-		image_asset_t* _get_image_asset(godot::StringName const& path);
+		image_asset_t* _get_image_asset(godot::StringName const& path, bool flip_y);
 
 	protected:
 		static void _bind_methods();
@@ -38,12 +38,12 @@ namespace OpenVic {
 
 		/* Search for and load an image at the specified path relative to the game defines, first checking the AssetManager's
 		 * image cache (if cache is true) in case it has already been loaded, and returning nullptr if image loading fails. */
-		godot::Ref<godot::Image> get_image(godot::StringName const& path, bool cache = true);
+		godot::Ref<godot::Image> get_image(godot::StringName const& path, bool cache = true, bool flip_y = false);
 
 		/* Create a texture from an image found at the specified path relative to the game defines, fist checking
 		 * AssetManager's texture cache in case it has already been loaded, and returning nullptr if image loading
 		 * or texture creation fails. */
-		godot::Ref<godot::ImageTexture> get_texture(godot::StringName const& path);
+		godot::Ref<godot::ImageTexture> get_texture(godot::StringName const& path, bool flip_y = false);
 
 		/* Search for and load a font with the specified name from the game defines' font directory, first checking the
 		 * AssetManager's font cache in case it has already been loaded, and returning nullptr if font loading fails. */

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -129,14 +129,6 @@ void GameSingleton::setup_logger() {
 	});
 }
 
-GameManager const& GameSingleton::get_game_manager() const {
-	return game_manager;
-}
-
-Dataloader const& GameSingleton::get_dataloader() const {
-	return dataloader;
-}
-
 Error GameSingleton::setup_game(int32_t bookmark_index) {
 	Bookmark const* bookmark = game_manager.get_history_manager().get_bookmark_manager().get_bookmark_by_index(bookmark_index);
 	ERR_FAIL_NULL_V_MSG(bookmark, FAILED, vformat("Failed to get bookmark with index: %d", bookmark_index));

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/classes/texture2d_array.hpp>
 
@@ -14,8 +13,8 @@ namespace OpenVic {
 
 		static inline GameSingleton* singleton = nullptr;
 
-		GameManager game_manager;
-		Dataloader dataloader;
+		GameManager PROPERTY(game_manager);
+		Dataloader PROPERTY(dataloader);
 
 		godot::Vector2i image_subdivisions;
 		godot::Ref<godot::Texture2DArray> province_shape_texture;
@@ -29,7 +28,6 @@ namespace OpenVic {
 		static godot::StringName const& _signal_province_selected();
 		static godot::StringName const& _signal_clock_state_changed();
 
-		godot::Error _generate_terrain_texture_array();
 		godot::Error _load_map_images();
 		godot::Error _load_terrain_variants();
 		godot::Error _load_flag_images();
@@ -49,9 +47,6 @@ namespace OpenVic {
 		~GameSingleton();
 
 		static void setup_logger();
-
-		GameManager const& get_game_manager() const;
-		Dataloader const& get_dataloader() const;
 
 		/* Load the game's defines in compatiblity mode from the filepath
 		 * pointing to the defines folder. */

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -15,6 +15,7 @@
 #include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GFXMaskedFlagTexture.hpp"
 #include "openvic-extension/classes/GFXPieChartTexture.hpp"
+#include "openvic-extension/classes/GUIListBox.hpp"
 #include "openvic-extension/classes/GUIOverlappingElementsBox.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 #include "openvic-extension/singletons/AssetManager.hpp"
@@ -485,6 +486,24 @@ static bool generate_overlapping_elements(generate_gui_args_t&& args) {
 	return ret;
 }
 
+static bool generate_listbox(generate_gui_args_t&& args) {
+	GUI::ListBox const& listbox = static_cast<GUI::ListBox const&>(args.element);
+
+	const String listbox_name = std_view_to_godot_string(listbox.get_name());
+
+	GUIListBox* gui_listbox = nullptr;
+	bool ret = new_control(gui_listbox, listbox, args.name);
+	ERR_FAIL_NULL_V_MSG(gui_listbox, false, vformat("Failed to create GUIListBox for GUI listbox %s", listbox_name));
+
+	if (gui_listbox->set_gui_listbox(&listbox) != OK) {
+		UtilityFunctions::push_error("Error initialising GUIListBox for GUI listbox ", listbox_name);
+		ret = false;
+	}
+
+	args.result = gui_listbox;
+	return ret;
+}
+
 template<std::derived_from<GUI::Element> T>
 requires requires(T const& element) {
 	{ element.get_size() } -> std::same_as<fvec2_t>;
@@ -511,10 +530,6 @@ static bool generate_placeholder(generate_gui_args_t&& args, Color colour) {
 
 	args.result = godot_rect;
 	return ret;
-}
-
-static bool generate_listbox(generate_gui_args_t&& args) {
-	return generate_placeholder<GUI::ListBox>(std::move(args), { 0.0f, 0.0f, 1.0f, 0.3f });
 }
 
 static bool generate_texteditbox(generate_gui_args_t&& args) {

--- a/game/assets/localisation/locales/en_GB/menus.csv
+++ b/game/assets/localisation/locales/en_GB/menus.csv
@@ -132,7 +132,7 @@ VIC2_DIR_DIALOG_SELECT;Select
 VIC2_DIR_DIALOG_CANCEL;Cancel
 
 ;; Province Overview Panel
-province_MISSING;No Province
+PROV_MISSING;No Province
 region_MISSING;No Region
 LIFE_RATING_TOOLTIP;Liferating: {life_rating}
 terrain_type_MISSING;No Terrain Type

--- a/game/assets/localisation/locales/ru_RU/menus.csv
+++ b/game/assets/localisation/locales/ru_RU/menus.csv
@@ -108,7 +108,7 @@ DIALOG_SAVE_AND_RESIGN;Сохраниться и выйти в главное м
 DIALOG_SAVE_AND_QUIT;Сохраниться и выйти из игры
 
 ;; Province Overview Panel
-province_MISSING;Нет провинции
+PROV_MISSING;Нет провинции
 region_MISSING;Нет региона
 LIFE_RATING_TOOLTIP;Уровень жизни: {life_rating}
 rgo_MISSING;Нет ДП

--- a/game/src/Game/GameSession/MapControlPanel/MapControlPanel.tscn
+++ b/game/src/Game/GameSession/MapControlPanel/MapControlPanel.tscn
@@ -40,7 +40,7 @@ alignment = 1
 [node name="MapmodesGrid" type="GridContainer" parent="MapPanelMargin/MapPanelList/MapDisplayList"]
 editor_description = "UI-750"
 layout_mode = 2
-columns = 11
+columns = 7
 
 [node name="Minimap" type="PanelContainer" parent="MapPanelMargin/MapPanelList/MapDisplayList"]
 editor_description = "UI-549"

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -251,8 +251,7 @@ func _update_info() -> void:
 	if _province_info:
 		# Header
 		if _province_name_label:
-			_province_name_label.text = "PROV" + _province_info.get(_province_info_province_key,
-				_province_info_province_key + _missing_suffix)
+			_province_name_label.text = GUINode.format_province_name(_province_info.get(_province_info_province_key, _missing_suffix))
 
 		if _region_name_label:
 			_region_name_label.text = _province_info.get(_province_info_region_key,
@@ -294,7 +293,7 @@ func _update_info() -> void:
 					push_error("Failed to set terrain type texture: ", terrain_type)
 
 		if _life_rating_bar:
-			_life_rating_bar.value = _province_info.get(_province_info_life_rating_key, 0)
+			_life_rating_bar.value = _province_info.get(_province_info_life_rating_key, 0) / 100.0
 
 		if _controller_flag_texture:
 			_controller_flag_texture.set_flag_country_name(_province_info.get(_province_info_controller_key, ""))

--- a/game/src/Game/GameSession/Topbar.gd
+++ b/game/src/Game/GameSession/Topbar.gd
@@ -73,7 +73,7 @@ func _ready() -> void:
 			button.pressed.connect(
 				Events.NationManagementScreens.toggle_nation_management_screen.bind(screen)
 			)
-			var icon : GFXSpriteTexture = get_gfx_sprite_texture_from_node(button)
+			var icon : GFXSpriteTexture = GUINode.get_gfx_sprite_texture_from_node(button)
 			if icon:
 				_nation_management_buttons[screen] = button
 				_nation_management_button_textures[screen] = icon
@@ -107,7 +107,6 @@ func _update_speed_controls() -> void:
 		if not GameSingleton.is_paused():
 			index += GameSingleton.get_speed() + 1
 		_speed_indicator_texture.set_icon_index(index)
-		_speed_indicator_button.queue_redraw()
 
 # REQUIREMENTS:
 # * UIFUN-71
@@ -130,4 +129,3 @@ func _on_decrease_speed_button_pressed() -> void:
 func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
 	for screen in _nation_management_buttons:
 		_nation_management_button_textures[screen].set_icon_index(1 + int(screen == active_screen))
-		_nation_management_buttons[screen].queue_redraw()

--- a/game/src/Game/GameStart.gd
+++ b/game/src/Game/GameStart.gd
@@ -70,7 +70,7 @@ func _setup_compatibility_mode_paths() -> void:
 		else:
 			# Check if the program is being run from inside the install directory,
 			# and if not also search for a Steam install
-			actual_base_path = GameSingleton.search_for_game_path("..")
+			actual_base_path = GameSingleton.search_for_game_path(".")
 		if not actual_base_path:
 			get_tree().paused = true
 			vic2_dir_dialog.popup_centered_ratio()


### PR DESCRIPTION
- Add `GUIListBox`, with scrollbar/scrolling and automatic child arrangment (which takes child visibility into account).
- `GUIScrollbar` tweaks:
  - length override, for `GUIListBox`'s scrollbars which need to have their lengths adjusted.
  - default start at 0 so that scrollbars start at the top rather than middle.
  - made range limits always min/max for non-range limited scrollbars.
- Connect textures' `changed` signal to `StyleBoxTexture`s' `emit_changed` function so that calling `set_icon_index` causes buttons to redraw.
- Flipped progress bar textures vertically to match Vic2, using a new `AssetManager` arg `bool flip_y`, and set their default max value to `1.0`.
- Made icons rotatable.
- Added `format_province_name` helper function.
- Fixed bug with default install directory search paths - `".."` should be `"."` to search the folder the executable is currently in.
- Reduced the number of mapmode button columns to make it take up less space (this will be replaced with the GUI generated minimap/mapmode panel soon anyway).
- Updated SIM submodule to include `UniqueKeyRegistry` invalidated identifier `std::string_view` fix (which was breaking `get_gui_position`) + technology changes needed for its nation management screen.