### PR TITLE
Update SIM submodule

### DIFF
--- a/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <openvic-simulation/country/Country.hpp>
-#include <openvic-simulation/interface/GFX.hpp>
+#include <openvic-simulation/interface/GFXSprite.hpp>
 
 #include "openvic-extension/classes/GFXButtonStateTexture.hpp"
 

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
@@ -2,7 +2,7 @@
 
 #include <godot_cpp/classes/image_texture.hpp>
 
-#include <openvic-simulation/interface/GFX.hpp>
+#include <openvic-simulation/interface/GFXSprite.hpp>
 
 #include "openvic-extension/utility/Utilities.hpp"
 

--- a/extension/src/openvic-extension/classes/GFXSpriteTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXSpriteTexture.hpp
@@ -2,7 +2,7 @@
 
 #include <godot_cpp/classes/atlas_texture.hpp>
 
-#include <openvic-simulation/interface/GFX.hpp>
+#include <openvic-simulation/interface/GFXSprite.hpp>
 
 #include "openvic-extension/classes/GFXButtonStateTexture.hpp"
 

--- a/extension/src/openvic-extension/singletons/AssetManager.hpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.hpp
@@ -5,7 +5,7 @@
 #include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/core/class_db.hpp>
 
-#include <openvic-simulation/interface/GFX.hpp>
+#include <openvic-simulation/interface/GFXSprite.hpp>
 
 namespace OpenVic {
 	class AssetManager : public godot::Object {

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -51,6 +51,7 @@ void GameSingleton::_bind_methods() {
 
 	OV_BIND_METHOD(GameSingleton::get_map_width);
 	OV_BIND_METHOD(GameSingleton::get_map_height);
+	OV_BIND_METHOD(GameSingleton::get_map_dims);
 	OV_BIND_METHOD(GameSingleton::get_map_aspect_ratio);
 	OV_BIND_METHOD(GameSingleton::get_terrain_texture);
 	OV_BIND_METHOD(GameSingleton::get_province_shape_image_subdivisions);
@@ -133,9 +134,8 @@ Error GameSingleton::setup_game(int32_t bookmark_index) {
 }
 
 int32_t GameSingleton::get_province_index_from_uv_coords(Vector2 const& coords) const {
-	const size_t x_mod_w = UtilityFunctions::fposmod(coords.x, 1.0f) * get_map_width();
-	const size_t y_mod_h = UtilityFunctions::fposmod(coords.y, 1.0f) * get_map_height();
-	return game_manager.get_map().get_province_index_at(x_mod_w, y_mod_h);
+	const Vector2 pos = coords.posmod(1.0f) * get_map_dims();
+	return game_manager.get_map().get_province_index_at(Utilities::from_godot_ivec2(pos));
 }
 
 int32_t GameSingleton::get_map_width() const {
@@ -144,6 +144,10 @@ int32_t GameSingleton::get_map_width() const {
 
 int32_t GameSingleton::get_map_height() const {
 	return game_manager.get_map().get_height();
+}
+
+Vector2i GameSingleton::get_map_dims() const {
+	return Utilities::to_godot_ivec2(game_manager.get_map().get_dims());
 }
 
 float GameSingleton::get_map_aspect_ratio() const {

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -61,6 +61,7 @@ namespace OpenVic {
 
 		int32_t get_map_width() const;
 		int32_t get_map_height() const;
+		godot::Vector2i get_map_dims() const;
 		float get_map_aspect_ratio() const;
 
 		/* The cosmetic terrain textures stored in a Texture2DArray. */

--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -55,6 +55,9 @@ int32_t MenuSingleton::get_population_menu_province_list_row_count() const {
 }
 
 TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int32_t start, int32_t count) const {
+	// TODO - remove when country population is used instead of total map population
+	ERR_FAIL_NULL_V(game_manager, {});
+
 	if (population_menu.province_list_entries.empty()) {
 		return {};
 	}
@@ -81,6 +84,9 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 		int32_t& start_counter;
 		int32_t& count_counter;
 
+		// TODO - remove when country population is used instead of total map population
+		const Pop::pop_size_t total_map_population;
+
 		/* This is the index among all entries, not just visible ones unlike start and count. */
 		int32_t index = 0;
 
@@ -98,7 +104,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 				country_dict[type_key] = population_menu_t::LIST_ENTRY_COUNTRY;
 				country_dict[index_key] = index;
 				country_dict[name_key] = std_view_to_godot_string(country_entry.country.get_identifier());
-				country_dict[size_key] = 0;
+				country_dict[size_key] = total_map_population;
 				country_dict[change_key] = 0;
 				country_dict[selected_key] = country_entry.selected;
 
@@ -119,7 +125,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 				state_dict[type_key] = population_menu_t::LIST_ENTRY_STATE;
 				state_dict[index_key] = index;
 				state_dict[name_key] = std_view_to_godot_string(state_entry.state.get_identifier());
-				state_dict[size_key] = 0;
+				state_dict[size_key] = state_entry.state.calculate_total_population();
 				state_dict[change_key] = 0;
 				state_dict[selected_key] = state_entry.selected;
 				state_dict[expanded_key] = state_entry.expanded;
@@ -151,7 +157,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 
 			return  true;
 		}
-	} entry_visitor { start, count };
+	} entry_visitor { start, count, game_manager->get_map().get_total_map_population() };
 
 	while (entry_visitor.index < population_menu.province_list_entries.size()
 		&& std::visit(entry_visitor, population_menu.province_list_entries[entry_visitor.index])) {

--- a/extension/src/openvic-extension/utility/UITools.hpp
+++ b/extension/src/openvic-extension/utility/UITools.hpp
@@ -2,7 +2,7 @@
 
 #include <godot_cpp/classes/control.hpp>
 
-#include <openvic-simulation/interface/GFX.hpp>
+#include <openvic-simulation/interface/GFXSprite.hpp>
 #include <openvic-simulation/interface/GUI.hpp>
 
 namespace OpenVic::UITools {

--- a/extension/src/openvic-extension/utility/Utilities.hpp
+++ b/extension/src/openvic-extension/utility/Utilities.hpp
@@ -41,11 +41,15 @@ namespace OpenVic::Utilities {
 		return { colour.redf(), colour.greenf(), colour.bluef(), colour.alphaf() };
 	}
 
-	_FORCE_INLINE_ godot::Vector2i to_godot_ivec2(ivec2_t vec) {
+	_FORCE_INLINE_ godot::Vector2i to_godot_ivec2(ivec2_t const& vec) {
 		return { vec.x, vec.y };
 	}
 
-	_FORCE_INLINE_ godot::Vector2 to_godot_fvec2(fvec2_t vec) {
+	_FORCE_INLINE_ godot::Vector2 to_godot_fvec2(fvec2_t const& vec) {
+		return { vec.x, vec.y };
+	}
+
+	_FORCE_INLINE_ ivec2_t from_godot_ivec2(godot::Vector2i const& vec) {
 		return { vec.x, vec.y };
 	}
 


### PR DESCRIPTION
Update the SIM submodule 3 times, each including corresponding changes to this repo:
- SIM adds `GFX::Actor` and renames `GFX.hpp` to `GFXSprite.hpp` which requires include path changes in this repo.
- SIM changes map pixel position to province/index functions, requiring uses of those functions to be changed in this repo and the addition of `GameSingleton::get_map_dims` and `Utilities::from_godot_ivec2`.
- SIM adds support for getting the total population of a region, which is then displayed in the population menu.