### PR TITLE
Scrolling model materials (tank tracks and smoke)

### DIFF
--- a/game/src/Game/Model/UnitModel.gd
+++ b/game/src/Game/Model/UnitModel.gd
@@ -12,21 +12,21 @@ var meshes : Array[MeshInstance3D]
 @export var primary_colour : Color:
 	set(col_in):
 		primary_colour = col_in
-		change_colour_prop(&"colour_primary", primary_colour)
+		_set_shader_parameter(&"colour_primary", primary_colour)
 		for unit : UnitModel in sub_units:
 			unit.primary_colour = col_in
 
 @export var secondary_colour: Color:
 	set(col_in):
 		secondary_colour = col_in
-		change_colour_prop(&"colour_secondary", secondary_colour)
+		_set_shader_parameter(&"colour_secondary", secondary_colour)
 		for unit : UnitModel in sub_units:
 			unit.secondary_colour = col_in
 
 @export var tertiary_colour : Color:
 	set(col_in):
 		tertiary_colour = col_in
-		change_colour_prop(&"colour_tertiary", tertiary_colour)
+		_set_shader_parameter(&"colour_tertiary", tertiary_colour)
 		for unit : UnitModel in sub_units:
 			unit.tertiary_colour = col_in
 
@@ -64,16 +64,19 @@ const ANIMATION_ATTACK : String = ANIMATION_LIBRARY + "/attack"
 				Anim.IDLE:
 					if idle_anim:
 						anim_player.set_current_animation(ANIMATION_IDLE)
+						_set_tex_scroll(scroll_speed_idle)
 						current_anim = Anim.IDLE
 						return
 				Anim.MOVE:
 					if move_anim:
 						anim_player.set_current_animation(ANIMATION_MOVE)
+						_set_tex_scroll(scroll_speed_move)
 						current_anim = Anim.MOVE
 						return
 				Anim.ATTACK:
 					if attack_anim:
 						anim_player.set_current_animation(ANIMATION_ATTACK)
+						_set_tex_scroll(scroll_speed_attack)
 						current_anim = Anim.ATTACK
 						return
 				_: #None
@@ -81,13 +84,28 @@ const ANIMATION_ATTACK : String = ANIMATION_LIBRARY + "/attack"
 
 			anim_player.stop()
 
+		_set_tex_scroll(0.0)
 		current_anim = Anim.NONE
 
 # TEXTURE SCROLL SPEEDS (TANKS TRACKS AND SMOKE)
 @export_subgroup("Texture_Scroll")
-@export var scroll_speed_idle : float = 0.0
-@export var scroll_speed_move : float = 0.0
-@export var scroll_speed_attack : float = 0.0
+@export var scroll_speed_idle : float:
+	set(speed_in):
+		scroll_speed_idle = speed_in
+		for unit : UnitModel in sub_units:
+			unit.scroll_speed_idle = speed_in
+
+@export var scroll_speed_move : float:
+	set(speed_in):
+		scroll_speed_move = speed_in
+		for unit : UnitModel in sub_units:
+			unit.scroll_speed_move = speed_in
+
+@export var scroll_speed_attack : float:
+	set(speed_in):
+		scroll_speed_attack = speed_in
+		for unit : UnitModel in sub_units:
+			unit.scroll_speed_attack = speed_in
 
 func unit_init() -> void:
 	for child : Node in get_children():
@@ -138,19 +156,15 @@ func attach_model(bone_name : String, model : Node3D) -> Error:
 
 	return OK
 
-func _set_tex_scroll(speed : float) -> void:
+func _set_shader_parameter(param_name : StringName, param_val : Variant) -> void:
 	for mesh : MeshInstance3D in meshes:
-		if mesh.get_active_material(0) is ShaderMaterial:
-			mesh.set_instance_shader_parameter(&"scroll", Vector2(0, speed))
+		mesh.set_instance_shader_parameter(param_name, param_val)
+
+func _set_tex_scroll(speed : float) -> void:
+	_set_shader_parameter(&"scroll_speed", speed)
 
 func set_flag_index(index : int) -> void:
-	for mesh : MeshInstance3D in meshes:
-		mesh.set_instance_shader_parameter(&"flag_index", index)
-
-func change_colour_prop(prop_name : StringName, prop_val : Color) -> void:
-	for mesh : MeshInstance3D in meshes:
-		if mesh.get_active_material(0) is ShaderMaterial:
-			mesh.set_instance_shader_parameter(prop_name, prop_val)
+	_set_shader_parameter(&"flag_index", index)
 
 func load_animation(prop_name : String, animIn : Animation) -> void:
 	if not animIn:

--- a/game/src/Game/Model/flag.gdshader
+++ b/game/src/Game/Model/flag.gdshader
@@ -9,7 +9,7 @@ uniform sampler2D texture_normal : hint_normal;
 
 instance uniform uint flag_index;
 
-uniform vec2 scroll_speed = vec2(-0.25,0);
+const float normal_scroll_speed = 0.3;
 
 // Scroll the Normal map, but leave the albedo alone
 void fragment() {
@@ -21,6 +21,9 @@ void fragment() {
 	vec2 flag_uv = (vec2(flag_pos) + UV * vec2(flag_dims)) / vec2(flag_sheet_dims);
 
 	ALBEDO = texture(texture_flag_sheet_diffuse, flag_uv).rgb;
-	//ALBEDO = vec3(1, 0, 0);
-	NORMAL_MAP = texture(texture_normal, UV + TIME*scroll_speed).rgb;
+
+	vec2 normal_uv = UV;
+	normal_uv.x -= TIME * normal_scroll_speed;
+
+	NORMAL_MAP = texture(texture_normal, normal_uv).rgb;
 }

--- a/game/src/Game/Model/scrolling.gdshader
+++ b/game/src/Game/Model/scrolling.gdshader
@@ -1,0 +1,19 @@
+shader_type spatial;
+
+// depth_prepass_alpha is to ensure opaque scrolling textures
+// (e.g. tank tracks) are rendered correctly
+render_mode cull_disabled, depth_prepass_alpha;
+
+uniform sampler2D scroll_texture_diffuse[32] : source_color, filter_linear_mipmap, repeat_enable;
+uniform float scroll_factor[32];
+
+instance uniform uint scroll_tex_index_diffuse;
+instance uniform float scroll_speed;
+
+void fragment() {
+	vec2 uv_scrolled = UV;
+	uv_scrolled.y += TIME * scroll_speed * scroll_factor[scroll_tex_index_diffuse];
+
+	ALBEDO = texture(scroll_texture_diffuse[scroll_tex_index_diffuse], uv_scrolled).rgb;
+	ALPHA = texture(scroll_texture_diffuse[scroll_tex_index_diffuse], UV).a;
+}

--- a/game/src/Game/Model/scrolling_mat.tres
+++ b/game/src/Game/Model/scrolling_mat.tres
@@ -1,0 +1,9 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://5utra6tpdqag"]
+
+[ext_resource type="Shader" path="res://src/Game/Model/scrolling.gdshader" id="1_oqkkj"]
+
+[resource]
+render_priority = 0
+shader = ExtResource("1_oqkkj")
+shader_parameter/scroll_texture_diffuse = []
+shader_parameter/scroll_factor = []

--- a/game/src/Game/Model/unit_colours.gdshader
+++ b/game/src/Game/Model/unit_colours.gdshader
@@ -1,11 +1,11 @@
 
 shader_type spatial;
 
-render_mode blend_mix, depth_draw_opaque, cull_disabled, diffuse_burley, specular_schlick_ggx;
+render_mode cull_disabled;
 
 //hold all the textures for the units that need this shader to mix in their
 //nation colours (mostly generic infantry units)
-uniform sampler2D texture_albedo[32] : source_color, filter_linear_mipmap, repeat_enable;
+uniform sampler2D texture_diffuse[32] : source_color, filter_linear_mipmap, repeat_enable;
 uniform sampler2D texture_nation_colors_mask[32] : source_color, filter_linear_mipmap, repeat_enable;
 
 instance uniform vec3 colour_primary : source_color;
@@ -14,12 +14,12 @@ instance uniform vec3 colour_tertiary : source_color;
 
 //used to access the right textures since different units (with different textures)
 //will use this same shader
-instance uniform uint tex_index_specular;
 instance uniform uint tex_index_diffuse;
+instance uniform uint tex_index_specular;
 
 void fragment() {
 	vec2 base_uv = UV;
-	vec4 albedo_tex = texture(texture_albedo[tex_index_diffuse], base_uv);
+	vec4 diffuse_tex = texture(texture_diffuse[tex_index_diffuse], base_uv);
 	vec4 nation_colours_tex = texture(texture_nation_colors_mask[tex_index_specular], base_uv);
 
 	//set colours to either be white (1,1,1) or the nation colour based on the mask
@@ -27,5 +27,5 @@ void fragment() {
 	vec3 secondary_col = mix(vec3(1.0, 1.0, 1.0), colour_secondary, nation_colours_tex.b);
 	vec3 tertiary_col = mix(vec3(1.0, 1.0, 1.0), colour_tertiary, nation_colours_tex.r);
 
-	ALBEDO = albedo_tex.rgb * primary_col * secondary_col * tertiary_col;
+	ALBEDO = diffuse_tex.rgb * primary_col * secondary_col * tertiary_col;
 }

--- a/game/src/Game/Model/unit_colours_mat.tres
+++ b/game/src/Game/Model/unit_colours_mat.tres
@@ -5,5 +5,5 @@
 [resource]
 render_priority = 0
 shader = ExtResource("1_axmiw")
-shader_parameter/texture_albedo = []
+shader_parameter/texture_diffuse = []
 shader_parameter/texture_nation_colors_mask = []


### PR DESCRIPTION
Tested for all vanilla models with scrolling textures. Examples can be seen by adding the following to a starting units OOB text file (and changing [the default unit animation](https://github.com/OpenVicProject/OpenVic/blob/master/game/src/Game/GameSession/ModelManager.gd#L56) to `MOVE` or `ATTACK`):
```
army = {
	name = "TANK TEST"
	location = 292
	regiment = {
		name = "Tank"
		type = tank
		home = 300
	}
}

navy = {
	name = "STEAM TEST"
	location = 2732
	ship = {
		name = "Steam Transport"
		type = steam_transport
	}
}
```