### PR TITLE
Improve map view and game panel user experience

### DIFF
--- a/extension/src/openvic-extension/classes/GUINode.hpp
+++ b/extension/src/openvic-extension/classes/GUINode.hpp
@@ -1,17 +1,27 @@
 #pragma once
 
+#include <godot_cpp/classes/bit_map.hpp>
 #include <godot_cpp/classes/button.hpp>
 #include <godot_cpp/classes/check_box.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/classes/input_event.hpp>
 #include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/panel.hpp>
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/classes/texture_progress_bar.hpp>
 #include <godot_cpp/classes/texture_rect.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/node_path.hpp>
+#include <godot_cpp/variant/rect2.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/vector2.hpp>
 
-#include <openvic-simulation/interface/GUI.hpp>
-
-#include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GFXMaskedFlagTexture.hpp"
 #include "openvic-extension/classes/GFXPieChartTexture.hpp"
+#include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GUIListBox.hpp"
 #include "openvic-extension/classes/GUIOverlappingElementsBox.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
@@ -19,6 +29,11 @@
 namespace OpenVic {
 	class GUINode : public godot::Control {
 		GDCLASS(GUINode, godot::Control)
+
+		godot::Ref<godot::BitMap> _click_mask;
+		godot::Vector<Control*> _mask_controls;
+		godot::Rect2 _texture_region;
+		godot::Rect2 _position_rect;
 
 	protected:
 		static void _bind_methods();
@@ -73,5 +88,14 @@ namespace OpenVic {
 		static godot::String int_to_formatted_string(int64_t val);
 		static godot::String float_to_formatted_string(float val, int32_t decimal_places);
 		static godot::String format_province_name(godot::String const& province_identifier);
+
+		godot::Ref<godot::BitMap> get_click_mask() const;
+		void set_click_mask(godot::Ref<godot::BitMap> const& mask);
+
+		void set_click_mask_from_nodepaths(godot::TypedArray<godot::NodePath> const& paths);
+		bool _update_click_mask_for(godot::Ref<godot::Image> const& img, int index);
+		void update_click_mask();
+
+		bool _has_point(godot::Vector2 const& point) const override;
 	};
 }

--- a/game/src/Game/GameSession/GameSession.tscn
+++ b/game/src/Game/GameSession/GameSession.tscn
@@ -28,63 +28,76 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_eklvp")
-_game_session_menu = NodePath("GameSessionMenu")
+_game_session_menu = NodePath("UICanvasLayer/UI/GameSessionMenu")
 
 [node name="MapView" parent="." instance=ExtResource("4_xkg5j")]
 
-[node name="ProvinceOverviewPanel" type="GUINode" parent="."]
+[node name="UICanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="UICanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="ProvinceOverviewPanel" type="GUINode" parent="UICanvasLayer/UI"]
 layout_mode = 1
 anchors_preset = 15
+mouse_force_pass_scroll_events = false
 script = ExtResource("5_lfv8l")
 
-[node name="Topbar" type="GUINode" parent="."]
+[node name="Topbar" type="GUINode" parent="UICanvasLayer/UI"]
 layout_mode = 1
 anchors_preset = 15
+mouse_force_pass_scroll_events = false
 script = ExtResource("4_2kbih")
 
-[node name="ProductionMenu" type="GUINode" parent="Topbar"]
+[node name="ProductionMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("5_16755")
 
-[node name="BudgetMenu" type="GUINode" parent="Topbar"]
+[node name="BudgetMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("6_vninv")
 
-[node name="TechnologyMenu" type="GUINode" parent="Topbar"]
+[node name="TechnologyMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("7_r712c")
 
-[node name="PoliticsMenu" type="GUINode" parent="Topbar"]
+[node name="PoliticsMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("8_ppdek")
 
-[node name="PopulationMenu" type="GUINode" parent="Topbar"]
+[node name="PopulationMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("10_laee7")
 
-[node name="TradeMenu" type="GUINode" parent="Topbar"]
+[node name="TradeMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("10_mv1r6")
 
-[node name="DiplomacyMenu" type="GUINode" parent="Topbar"]
+[node name="DiplomacyMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("11_fu7ys")
 
-[node name="MilitaryMenu" type="GUINode" parent="Topbar"]
+[node name="MilitaryMenu" type="GUINode" parent="UICanvasLayer/UI/Topbar"]
 layout_mode = 1
 anchors_preset = 15
 script = ExtResource("12_6h6nc")
 
-[node name="MapControlPanel" parent="." instance=ExtResource("3_afh6d")]
+[node name="MapControlPanel" parent="UICanvasLayer/UI" instance=ExtResource("3_afh6d")]
 layout_mode = 1
-anchors_preset = 3
+anchors_preset = -1
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -92,7 +105,7 @@ anchor_bottom = 1.0
 grow_horizontal = 0
 grow_vertical = 0
 
-[node name="GameSessionMenu" parent="." instance=ExtResource("3_bvmqh")]
+[node name="GameSessionMenu" parent="UICanvasLayer/UI" instance=ExtResource("3_bvmqh")]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -107,11 +120,12 @@ offset_bottom = 165.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="OptionsMenu" parent="." instance=ExtResource("6_p5mnx")]
+[node name="OptionsMenu" parent="UICanvasLayer/UI" instance=ExtResource("6_p5mnx")]
 visible = false
 layout_mode = 1
+mouse_force_pass_scroll_events = false
 
-[node name="SaveLoadMenu" parent="." instance=ExtResource("8_4g7ko")]
+[node name="SaveLoadMenu" parent="UICanvasLayer/UI" instance=ExtResource("8_4g7ko")]
 visible = false
 layout_mode = 1
 anchors_preset = -1
@@ -120,7 +134,7 @@ anchor_right = 0.5
 offset_left = -640.0
 offset_right = 640.0
 
-[node name="MusicPlayer" parent="." instance=ExtResource("2_kt6aa")]
+[node name="MusicPlayer" parent="UICanvasLayer/UI" instance=ExtResource("2_kt6aa")]
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
@@ -129,15 +143,13 @@ offset_left = -150.0
 offset_right = 0.0
 grow_horizontal = 0
 
-[connection signal="map_view_camera_changed" from="MapView" to="MapControlPanel" method="_on_map_view_camera_changed"]
-[connection signal="game_session_menu_button_pressed" from="MapControlPanel" to="." method="_on_game_session_menu_button_pressed"]
-[connection signal="minimap_clicked" from="MapControlPanel" to="MapView" method="_on_minimap_clicked"]
-[connection signal="mouse_entered" from="MapControlPanel" to="MapView" method="_on_mouse_exited_viewport"]
-[connection signal="mouse_exited" from="MapControlPanel" to="MapView" method="_on_mouse_entered_viewport"]
-[connection signal="zoom_in_button_pressed" from="MapControlPanel" to="MapView" method="zoom_in"]
-[connection signal="zoom_out_button_pressed" from="MapControlPanel" to="MapView" method="zoom_out"]
-[connection signal="load_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_load"]
-[connection signal="options_button_pressed" from="GameSessionMenu" to="OptionsMenu" method="show"]
-[connection signal="save_button_pressed" from="GameSessionMenu" to="SaveLoadMenu" method="show_for_save"]
-[connection signal="back_button_pressed" from="OptionsMenu" to="MapView" method="enable_processing"]
-[connection signal="back_button_pressed" from="OptionsMenu" to="OptionsMenu" method="hide"]
+[connection signal="map_view_camera_changed" from="MapView" to="UICanvasLayer/UI/MapControlPanel" method="_on_map_view_camera_changed"]
+[connection signal="game_session_menu_button_pressed" from="UICanvasLayer/UI/MapControlPanel" to="." method="_on_game_session_menu_button_pressed"]
+[connection signal="minimap_clicked" from="UICanvasLayer/UI/MapControlPanel" to="MapView" method="_on_minimap_clicked"]
+[connection signal="zoom_in_button_pressed" from="UICanvasLayer/UI/MapControlPanel" to="MapView" method="zoom_in"]
+[connection signal="zoom_out_button_pressed" from="UICanvasLayer/UI/MapControlPanel" to="MapView" method="zoom_out"]
+[connection signal="load_button_pressed" from="UICanvasLayer/UI/GameSessionMenu" to="UICanvasLayer/UI/SaveLoadMenu" method="show_for_load"]
+[connection signal="options_button_pressed" from="UICanvasLayer/UI/GameSessionMenu" to="UICanvasLayer/UI/OptionsMenu" method="show"]
+[connection signal="save_button_pressed" from="UICanvasLayer/UI/GameSessionMenu" to="UICanvasLayer/UI/SaveLoadMenu" method="show_for_save"]
+[connection signal="back_button_pressed" from="UICanvasLayer/UI/OptionsMenu" to="MapView" method="enable_processing"]
+[connection signal="back_button_pressed" from="UICanvasLayer/UI/OptionsMenu" to="UICanvasLayer/UI/OptionsMenu" method="hide"]

--- a/game/src/Game/GameSession/GameSessionMenu.tscn
+++ b/game/src/Game/GameSession/GameSessionMenu.tscn
@@ -7,6 +7,7 @@
 [node name="GameSessionMenu" type="PanelContainer" node_paths=PackedStringArray("_main_menu_dialog", "_quit_dialog")]
 process_mode = 3
 editor_description = "UI-68"
+mouse_force_pass_scroll_events = false
 theme = ExtResource("1_2onog")
 theme_type_variation = &"SessionPanel"
 script = ExtResource("1_usq6o")

--- a/game/src/Game/GameSession/MapControlPanel/MapControlPanel.tscn
+++ b/game/src/Game/GameSession/MapControlPanel/MapControlPanel.tscn
@@ -17,7 +17,7 @@ events = [SubResource("InputEventAction_5nck3")]
 
 [node name="MapControlPanel" type="PanelContainer" node_paths=PackedStringArray("_mapmodes_grid")]
 editor_description = "SS-103, UI-548"
-mouse_filter = 1
+mouse_force_pass_scroll_events = false
 script = ExtResource("1_ign64")
 _mapmodes_grid = NodePath("MapPanelMargin/MapPanelList/MapDisplayList/MapmodesGrid")
 

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -125,6 +125,12 @@ func _ready() -> void:
 		push_error("Failed to generate province overview panel!")
 		return
 
+	# Disables all consuming invisible panel
+	var prov_view := get_panel_from_nodepath(^"./province_view")
+	if prov_view:
+		prov_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	set_click_mask_from_nodepaths([^"./province_view/background"])
+
 	var close_button : Button = get_button_from_nodepath(^"./province_view/close_button")
 	if close_button:
 		close_button.pressed.connect(_on_close_button_pressed)

--- a/game/src/Game/GameSession/Topbar.gd
+++ b/game/src/Game/GameSession/Topbar.gd
@@ -27,6 +27,12 @@ func _ready() -> void:
 
 	const player_country : String = "SLV"
 
+	# Disables all consuming invisible panel
+	var topbar := get_panel_from_nodepath(^"./topbar")
+	if topbar:
+		topbar.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	set_click_mask_from_nodepaths([^"./topbar/topbar_bg", ^"./topbar/topbar_paper"])
+
 	# Player country info
 	var player_flag_texture : GFXMaskedFlagTexture = get_gfx_masked_flag_texture_from_nodepath(^"./topbar/player_flag")
 	if player_flag_texture:

--- a/game/src/Game/Menu/SaveLoadMenu/SaveLoadMenu.tscn
+++ b/game/src/Game/Menu/SaveLoadMenu/SaveLoadMenu.tscn
@@ -33,6 +33,7 @@ _overwrite_dialog = NodePath("OverwriteDialog")
 
 [node name="SaveLoadPanel" type="PanelContainer" parent="."]
 layout_mode = 2
+mouse_force_pass_scroll_events = false
 
 [node name="SaveLoadList" type="VBoxContainer" parent="SaveLoadPanel"]
 layout_mode = 2

--- a/game/src/Game/MusicConductor/MusicPlayer.tscn
+++ b/game/src/Game/MusicConductor/MusicPlayer.tscn
@@ -21,6 +21,7 @@ editor_description = "UI-105, UI-107, UI-110, UIFUN-92"
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 focus_mode = 0
+mouse_force_pass_scroll_events = false
 alignment = 1
 text_overrun_behavior = 3
 fit_to_longest_item = false


### PR DESCRIPTION
Fixes #201 
Minimizes panel mouse obstruction to scripted panel images (functionally what is currently visible)
Prevents map view from hovering inside UI elements
Unsets province hover when not over provinces

---

Add `GUINode.click_mask`
* Prevents mouse interactions not within click_mask

Add `GUINode.set_click_mask_from_nodepaths`
* Generates click_mask from paths relating to GUINode textures
* Sets nodepaths to MOUSE_FILTER_IGNORE

Add CanvasLayer parent to GameSession UI nodes
Set mouse_force_pass_scroll_events to GameSession UI nodes
Set MapControlPanel mouse_filter to default (MOUSE_FILTER_STOP)

Move MapView mouse viewport changes to _input
Move MapView _action_drag released check to _input
Move MapView processing to _process
Remove viewport and window notifications
Disable if window is not focused or input is handled:
* MapView mouse interactions (including edge scrolling and drag panning)
* MapView province hover

Set mouse_filter to MOUSE_FILTER_IGNORE for ProvinceOverviewPanel province_view panel
Set ProvinceOverviewPanel click_mask path to `province_view/background`

Set mouse_filter to MOUSE_FILTER_IGNORE for Topbar topbar panel
Set Topbar click_mask path to `topbar/topbar_bg` and `topbar/topbar_paper`

Expected panel hover behavior:


https://github.com/OpenVicProject/OpenVic/assets/4315446/e7c6d5b7-98d5-4e4c-b046-4aad6fd4293e


