### PR TITLE
Pre-allocate and use std::move for Godot Arrays and Dictionaries

### DIFF
--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
@@ -54,12 +54,14 @@ namespace OpenVic {
 				return lhs.first < rhs.first;
 			});
 			godot_pie_chart_data_t array;
-			for (auto const& [key, val] : sorted_dist) {
+			ERR_FAIL_COND_V(array.resize(sorted_dist.size()) != OK, {});
+			for (size_t idx = 0; idx < array.size(); ++idx) {
+				auto const& [key, val] = sorted_dist[idx];
 				Dictionary sub_dict;
 				sub_dict[_slice_identifier_key()] = Utilities::std_view_to_godot_string(key->get_identifier());
 				sub_dict[_slice_colour_key()] = Utilities::to_godot_color(key->get_colour());
 				sub_dict[_slice_weight_key()] = val.to_float();
-				array.push_back(sub_dict);
+				array[idx] = std::move(sub_dict);
 			}
 			return array;
 		}

--- a/extension/src/openvic-extension/classes/MapMesh.cpp
+++ b/extension/src/openvic-extension/classes/MapMesh.cpp
@@ -92,7 +92,7 @@ bool MapMesh::is_valid_uv_coord(godot::Vector2 const& uv) const {
 
 Array MapMesh::_create_mesh_array() const {
 	Array arr;
-	arr.resize(Mesh::ARRAY_MAX);
+	ERR_FAIL_COND_V(arr.resize(Mesh::ARRAY_MAX) != OK, {});
 
 	const int32_t vertex_count = (subdivide_w + 2) * (subdivide_d + 2);
 	const int32_t indice_count = (subdivide_w + 1) * (subdivide_d + 1) * 6;
@@ -103,11 +103,11 @@ Array MapMesh::_create_mesh_array() const {
 	PackedVector2Array uvs;
 	PackedInt32Array indices;
 
-	points.resize(vertex_count);
-	normals.resize(vertex_count);
-	tangents.resize(vertex_count * 4);
-	uvs.resize(vertex_count);
-	indices.resize(indice_count);
+	ERR_FAIL_COND_V(points.resize(vertex_count) != OK, {});
+	ERR_FAIL_COND_V(normals.resize(vertex_count) != OK, {});
+	ERR_FAIL_COND_V(tangents.resize(vertex_count * 4) != OK, {});
+	ERR_FAIL_COND_V(uvs.resize(vertex_count) != OK, {});
+	ERR_FAIL_COND_V(indices.resize(indice_count) != OK, {});
 
 	static const Vector3 normal { 0.0f, 1.0f, 0.0f };
 	const Size2 uv_size { 1.0f + 2.0f * repeat_proportion, 1.0f };
@@ -153,11 +153,11 @@ Array MapMesh::_create_mesh_array() const {
 		thisrow = point_index;
 	}
 
-	arr[Mesh::ARRAY_VERTEX] = points;
-	arr[Mesh::ARRAY_NORMAL] = normals;
-	arr[Mesh::ARRAY_TANGENT] = tangents;
-	arr[Mesh::ARRAY_TEX_UV] = uvs;
-	arr[Mesh::ARRAY_INDEX] = indices;
+	arr[Mesh::ARRAY_VERTEX] = std::move(points);
+	arr[Mesh::ARRAY_NORMAL] = std::move(normals);
+	arr[Mesh::ARRAY_TANGENT] = std::move(tangents);
+	arr[Mesh::ARRAY_TEX_UV] = std::move(uvs);
+	arr[Mesh::ARRAY_INDEX] = std::move(indices);
 
 	return arr;
 }

--- a/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
+++ b/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
@@ -111,7 +111,7 @@ Error LoadLocalisation::load_localisation_dir(String const& dir_path) const {
 	ERR_FAIL_COND_V_MSG(
 		!DirAccess::dir_exists_absolute(dir_path), FAILED, vformat("Localisation directory does not exist: %s", dir_path)
 	);
-	PackedStringArray const dirs = DirAccess::get_directories_at(dir_path);
+	const PackedStringArray dirs = DirAccess::get_directories_at(dir_path);
 	ERR_FAIL_COND_V_MSG(
 		dirs.size() < 1, FAILED, vformat("Localisation directory does not contain any sub-directories: %s", dir_path)
 	);

--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -575,9 +575,10 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_rows(int32_t start
 	// TODO - monthly change
 
 	TypedArray<Dictionary> array;
+	ERR_FAIL_COND_V(array.resize(count) != OK, {});
 
-	for (int32_t idx = start; idx < start + count; ++idx) {
-		Pop const* pop = population_menu.filtered_pops[idx];
+	for (int32_t idx = 0; idx < count; ++idx) {
+		Pop const* pop = population_menu.filtered_pops[start + idx];
 		Dictionary pop_dict;
 
 		pop_dict[pop_size_key] = pop->get_size();
@@ -598,7 +599,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_rows(int32_t start
 		pop_dict[pop_size_change_key] = pop->get_total_change();
 		pop_dict[pop_literacy_key] = pop->get_literacy().to_float();
 
-		array.push_back(pop_dict);
+		array[idx] = std::move(pop_dict);
 	}
 
 	return array;
@@ -619,9 +620,10 @@ PackedInt32Array MenuSingleton::get_population_menu_pop_filter_setup_info() {
 	ERR_FAIL_COND_V_MSG(population_menu.pop_filters.empty(), {}, "Failed to generate population menu pop filters!");
 
 	PackedInt32Array array;
+	ERR_FAIL_COND_V(array.resize(population_menu.pop_filters.size()) != OK, {});
 
-	for (auto const& [pop_type, filter] : population_menu.pop_filters) {
-		array.push_back(pop_type->get_sprite());
+	for (int32_t idx = 0; idx < array.size(); ++idx) {
+		array[idx] = population_menu.pop_filters.data()[idx].first->get_sprite();
 	}
 
 	return array;
@@ -633,13 +635,18 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_filter_info() cons
 	static const StringName pop_filter_selected_key = "selected";
 
 	TypedArray<Dictionary> array;
+	ERR_FAIL_COND_V(array.resize(population_menu.pop_filters.size()) != OK, {});
 
-	for (auto const& [pop_type, filter] : population_menu.pop_filters) {
+	for (int32_t idx = 0; idx < array.size(); ++idx) {
+		population_menu_t::pop_filter_t const& filter = population_menu.pop_filters.data()[idx].second;
+
 		Dictionary filter_dict;
+
 		filter_dict[pop_filter_count_key] = filter.count;
 		filter_dict[pop_filter_change_key] = filter.promotion_demotion_change;
 		filter_dict[pop_filter_selected_key] = filter.selected;
-		array.push_back(filter_dict);
+
+		array[idx] = std::move(filter_dict);
 	}
 
 	return array;
@@ -688,17 +695,20 @@ void MenuSingleton::population_menu_deselect_all_pop_filters() {
 
 PackedStringArray MenuSingleton::get_population_menu_distribution_setup_info() const {
 	static const PackedStringArray distribution_names = []() -> PackedStringArray {
-		PackedStringArray array;
-
-		for (char const* name : std::array<char const*, population_menu_t::DISTRIBUTION_COUNT> {
+		constexpr std::array<char const*, population_menu_t::DISTRIBUTION_COUNT> NAMES {
 			/* Workforce (PopType)   */       "WORKFORCE_DISTTITLE",
 			/* Religion              */        "RELIGION_DISTTITLE",
 			/* Ideology              */        "IDEOLOGY_DISTTITLE",
 			/* Nationality (Culture) */     "NATIONALITY_DISTTITLE",
 			/* Issues                */ "DOMINANT_ISSUES_DISTTITLE",
 			/* Vote                  */      "ELECTORATE_DISTTITLE"
-		}) {
-			array.push_back(name);
+		};
+
+		PackedStringArray array;
+		ERR_FAIL_COND_V(array.resize(NAMES.size()) != OK, {});
+
+		for (int32_t idx = 0; idx < array.size(); ++idx) {
+			array[idx] = NAMES[idx];
 		}
 
 		return array;
@@ -709,9 +719,10 @@ PackedStringArray MenuSingleton::get_population_menu_distribution_setup_info() c
 
 TypedArray<Array> MenuSingleton::get_population_menu_distribution_info() const {
 	TypedArray<Array> array;
+	ERR_FAIL_COND_V(array.resize(population_menu.distributions.size()) != OK, {});
 
-	for (fixed_point_map_t<HasIdentifierAndColour const*> const& distribution : population_menu.distributions) {
-		array.push_back(GFXPieChartTexture::distribution_to_slices_array(distribution));
+	for (int32_t idx = 0; idx < array.size(); ++idx) {
+		array[idx] = GFXPieChartTexture::distribution_to_slices_array(population_menu.distributions[idx]);
 	}
 
 	return array;

--- a/extension/src/openvic-extension/utility/Utilities.cpp
+++ b/extension/src/openvic-extension/utility/Utilities.cpp
@@ -80,7 +80,8 @@ static Ref<Image> load_dds_image(String const& path) {
 	);
 
 	PackedByteArray pixels;
-	pixels.resize(size);
+	ERR_FAIL_COND_V(pixels.resize(size) != OK, nullptr);
+
 	/* Index offset used to control whether we are reading */
 	const size_t rb_idx = 2 * needs_bgr_to_rgb;
 	uint8_t const* ptr = static_cast<uint8_t const*>(texture.data());


### PR DESCRIPTION
- Reduces unnecessary re-allocations and copies by resizing `godot::Array`s before filling them and `std::move`-ing `godot::Array`s and `godot::Dictionary`s.
- Check return value of resize calls.