### PR TITLE
Add province names and improve zooming

### DIFF
--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -60,6 +60,8 @@ void GameSingleton::_bind_methods() {
 	OV_BIND_METHOD(GameSingleton::get_province_shape_texture);
 	OV_BIND_METHOD(GameSingleton::get_province_colour_texture);
 
+	OV_BIND_METHOD(GameSingleton::get_province_names);
+
 	OV_BIND_METHOD(GameSingleton::get_mapmode_count);
 	OV_BIND_METHOD(GameSingleton::get_mapmode_identifier);
 	OV_BIND_METHOD(GameSingleton::set_mapmode, { "identifier" });
@@ -241,6 +243,39 @@ Error GameSingleton::_update_colour_image() {
 		province_colour_texture->update(province_colour_image);
 	}
 	return err;
+}
+
+TypedArray<Dictionary> GameSingleton::get_province_names() const {
+	static const StringName identifier_key = "identifier";
+	static const StringName position_key = "position";
+	static const StringName rotation_key = "rotation";
+	static const StringName scale_key = "scale";
+
+	TypedArray<Dictionary> ret;
+	ERR_FAIL_COND_V(ret.resize(game_manager.get_map().get_province_count()) != OK, {});
+
+	for (int32_t index = 0; index < game_manager.get_map().get_province_count(); ++index) {
+		Province const& province = game_manager.get_map().get_provinces()[index];
+
+		Dictionary province_dict;
+
+		province_dict[identifier_key] = std_view_to_godot_string(province.get_identifier());
+		province_dict[position_key] = Utilities::to_godot_fvec2(province.get_text_position()) / get_map_dims();
+
+		const float rotation = province.get_text_rotation().to_float();
+		if (rotation != 0.0f) {
+			province_dict[rotation_key] = rotation;
+		}
+
+		const float scale = province.get_text_scale().to_float();
+		if (scale != 1.0f) {
+			province_dict[scale_key] = scale;
+		}
+
+		ret[index] = std::move(province_dict);
+	}
+
+	return ret;
 }
 
 int32_t GameSingleton::get_mapmode_count() const {

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -95,6 +95,8 @@ namespace OpenVic {
 		/* The base and stripe colours for each province. */
 		godot::Ref<godot::ImageTexture> get_province_colour_texture() const;
 
+		godot::TypedArray<godot::Dictionary> get_province_names() const;
+
 		int32_t get_mapmode_count() const;
 		godot::String get_mapmode_identifier(int32_t index) const;
 		godot::Error set_mapmode(godot::String const& identifier);

--- a/game/src/Game/GameSession/MapText.gd
+++ b/game/src/Game/GameSession/MapText.gd
@@ -1,0 +1,50 @@
+class_name MapText
+extends Node3D
+
+@export var _map_view : MapView
+
+var _province_name_font : Font
+
+const _province_name_scale : float = 1.0 / 48.0
+
+func _ready() -> void:
+	_province_name_font = AssetManager.get_font(&"mapfont_56")
+
+func _clear_children() -> void:
+	var child_count : int = get_child_count()
+	while child_count > 0:
+		child_count -= 1
+		remove_child(get_child(child_count))
+
+func generate_map_names() -> void:
+	_clear_children()
+
+	for dict : Dictionary in GameSingleton.get_province_names():
+		_add_province_name(dict)
+
+func _add_province_name(dict : Dictionary) -> void:
+	const identifier_key : StringName = &"identifier"
+	const position_key : StringName = &"position"
+	const rotation_key : StringName = &"rotation"
+	const scale_key : StringName = &"scale"
+
+	var label : Label3D = Label3D.new()
+
+	label.set_draw_flag(Label3D.FLAG_DOUBLE_SIDED, false)
+	label.set_modulate(Color.BLACK)
+	label.set_outline_size(0)
+	label.set_font(_province_name_font)
+	label.set_vertical_alignment(VERTICAL_ALIGNMENT_BOTTOM)
+
+	var identifier : String = dict[identifier_key]
+	label.set_name(identifier)
+	label.set_text(GUINode.format_province_name(identifier))
+
+	label.set_position(_map_view._map_to_world_coords(dict[position_key]) + Vector3(0, 0.001, 0))
+
+	label.rotate_x(-PI / 2)
+	label.rotate_y(dict.get(rotation_key, 0.0))
+
+	label.scale *= dict.get(scale_key, 1.0) * _province_name_scale
+
+	add_child(label)

--- a/game/src/Game/GameSession/MapView.tscn
+++ b/game/src/Game/GameSession/MapView.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://dkehmdnuxih2r"]
+[gd_scene load_steps=8 format=3 uid="uid://dkehmdnuxih2r"]
 
 [ext_resource type="Script" path="res://src/Game/GameSession/MapView.gd" id="1_exccw"]
 [ext_resource type="Shader" path="res://src/Game/GameSession/TerrainMap.gdshader" id="1_upocn"]
+[ext_resource type="Script" path="res://src/Game/GameSession/MapText.gd" id="2_13bgq"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_tayeg"]
 render_priority = 0
@@ -23,16 +24,21 @@ albedo_color = Color(0, 0, 0, 1)
 material = SubResource("StandardMaterial3D_irk50")
 size = Vector2(6, 2)
 
-[node name="MapView" type="Node3D" node_paths=PackedStringArray("_camera", "_map_mesh_instance", "_map_background_instance")]
+[node name="MapView" type="Node3D" node_paths=PackedStringArray("_camera", "_map_mesh_instance", "_map_background_instance", "_map_text")]
 editor_description = "SS-73"
 script = ExtResource("1_exccw")
 _camera = NodePath("MapCamera")
 _map_mesh_instance = NodePath("MapMeshInstance")
 _map_background_instance = NodePath("MapBackgroundInstance")
+_map_text = NodePath("MapText")
 
 [node name="MapCamera" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.25, 1.5, -2.75)
 near = 0.01
+
+[node name="MapText" type="Node3D" parent="." node_paths=PackedStringArray("_map_view")]
+script = ExtResource("2_13bgq")
+_map_view = NodePath("..")
 
 [node name="MapMeshInstance" type="MeshInstance3D" parent="."]
 editor_description = "FS-343"
@@ -43,3 +49,5 @@ mesh = SubResource("MapMesh_3gtsd")
 [node name="MapBackgroundInstance" type="MeshInstance3D" parent="."]
 transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0, -1, 0)
 mesh = SubResource("PlaneMesh_fnhgl")
+
+[connection signal="detailed_view_changed" from="." to="MapText" method="set_visible"]


### PR DESCRIPTION
There are now 3 zoom states:
- closest ("detailed") - terrain map used, province names visible (and models soon too)
- middle - terrain map used but without province names
- farthest ("parchment") - parchment map used, no province names