### PR TITLE
Assorted UI Changes (in preparation for Population Menu)

### DIFF
--- a/extension/src/openvic-extension/classes/GFXButtonStateTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXButtonStateTexture.hpp
@@ -32,6 +32,7 @@ namespace OpenVic {
 			HOVER,
 			PRESSED,
 			DISABLED,
+			SELECTED,
 			BUTTON_STATE_COUNT
 		};
 
@@ -62,8 +63,8 @@ namespace OpenVic {
 			godot::Vector2i const& new_cornered_tile_border_size
 		);
 
-		static godot::StringName const& button_state_to_theme_name(ButtonState button_state);
-		godot::StringName const& get_button_state_theme() const;
+		static godot::StringName const& button_state_to_name(ButtonState button_state);
+		godot::StringName const& get_button_state_name() const;
 	};
 
 	class GFXButtonStateHavingTexture : public GFXCorneredTileSupportingTexture {

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
@@ -29,15 +29,17 @@ namespace OpenVic {
 	public:
 		GFXPieChartTexture();
 
+		using godot_pie_chart_data_t = godot::TypedArray<godot::Dictionary>;
+
 		/* Set slices given an Array of Dictionaries, each with the following key-value entries:
 		 *  - colour: Color
 		 *  - weight: float */
-		godot::Error set_slices_array(godot::TypedArray<godot::Dictionary> const& new_slices);
+		godot::Error set_slices_array(godot_pie_chart_data_t const& new_slices);
 
 		/* Generate slice data from a distribution of HasIdentifierAndColour derived objects, sorted by their weight.
 		 * The resulting Array of Dictionaries can be used as an argument for set_slices_array. */
 		template<std::derived_from<HasIdentifierAndColour> T>
-		static godot::TypedArray<godot::Dictionary> distribution_to_slices_array(fixed_point_map_t<T const*> const& dist) {
+		static godot_pie_chart_data_t distribution_to_slices_array(fixed_point_map_t<T const*> const& dist) {
 			using namespace godot;
 			using entry_t = std::pair<T const*, fixed_point_t>;
 			std::vector<entry_t> sorted_dist;
@@ -49,9 +51,9 @@ namespace OpenVic {
 				sorted_dist.push_back(entry);
 			}
 			std::sort(sorted_dist.begin(), sorted_dist.end(), [](entry_t const& lhs, entry_t const& rhs) -> bool {
-				return lhs.second < rhs.second;
+				return lhs.first < rhs.first;
 			});
-			TypedArray<Dictionary> array;
+			godot_pie_chart_data_t array;
 			for (auto const& [key, val] : sorted_dist) {
 				Dictionary sub_dict;
 				sub_dict[_slice_identifier_key()] = Utilities::std_view_to_godot_string(key->get_identifier());

--- a/extension/src/openvic-extension/classes/GUIListBox.hpp
+++ b/extension/src/openvic-extension/classes/GUIListBox.hpp
@@ -14,18 +14,18 @@ namespace OpenVic {
 
 		GUIScrollbar* scrollbar;
 
-		struct child_data_t {
-			Control* child;
-			real_t start_pos, height;
-		};
-
-		std::vector<child_data_t> children_data;
-
 		/* The children_data index of the topmost visible child element. */
 		int32_t PROPERTY(scroll_index);
 		int32_t PROPERTY(max_scroll_index);
 
-		godot::Error _calculate_child_arrangement();
+		bool PROPERTY_CUSTOM_PREFIX(fixed, is);
+		int32_t PROPERTY(fixed_item_count);
+		int32_t PROPERTY(fixed_visible_items);
+		real_t PROPERTY(fixed_item_height);
+
+		static godot::StringName const& _signal_scroll_index_changed();
+
+		godot::Error _calculate_max_scroll_index(bool signal);
 		godot::Error _update_child_positions();
 
 	protected:
@@ -42,10 +42,13 @@ namespace OpenVic {
 		/* Reset gui_listbox to nullptr, and remove all child elements. */
 		void clear();
 
-		/* Remove all child elements except for the scrollbar. */
-		void clear_children();
+		/* Remove child elements until there are remaining_child_count left excluding the scrollbar. */
+		void clear_children(int32_t remaining_child_count = 0);
 
-		void set_scroll_index(int32_t new_scroll_index);
+		void set_scroll_index(int32_t new_scroll_index, bool signal = true);
+
+		godot::Error set_fixed(int32_t item_count, real_t item_height, bool signal = true);
+		godot::Error unset_fixed(bool signal = true);
 
 		/* Set the GUI::ListBox. This does not affect any existing child elements. */
 		godot::Error set_gui_listbox(GUI::ListBox const* new_gui_listbox);

--- a/extension/src/openvic-extension/classes/GUIScrollbar.cpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.cpp
@@ -394,7 +394,7 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 			for (GFXButtonStateTexture::ButtonState state : { HOVER, PRESSED }) {
 				ERR_FAIL_NULL_V_MSG(texture->get_button_state_texture(state), false, vformat(
 					"Failed to generate %s texture for %s element %s for GUIScrollbar %s!",
-					GFXButtonStateTexture::button_state_to_theme_name(state), target, element_name, gui_scrollbar_name
+					GFXButtonStateTexture::button_state_to_name(state), target, element_name, gui_scrollbar_name
 				));
 			}
 		}

--- a/extension/src/openvic-extension/classes/GUIScrollbar.cpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.cpp
@@ -36,6 +36,8 @@ void GUIScrollbar::_bind_methods() {
 	OV_BIND_METHOD(GUIScrollbar::get_min_value);
 	OV_BIND_METHOD(GUIScrollbar::get_max_value);
 	OV_BIND_METHOD(GUIScrollbar::set_value, { "new_value", "signal" }, DEFVAL(true));
+	OV_BIND_METHOD(GUIScrollbar::increment_value, { "signal" }, DEFVAL(true));
+	OV_BIND_METHOD(GUIScrollbar::decrement_value, { "signal" }, DEFVAL(true));
 	OV_BIND_METHOD(GUIScrollbar::set_value_as_ratio, { "new_ratio", "signal" }, DEFVAL(true));
 
 	OV_BIND_METHOD(GUIScrollbar::is_range_limited);
@@ -464,6 +466,14 @@ void GUIScrollbar::set_value(int32_t new_value, bool signal) {
 	if (signal && value != old_value) {
 		emit_value_changed();
 	}
+}
+
+void GUIScrollbar::increment_value(bool signal) {
+	set_value(value + 1, signal);
+}
+
+void GUIScrollbar::decrement_value(bool signal) {
+	set_value(value - 1, signal);
 }
 
 float GUIScrollbar::get_value_as_ratio() const {

--- a/extension/src/openvic-extension/classes/GUIScrollbar.hpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.hpp
@@ -93,6 +93,8 @@ namespace OpenVic {
 		godot::String get_gui_scrollbar_name() const;
 
 		void set_value(int32_t new_value, bool signal = true);
+		void increment_value(bool signal = true);
+		void decrement_value(bool signal = true);
 
 		float get_value_as_ratio() const;
 		void set_value_as_ratio(float new_ratio, bool signal = true);

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -177,8 +177,13 @@ static bool generate_icon(generate_gui_args_t&& args) {
 				godot_progress_bar, false, vformat("Failed to create TextureProgressBar for GUI icon %s", icon_name)
 			);
 
+			static constexpr double MIN_VALUE = 0.0, MAX_VALUE = 1.0;
+			static constexpr uint32_t STEPS = 100;
+
 			godot_progress_bar->set_nine_patch_stretch(true);
-			godot_progress_bar->set_max(1.0);
+			godot_progress_bar->set_step((MAX_VALUE - MIN_VALUE) / STEPS);
+			godot_progress_bar->set_min(MIN_VALUE);
+			godot_progress_bar->set_max(MAX_VALUE);
 
 			GFX::ProgressBar const* progress_bar = icon.get_sprite()->cast_to<GFX::ProgressBar>();
 
@@ -435,7 +440,12 @@ static bool generate_text(generate_gui_args_t&& args) {
 	ERR_FAIL_NULL_V_MSG(godot_label, false, vformat("Failed to create Label for GUI text %s", text_name));
 
 	godot_label->set_text(std_view_to_godot_string(text.get_text()));
-	godot_label->set_custom_minimum_size(Utilities::to_godot_fvec2(text.get_max_size()));
+
+	static const Vector2 default_padding { 1.0f, 0.0f };
+	const Vector2 border_size = Utilities::to_godot_fvec2(text.get_border_size()) + default_padding;
+	const Vector2 max_size = Utilities::to_godot_fvec2(text.get_max_size());
+	godot_label->set_position(godot_label->get_position() + border_size);
+	godot_label->set_custom_minimum_size(max_size - 2 * border_size);
 
 	using enum GUI::AlignedElement::format_t;
 	static const ordered_map<GUI::AlignedElement::format_t, HorizontalAlignment> format_map {

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -347,11 +347,11 @@ static bool generate_button(generate_gui_args_t&& args) {
 				Ref<GFXButtonStateTexture> button_state_texture = texture->get_button_state_texture(button_state);
 				if (button_state_texture.is_valid()) {
 					ret &= add_theme_stylebox(
-						godot_button, button_state_texture->get_button_state_theme(), button_state_texture
+						godot_button, button_state_texture->get_button_state_name(), button_state_texture
 					);
 				} else {
 					UtilityFunctions::push_error(
-						"Failed to make ", GFXButtonStateTexture::button_state_to_theme_name(button_state),
+						"Failed to make ", GFXButtonStateTexture::button_state_to_name(button_state),
 						" GFXButtonStateTexture for GUI button ", button_name
 					);
 					ret = false;


### PR DESCRIPTION
- UI work needed for Population Menu:
  - Label padding (`border_size` + 1px of default horizontal padding)
  - Progressbar min/max/steps standardised to `[0, 1]` with `0.01` steps.
  - Piechart slices changed to key item definition order and their positioning changed to start on the positive x-axis (right) and continue around anti-clockwise.
  - `SELECTED` button state texture added (all components reduced by `0.3`).
  - `GUIListBox` reworked to use a calculated max scroll index (either from all current child elements or for a `fixed` item count and height), with a `scroll_index_changed` signal added and it's `GUIScrollbar` changed to an internal child (so by default it won't contribute to child count or lookup by index).