### PR TITLE
Use UTF8 encoding and simplify godot string conversion

### DIFF
--- a/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
@@ -9,10 +9,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
-using OpenVic::Utilities::std_view_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string_name;
-
 Error GFXMaskedFlagTexture::_generate_combined_image() {
 	ERR_FAIL_NULL_V(overlay_image, FAILED);
 	/* Whether we've already set the ImageTexture to an image of the right dimensions and format,
@@ -127,11 +123,11 @@ Error GFXMaskedFlagTexture::set_gfx_masked_flag(GFX::MaskedFlag const* new_gfx_m
 	AssetManager* asset_manager = AssetManager::get_singleton();
 	ERR_FAIL_NULL_V(asset_manager, FAILED);
 
-	const StringName overlay_file = std_view_to_godot_string_name(new_gfx_masked_flag->get_overlay_file());
+	const StringName overlay_file = Utilities::std_to_godot_string(new_gfx_masked_flag->get_overlay_file());
 	const Ref<Image> new_overlay_image = asset_manager->get_image(overlay_file);
 	ERR_FAIL_NULL_V_MSG(new_overlay_image, FAILED, vformat("Failed to load flag overlay image: %s", overlay_file));
 
-	const StringName mask_file = std_view_to_godot_string_name(new_gfx_masked_flag->get_mask_file());
+	const StringName mask_file = Utilities::std_to_godot_string(new_gfx_masked_flag->get_mask_file());
 	const Ref<Image> new_mask_image = asset_manager->get_image(mask_file);
 	ERR_FAIL_NULL_V_MSG(new_mask_image, FAILED, vformat("Failed to load flag mask image: %s", mask_file));
 
@@ -152,14 +148,15 @@ Error GFXMaskedFlagTexture::set_gfx_masked_flag_name(String const& gfx_masked_fl
 	ERR_FAIL_NULL_V_MSG(
 		new_masked_flag, FAILED, vformat(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_masked_flag_name,
-			std_view_to_godot_string(sprite->get_type()), std_view_to_godot_string(GFX::MaskedFlag::get_type_static())
+			Utilities::std_to_godot_string(sprite->get_type()),
+			Utilities::std_to_godot_string(GFX::MaskedFlag::get_type_static())
 		)
 	);
 	return set_gfx_masked_flag(new_masked_flag);
 }
 
 String GFXMaskedFlagTexture::get_gfx_masked_flag_name() const {
-	return gfx_masked_flag != nullptr ? std_view_to_godot_string(gfx_masked_flag->get_name()) : String {};
+	return gfx_masked_flag != nullptr ? Utilities::std_to_godot_string(gfx_masked_flag->get_name()) : String {};
 }
 
 Error GFXMaskedFlagTexture::set_flag_country_and_type(
@@ -197,7 +194,7 @@ Error GFXMaskedFlagTexture::set_flag_country_name_and_type(
 	ERR_FAIL_NULL_V(game_singleton, FAILED);
 	CountryDefinition const* new_flag_country =
 		game_singleton->get_definition_manager().get_country_definition_manager().get_country_definition_by_identifier(
-			godot_to_std_string(new_flag_country_name)
+			Utilities::godot_to_std_string(new_flag_country_name)
 		);
 	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, vformat("Country not found: %s", new_flag_country_name));
 	return set_flag_country_and_type(new_flag_country, new_flag_type);
@@ -216,12 +213,12 @@ Error GFXMaskedFlagTexture::set_flag_country_name(String const& new_flag_country
 	ERR_FAIL_NULL_V(game_singleton, FAILED);
 	CountryDefinition const* new_flag_country =
 		game_singleton->get_definition_manager().get_country_definition_manager().get_country_definition_by_identifier(
-			godot_to_std_string(new_flag_country_name)
+			Utilities::godot_to_std_string(new_flag_country_name)
 		);
 	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, vformat("Country not found: %s", new_flag_country_name));
 	return set_flag_country(new_flag_country);
 }
 
 String GFXMaskedFlagTexture::get_flag_country_name() const {
-	return flag_country != nullptr ? std_view_to_godot_string(flag_country->get_identifier()) : String {};
+	return flag_country != nullptr ? Utilities::std_to_godot_string(flag_country->get_identifier()) : String {};
 }

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
@@ -8,8 +8,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::std_view_to_godot_string;
-
 StringName const& GFXPieChartTexture::_slice_identifier_key() {
 	static const StringName slice_identifier_key = "identifier";
 	return slice_identifier_key;
@@ -109,7 +107,8 @@ Error GFXPieChartTexture::set_slices_array(godot_pie_chart_data_t const& new_sli
 	for (int32_t i = 0; i < new_slices.size(); ++i) {
 		Dictionary const& slice_dict = new_slices[i];
 		ERR_CONTINUE_MSG(
-			!slice_dict.has(_slice_colour_key()) || !slice_dict.has(_slice_weight_key()), vformat("Invalid slice keys at index %d", i)
+			!slice_dict.has(_slice_colour_key()) || !slice_dict.has(_slice_weight_key()),
+			vformat("Invalid slice keys at index %d", i)
 		);
 		const slice_t slice = std::make_pair(slice_dict[_slice_colour_key()], slice_dict[_slice_weight_key()]);
 		if (slice.second > 0.0f) {
@@ -171,12 +170,13 @@ Error GFXPieChartTexture::set_gfx_pie_chart_name(String const& gfx_pie_chart_nam
 	ERR_FAIL_NULL_V_MSG(
 		new_pie_chart, FAILED, vformat(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_pie_chart_name,
-			std_view_to_godot_string(sprite->get_type()), std_view_to_godot_string(GFX::PieChart::get_type_static())
+			Utilities::std_to_godot_string(sprite->get_type()),
+			Utilities::std_to_godot_string(GFX::PieChart::get_type_static())
 		)
 	);
 	return set_gfx_pie_chart(new_pie_chart);
 }
 
 String GFXPieChartTexture::get_gfx_pie_chart_name() const {
-	return gfx_pie_chart != nullptr ? std_view_to_godot_string(gfx_pie_chart->get_name()) : String {};
+	return gfx_pie_chart != nullptr ? Utilities::std_to_godot_string(gfx_pie_chart->get_name()) : String {};
 }

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
@@ -85,7 +85,7 @@ namespace OpenVic {
 			for (size_t idx = 0; idx < array.size(); ++idx) {
 				auto const& [key, val] = sorted_dist[idx];
 				Dictionary sub_dict;
-				sub_dict[_slice_identifier_key()] = Utilities::std_view_to_godot_string(key->get_identifier());
+				sub_dict[_slice_identifier_key()] = Utilities::std_to_godot_string(key->get_identifier());
 				sub_dict[_slice_colour_key()] = Utilities::to_godot_color(key->get_colour());
 				sub_dict[_slice_weight_key()] = val.to_float();
 				array[idx] = std::move(sub_dict);

--- a/extension/src/openvic-extension/classes/GFXSpriteTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXSpriteTexture.cpp
@@ -11,13 +11,12 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::std_view_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string_name;
-
 void GFXSpriteTexture::_bind_methods() {
 	OV_BIND_METHOD(GFXSpriteTexture::clear);
 
-	OV_BIND_METHOD(GFXSpriteTexture::set_gfx_texture_sprite_name, { "gfx_texture_sprite_name", "icon" }, DEFVAL(GFX::NO_FRAMES));
+	OV_BIND_METHOD(
+		GFXSpriteTexture::set_gfx_texture_sprite_name, { "gfx_texture_sprite_name", "icon" }, DEFVAL(GFX::NO_FRAMES)
+	);
 	OV_BIND_METHOD(GFXSpriteTexture::get_gfx_texture_sprite_name);
 
 	OV_BIND_METHOD(GFXSpriteTexture::set_icon_index, { "new_icon_index" });
@@ -31,7 +30,9 @@ void GFXSpriteTexture::_bind_methods() {
 GFXSpriteTexture::GFXSpriteTexture()
   : gfx_texture_sprite { nullptr }, icon_index { GFX::NO_FRAMES }, icon_count { GFX::NO_FRAMES } {}
 
-Ref<GFXSpriteTexture> GFXSpriteTexture::make_gfx_sprite_texture(GFX::TextureSprite const* gfx_texture_sprite, GFX::frame_t icon) {
+Ref<GFXSpriteTexture> GFXSpriteTexture::make_gfx_sprite_texture(
+	GFX::TextureSprite const* gfx_texture_sprite, GFX::frame_t icon
+) {
 	Ref<GFXSpriteTexture> texture;
 	texture.instantiate();
 	ERR_FAIL_NULL_V(texture, nullptr);
@@ -56,7 +57,7 @@ Error GFXSpriteTexture::set_gfx_texture_sprite(GFX::TextureSprite const* new_gfx
 		AssetManager* asset_manager = AssetManager::get_singleton();
 		ERR_FAIL_NULL_V(asset_manager, FAILED);
 
-		const StringName texture_file = std_view_to_godot_string_name(new_gfx_texture_sprite->get_texture_file());
+		const StringName texture_file = Utilities::std_to_godot_string(new_gfx_texture_sprite->get_texture_file());
 
 		/* Needed for GFXButtonStateTexture, AssetManager::get_texture will re-use this image from its internal cache. */
 		const Ref<Image> image = asset_manager->get_image(texture_file);
@@ -98,14 +99,15 @@ Error GFXSpriteTexture::set_gfx_texture_sprite_name(String const& gfx_texture_sp
 	ERR_FAIL_NULL_V_MSG(
 		new_texture_sprite, FAILED, vformat(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_texture_sprite_name,
-			std_view_to_godot_string(sprite->get_type()), std_view_to_godot_string(GFX::TextureSprite::get_type_static())
+			Utilities::std_to_godot_string(sprite->get_type()),
+			Utilities::std_to_godot_string(GFX::TextureSprite::get_type_static())
 		)
 	);
 	return set_gfx_texture_sprite(new_texture_sprite, icon);
 }
 
 String GFXSpriteTexture::get_gfx_texture_sprite_name() const {
-	return gfx_texture_sprite != nullptr ? std_view_to_godot_string(gfx_texture_sprite->get_name()) : String {};
+	return gfx_texture_sprite != nullptr ? Utilities::std_to_godot_string(gfx_texture_sprite->get_name()) : String {};
 }
 
 Error GFXSpriteTexture::set_icon_index(int32_t new_icon_index) {

--- a/extension/src/openvic-extension/classes/GUIListBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIListBox.cpp
@@ -11,8 +11,6 @@ using namespace OpenVic;
 using namespace godot;
 using namespace OpenVic::Utilities::literals;
 
-using OpenVic::Utilities::std_view_to_godot_string;
-
 /* StringNames cannot be constructed until Godot has called StringName::setup(),
  * so we must use wrapper functions to delay their initialisation. */
 StringName const& GUIListBox::_signal_scroll_index_changed() {
@@ -252,7 +250,7 @@ Error GUIListBox::set_gui_listbox(GUI::ListBox const* new_gui_listbox) {
 
 	gui_listbox = new_gui_listbox;
 
-	const String scrollbar_name = std_view_to_godot_string(gui_listbox->get_scrollbar_name());
+	const String scrollbar_name = Utilities::std_to_godot_string(gui_listbox->get_scrollbar_name());
 
 	Error err = OK;
 
@@ -300,7 +298,7 @@ Error GUIListBox::set_gui_listbox(GUI::ListBox const* new_gui_listbox) {
 }
 
 String GUIListBox::get_gui_listbox_name() const {
-	return gui_listbox != nullptr ? std_view_to_godot_string(gui_listbox->get_name()) : String {};
+	return gui_listbox != nullptr ? Utilities::std_to_godot_string(gui_listbox->get_name()) : String {};
 }
 
 GUIScrollbar* GUIListBox::get_scrollbar() const {

--- a/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
@@ -9,8 +9,6 @@
 using namespace OpenVic;
 using namespace godot;
 
-using OpenVic::Utilities::std_view_to_godot_string;
-
 Error GUIOverlappingElementsBox::_update_child_positions() {
 	ERR_FAIL_NULL_V(gui_overlapping_elements_box, FAILED);
 	const int32_t child_count = get_child_count();
@@ -108,7 +106,7 @@ Error GUIOverlappingElementsBox::set_child_count(int32_t new_count) {
 			)
 		);
 		Error err = OK;
-		const String gui_child_element_name = std_view_to_godot_string(gui_child_element->get_name()) + "_";
+		const String gui_child_element_name = Utilities::std_to_godot_string(gui_child_element->get_name()) + "_";
 		do {
 			Control* child = nullptr;
 			const String name = gui_child_element_name + itos(child_count);
@@ -155,7 +153,9 @@ Error GUIOverlappingElementsBox::set_gui_overlapping_elements_box(
 }
 
 String GUIOverlappingElementsBox::get_gui_overlapping_elements_box_name() const {
-	return gui_overlapping_elements_box != nullptr ? std_view_to_godot_string(gui_overlapping_elements_box->get_name()) : String {};
+	return gui_overlapping_elements_box != nullptr
+		? Utilities::std_to_godot_string(gui_overlapping_elements_box->get_name())
+		: String {};
 }
 
 Error GUIOverlappingElementsBox::set_gui_child_element(GUI::Element const* new_gui_child_element) {
@@ -184,5 +184,5 @@ Error GUIOverlappingElementsBox::set_gui_child_element_name(
 }
 
 String GUIOverlappingElementsBox::get_gui_child_element_name() const {
-	return gui_child_element != nullptr ? std_view_to_godot_string(gui_child_element->get_name()) : String {};
+	return gui_child_element != nullptr ? Utilities::std_to_godot_string(gui_child_element->get_name()) : String {};
 }

--- a/extension/src/openvic-extension/classes/GUIScrollbar.cpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.cpp
@@ -11,9 +11,6 @@
 using namespace OpenVic;
 using namespace godot;
 
-using OpenVic::Utilities::std_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string;
-
 /* StringNames cannot be constructed until Godot has called StringName::setup(),
  * so we must use wrapper functions to delay their initialisation. */
 StringName const& GUIScrollbar::signal_value_changed() {
@@ -360,7 +357,7 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 
 	gui_scrollbar = new_gui_scrollbar;
 
-	const String gui_scrollbar_name = std_view_to_godot_string(gui_scrollbar->get_name());
+	const String gui_scrollbar_name = Utilities::std_to_godot_string(gui_scrollbar->get_name());
 
 	orientation = gui_scrollbar->is_horizontal() ? HORIZONTAL : VERTICAL;
 	length_override = 0.0f;
@@ -374,7 +371,7 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 		ERR_FAIL_NULL_V_MSG(element, false, vformat(
 			"Invalid %s element for GUIScrollbar %s - null!", target, gui_scrollbar_name
 		));
-		const String element_name = std_view_to_godot_string(element->get_name());
+		const String element_name = Utilities::std_to_godot_string(element->get_name());
 
 		/* Get Sprite, convert to TextureSprite, use to make a GFXSpriteTexture. */
 		GFX::Sprite const* sprite = element->get_sprite();
@@ -384,8 +381,9 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 		GFX::TextureSprite const* texture_sprite = sprite->cast_to<GFX::TextureSprite>();
 		ERR_FAIL_NULL_V_MSG(texture_sprite, false, vformat(
 			"Invalid %s element %s for GUIScrollbar %s - sprite type is %s with base type %s, expected base %s!", target,
-			element_name, gui_scrollbar_name, std_view_to_godot_string(sprite->get_type()),
-			std_view_to_godot_string(sprite->get_base_type()), std_view_to_godot_string(GFX::TextureSprite::get_type_static())
+			element_name, gui_scrollbar_name, Utilities::std_to_godot_string(sprite->get_type()),
+			Utilities::std_to_godot_string(sprite->get_base_type()),
+			Utilities::std_to_godot_string(GFX::TextureSprite::get_type_static())
 		));
 		texture = GFXSpriteTexture::make_gfx_sprite_texture(texture_sprite);
 		ERR_FAIL_NULL_V_MSG(texture, false, vformat(
@@ -427,8 +425,8 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 	fixed_point_t step_size = gui_scrollbar->get_step_size();
 	if (step_size <= 0) {
 		UtilityFunctions::push_error(
-			"Invalid step size ", std_to_godot_string(step_size.to_string()), " for GUIScrollbar ", gui_scrollbar_name,
-			" - not positive! Defaulting to 1."
+			"Invalid step size ", Utilities::std_to_godot_string(step_size.to_string()), " for GUIScrollbar ",
+			gui_scrollbar_name, " - not positive! Defaulting to 1."
 		);
 		step_size = 1;
 		ret = false;
@@ -446,7 +444,9 @@ Error GUIScrollbar::set_gui_scrollbar_name(String const& gui_scene, String const
 	if (gui_scene.is_empty() && gui_scrollbar_name.is_empty()) {
 		return set_gui_scrollbar(nullptr);
 	}
-	ERR_FAIL_COND_V_MSG(gui_scene.is_empty() || gui_scrollbar_name.is_empty(), FAILED, "GUI scene or scrollbar name is empty!");
+	ERR_FAIL_COND_V_MSG(
+		gui_scene.is_empty() || gui_scrollbar_name.is_empty(), FAILED, "GUI scene or scrollbar name is empty!"
+	);
 
 	GUI::Element const* gui_element = UITools::get_gui_element(gui_scene, gui_scrollbar_name);
 	ERR_FAIL_NULL_V(gui_element, FAILED);
@@ -456,7 +456,7 @@ Error GUIScrollbar::set_gui_scrollbar_name(String const& gui_scene, String const
 }
 
 String GUIScrollbar::get_gui_scrollbar_name() const {
-	return gui_scrollbar != nullptr ? std_view_to_godot_string(gui_scrollbar->get_name()) : String {};
+	return gui_scrollbar != nullptr ? Utilities::std_to_godot_string(gui_scrollbar->get_name()) : String {};
 }
 
 void GUIScrollbar::set_value(int32_t new_value, bool signal) {

--- a/extension/src/openvic-extension/singletons/AssetManager.cpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.cpp
@@ -9,9 +9,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
-using OpenVic::Utilities::std_to_godot_string;
-
 void AssetManager::_bind_methods() {
 	OV_BIND_METHOD(AssetManager::get_image, { "path", "load_flags" }, DEFVAL(LOAD_FLAG_CACHE_IMAGE));
 	OV_BIND_METHOD(AssetManager::get_texture, { "path", "load_flags" }, DEFVAL(LOAD_FLAG_CACHE_TEXTURE));
@@ -41,8 +38,9 @@ Ref<Image> AssetManager::_load_image(StringName const& path, bool flip_y) {
 	GameSingleton* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
 
-	const String lookedup_path =
-		std_to_godot_string(game_singleton->get_dataloader().lookup_image_file(godot_to_std_string(path)).string());
+	const String lookedup_path = Utilities::std_to_godot_string(
+		game_singleton->get_dataloader().lookup_image_file(Utilities::godot_to_std_string(path)).string()
+	);
 	ERR_FAIL_COND_V_MSG(lookedup_path.is_empty(), nullptr, vformat("Failed to look up image: %s", path));
 
 	const Ref<Image> image = Utilities::load_godot_image(lookedup_path);
@@ -145,8 +143,9 @@ Ref<Font> AssetManager::get_font(StringName const& name) {
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
 
 	const String font_path = font_dir + name + font_ext;
-	const String lookedup_font_path =
-		std_to_godot_string(game_singleton->get_dataloader().lookup_file(godot_to_std_string(font_path)).string());
+	const String lookedup_font_path = Utilities::std_to_godot_string(
+		game_singleton->get_dataloader().lookup_file(Utilities::godot_to_std_string(font_path)).string()
+	);
 	if (lookedup_font_path.is_empty()) {
 		fonts.emplace(name, nullptr);
 

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -16,11 +16,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
-using OpenVic::Utilities::std_to_godot_string;
-using OpenVic::Utilities::std_to_godot_string_name;
-using OpenVic::Utilities::std_view_to_godot_string;
-
 /* Maximum width or height a GPU texture can have. */
 static constexpr int32_t GPU_DIM_LIMIT = 0x3FFF;
 
@@ -110,13 +105,13 @@ GameSingleton::~GameSingleton() {
 
 void GameSingleton::setup_logger() {
 	Logger::set_info_func([](std::string&& str) {
-		UtilityFunctions::print(std_to_godot_string(str));
+		UtilityFunctions::print(Utilities::std_to_godot_string(str));
 	});
 	Logger::set_warning_func([](std::string&& str) {
-		UtilityFunctions::push_warning(std_to_godot_string(str));
+		UtilityFunctions::push_warning(Utilities::std_to_godot_string(str));
 	});
 	Logger::set_error_func([](std::string&& str) {
-		UtilityFunctions::push_error(std_to_godot_string(str));
+		UtilityFunctions::push_error(Utilities::std_to_godot_string(str));
 	});
 }
 
@@ -284,7 +279,7 @@ TypedArray<Dictionary> GameSingleton::get_province_names() const {
 
 		Dictionary province_dict;
 
-		province_dict[identifier_key] = std_view_to_godot_string(province.get_identifier());
+		province_dict[identifier_key] = Utilities::std_to_godot_string(province.get_identifier());
 		province_dict[position_key] = Utilities::to_godot_fvec2(province.get_text_position()) / get_map_dims();
 
 		const float rotation = province.get_text_rotation().to_float();
@@ -310,14 +305,14 @@ int32_t GameSingleton::get_mapmode_count() const {
 String GameSingleton::get_mapmode_identifier(int32_t index) const {
 	Mapmode const* mapmode = get_definition_manager().get_mapmode_manager().get_mapmode_by_index(index);
 	if (mapmode != nullptr) {
-		return std_view_to_godot_string(mapmode->get_identifier());
+		return Utilities::std_to_godot_string(mapmode->get_identifier());
 	}
 	return String {};
 }
 
 Error GameSingleton::set_mapmode(String const& identifier) {
 	Mapmode const* mapmode =
-		get_definition_manager().get_mapmode_manager().get_mapmode_by_identifier(godot_to_std_string(identifier));
+		get_definition_manager().get_mapmode_manager().get_mapmode_by_identifier(Utilities::godot_to_std_string(identifier));
 	ERR_FAIL_NULL_V_MSG(mapmode, FAILED, vformat("Failed to find mapmode with identifier: %s", identifier));
 	mapmode_index = mapmode->get_index();
 	return _update_colour_image();
@@ -500,7 +495,7 @@ Error GameSingleton::_load_flag_sheet() {
 	/* Generate flag type - index lookup map */
 	flag_type_index_map.clear();
 	for (std::string const& type : government_type_manager.get_flag_types()) {
-		flag_type_index_map.emplace(std_to_godot_string_name(type), static_cast<int32_t>(flag_type_index_map.size()));
+		flag_type_index_map.emplace(Utilities::std_to_godot_string(type), static_cast<int32_t>(flag_type_index_map.size()));
 	}
 
 	flag_sheet_count = country_definition_manager.get_country_definition_count() * flag_type_index_map.size();
@@ -512,7 +507,7 @@ Error GameSingleton::_load_flag_sheet() {
 
 	Error ret = OK;
 	for (CountryDefinition const& country : country_definition_manager.get_country_definitions()) {
-		const String country_name = std_view_to_godot_string(country.get_identifier());
+		const String country_name = Utilities::std_to_godot_string(country.get_identifier());
 
 		for (auto const& [flag_type, flag_type_index] : flag_type_index_map) {
 			static const String flag_directory = "gfx/flags/";
@@ -590,7 +585,7 @@ Error GameSingleton::_load_flag_sheet() {
 Error GameSingleton::load_defines_compatibility_mode(PackedStringArray const& file_paths) {
 	Dataloader::path_vector_t roots;
 	for (String const& path : file_paths) {
-		roots.push_back(godot_to_std_string(path));
+		roots.push_back(Utilities::godot_to_std_string(path));
 	}
 
 	Error err = OK;
@@ -618,9 +613,11 @@ Error GameSingleton::load_defines_compatibility_mode(PackedStringArray const& fi
 }
 
 String GameSingleton::search_for_game_path(String const& hint_path) {
-	return std_to_godot_string(Dataloader::search_for_game_path(godot_to_std_string(hint_path)).string());
+	return Utilities::std_to_godot_string(
+		Dataloader::search_for_game_path(Utilities::godot_to_std_string(hint_path)).string()
+	);
 }
 
 String GameSingleton::lookup_file_path(String const& path) const {
-	return std_to_godot_string(get_dataloader().lookup_file(godot_to_std_string(path)).string());
+	return Utilities::std_to_godot_string(get_dataloader().lookup_file(Utilities::godot_to_std_string(path)).string());
 }

--- a/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
+++ b/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
@@ -136,8 +136,8 @@ bool LoadLocalisation::add_message(std::string_view key, Dataloader::locale_t lo
 			translation, false, vformat("Failed to get translation object: %s", Dataloader::locale_names[locale])
 		);
 	}
-	const StringName godot_key = Utilities::std_view_to_godot_string_name(key);
-	const StringName godot_localisation = Utilities::std_view_to_godot_string_name(localisation);
+	const StringName godot_key = Utilities::std_to_godot_string(key);
+	const StringName godot_localisation = Utilities::std_to_godot_string(localisation);
 	if (0) {
 		const StringName old_localisation = translation->get_message(godot_key);
 		if (!old_localisation.is_empty()) {

--- a/extension/src/openvic-extension/singletons/ModelSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/ModelSingleton.cpp
@@ -13,10 +13,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
-using OpenVic::Utilities::std_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string;
-
 void ModelSingleton::_bind_methods() {
 	OV_BIND_METHOD(ModelSingleton::get_units);
 	OV_BIND_METHOD(ModelSingleton::get_cultural_gun_model, { "culture" });
@@ -47,7 +43,7 @@ GFX::Actor const* ModelSingleton::get_actor(std::string_view name, bool error_on
 		game_singleton->get_definition_manager().get_ui_manager().get_cast_object_by_identifier<GFX::Actor>(name);
 
 	if (error_on_fail) {
-		ERR_FAIL_NULL_V_MSG(actor, nullptr, vformat("Failed to find actor \"%s\"", std_view_to_godot_string(name)));
+		ERR_FAIL_NULL_V_MSG(actor, nullptr, vformat("Failed to find actor \"%s\"", Utilities::std_to_godot_string(name)));
 	}
 
 	return actor;
@@ -62,7 +58,7 @@ GFX::Actor const* ModelSingleton::get_cultural_actor(
 	ERR_FAIL_COND_V_MSG(
 		culture.empty() || name.empty(), nullptr, vformat(
 			"Failed to find actor \"%s\" for culture \"%s\" - neither can be empty",
-			std_view_to_godot_string(name), std_view_to_godot_string(culture)
+			Utilities::std_to_godot_string(name), Utilities::std_to_godot_string(culture)
 		)
 	);
 
@@ -90,8 +86,8 @@ GFX::Actor const* ModelSingleton::get_cultural_actor(
 
 	ERR_FAIL_NULL_V_MSG(
 		actor, nullptr, vformat(
-			"Failed to find actor \"%s\" for culture \"%s\"", std_view_to_godot_string(name),
-			std_view_to_godot_string(culture)
+			"Failed to find actor \"%s\" for culture \"%s\"", Utilities::std_to_godot_string(name),
+			Utilities::std_to_godot_string(culture)
 		)
 	);
 
@@ -109,7 +105,7 @@ Dictionary ModelSingleton::get_animation_dict(GFX::Actor::Animation const& anima
 
 	Dictionary dict;
 
-	dict[file_key] = std_view_to_godot_string(animation.get_file());
+	dict[file_key] = Utilities::std_to_godot_string(animation.get_file());
 	dict[time_key] = animation.get_scroll_time().to_float();
 
 	animation_cache.emplace(&animation, dict);
@@ -132,7 +128,7 @@ Dictionary ModelSingleton::get_model_dict(GFX::Actor const& actor) {
 
 	Dictionary dict;
 
-	dict[file_key] = std_view_to_godot_string(actor.get_model_file());
+	dict[file_key] = Utilities::std_to_godot_string(actor.get_model_file());
 	dict[scale_key] = actor.get_scale().to_float();
 
 	const auto set_animation = [this, &dict](StringName const& key, std::optional<GFX::Actor::Animation> const& animation) {
@@ -164,13 +160,14 @@ Dictionary ModelSingleton::get_model_dict(GFX::Actor const& actor) {
 				ERR_CONTINUE_MSG(
 					attachment_actor == nullptr, vformat(
 						"Failed to find \"%s\" attachment actor for actor \"%s\"",
-						std_view_to_godot_string(attachment.get_actor_name()), std_view_to_godot_string(actor.get_name())
+						Utilities::std_to_godot_string(attachment.get_actor_name()),
+						Utilities::std_to_godot_string(actor.get_name())
 					)
 				);
 
 				Dictionary attachment_dict;
 
-				attachment_dict[attachment_node_key] = std_view_to_godot_string(attachment.get_attach_node());
+				attachment_dict[attachment_node_key] = Utilities::std_to_godot_string(attachment.get_attach_node());
 				attachment_dict[attachment_model_key] = get_model_dict(*attachment_actor);
 
 				attachments_array[idx] = std::move(attachment_dict);
@@ -184,7 +181,7 @@ Dictionary ModelSingleton::get_model_dict(GFX::Actor const& actor) {
 		} else {
 			UtilityFunctions::push_error(
 				"Failed to resize attachments array to the correct size (", static_cast<int64_t>(attachments.size()),
-				") for model for actor \"", std_view_to_godot_string(actor.get_name()), "\""
+				") for model for actor \"", Utilities::std_to_godot_string(actor.get_name()), "\""
 			);
 		}
 	}
@@ -225,7 +222,7 @@ bool ModelSingleton::add_unit_dict(
 
 	/* Last unit to enter the province is shown on top. */
 	_UnitInstanceGroup const& unit = *units.back();
-	ERR_FAIL_COND_V_MSG(unit.empty(), false, vformat("Empty unit \"%s\"", std_view_to_godot_string(unit.get_name())));
+	ERR_FAIL_COND_V_MSG(unit.empty(), false, vformat("Empty unit \"%s\"", Utilities::std_to_godot_string(unit.get_name())));
 
 	CountryDefinition const* country = unit.get_country()->get_country_definition();
 
@@ -233,7 +230,7 @@ bool ModelSingleton::add_unit_dict(
 	UnitType const* display_unit_type = unit.get_display_unit_type();
 	ERR_FAIL_NULL_V_MSG(
 		display_unit_type, false, vformat(
-			"Failed to get display unit type for unit \"%s\"", std_view_to_godot_string(unit.get_name())
+			"Failed to get display unit type for unit \"%s\"", Utilities::std_to_godot_string(unit.get_name())
 		)
 	);
 
@@ -255,9 +252,9 @@ bool ModelSingleton::add_unit_dict(
 		} else {
 			UtilityFunctions::push_error(
 				"Mount sprite and attach node must both be set or both be empty - regiment type \"",
-				std_view_to_godot_string(regiment_type->get_identifier()), "\" has mount \"",
-				std_view_to_godot_string(regiment_type->get_sprite_mount()), "\" and attach node \"",
-				std_view_to_godot_string(regiment_type->get_sprite_mount_attach_node()), "\""
+				Utilities::std_to_godot_string(regiment_type->get_identifier()), "\" has mount \"",
+				Utilities::std_to_godot_string(regiment_type->get_sprite_mount()), "\" and attach node \"",
+				Utilities::std_to_godot_string(regiment_type->get_sprite_mount_attach_node()), "\""
 			);
 			ret = false;
 		}
@@ -272,15 +269,15 @@ bool ModelSingleton::add_unit_dict(
 	ERR_FAIL_NULL_V_MSG(
 		actor, false, vformat(
 			"Failed to find \"%s\" actor of graphical culture type \"%s\" for unit \"%s\"",
-			std_view_to_godot_string(display_unit_type->get_sprite()),
-			std_view_to_godot_string(graphical_culture_type.get_identifier()),
-			std_view_to_godot_string(unit.get_name())
+			Utilities::std_to_godot_string(display_unit_type->get_sprite()),
+			Utilities::std_to_godot_string(graphical_culture_type.get_identifier()),
+			Utilities::std_to_godot_string(unit.get_name())
 		)
 	);
 
 	Dictionary dict;
 
-	dict[culture_key] = std_view_to_godot_string(graphical_culture_type.get_identifier());
+	dict[culture_key] = Utilities::std_to_godot_string(graphical_culture_type.get_identifier());
 
 	dict[model_key] = get_model_dict(*actor);
 
@@ -289,13 +286,13 @@ bool ModelSingleton::add_unit_dict(
 
 		if (mount_actor != nullptr) {
 			dict[mount_model_key] = get_model_dict(*mount_actor);
-			dict[mount_attach_node_key] = std_view_to_godot_string(mount_attach_node_name);
+			dict[mount_attach_node_key] = Utilities::std_to_godot_string(mount_attach_node_name);
 		} else {
 			UtilityFunctions::push_error(vformat(
 				"Failed to find \"%s\" mount actor of graphical culture type \"%s\" for unit \"%s\"",
-				std_view_to_godot_string(mount_actor_name),
-				std_view_to_godot_string(graphical_culture_type.get_identifier()),
-				std_view_to_godot_string(unit.get_name())
+				Utilities::std_to_godot_string(mount_actor_name),
+				Utilities::std_to_godot_string(graphical_culture_type.get_identifier()),
+				Utilities::std_to_godot_string(unit.get_name())
 			));
 			ret = false;
 		}
@@ -337,13 +334,13 @@ TypedArray<Dictionary> ModelSingleton::get_units() {
 		if (province.get_province_definition().is_water()) {
 			if (!add_unit_dict(province.get_navies(), ret)) {
 				UtilityFunctions::push_error(
-					"Error adding navy to province \"", std_view_to_godot_string(province.get_identifier()), "\""
+					"Error adding navy to province \"", Utilities::std_to_godot_string(province.get_identifier()), "\""
 				);
 			}
 		} else {
 			if (!add_unit_dict(province.get_armies(), ret)) {
 				UtilityFunctions::push_error(
-					"Error adding army to province \"", std_view_to_godot_string(province.get_identifier()), "\""
+					"Error adding army to province \"", Utilities::std_to_godot_string(province.get_identifier()), "\""
 				);
 			}
 		}
@@ -357,7 +354,7 @@ TypedArray<Dictionary> ModelSingleton::get_units() {
 Dictionary ModelSingleton::get_cultural_gun_model(String const& culture) {
 	static constexpr std::string_view gun_actor_name = "Gun1";
 
-	GFX::Actor const* actor = get_cultural_actor(godot_to_std_string(culture), gun_actor_name, {});
+	GFX::Actor const* actor = get_cultural_actor(Utilities::godot_to_std_string(culture), gun_actor_name, {});
 
 	ERR_FAIL_NULL_V(actor, {});
 
@@ -367,7 +364,7 @@ Dictionary ModelSingleton::get_cultural_gun_model(String const& culture) {
 Dictionary ModelSingleton::get_cultural_helmet_model(String const& culture) {
 	static constexpr std::string_view helmet_actor_name = "Helmet1";
 
-	GFX::Actor const* actor = get_cultural_actor(godot_to_std_string(culture), helmet_actor_name, {});
+	GFX::Actor const* actor = get_cultural_actor(Utilities::godot_to_std_string(culture), helmet_actor_name, {});
 
 	ERR_FAIL_NULL_V(actor, {});
 
@@ -438,8 +435,8 @@ bool ModelSingleton::add_building_dict(
 	ERR_FAIL_NULL_V_MSG(
 		actor, false, vformat(
 			"Failed to find \"%s\" actor for building \"%s\" in province \"%s\"",
-			std_to_godot_string(actor_name), std_view_to_godot_string(building.get_identifier()),
-			std_view_to_godot_string(province.get_identifier())
+			Utilities::std_to_godot_string(actor_name), Utilities::std_to_godot_string(building.get_identifier()),
+			Utilities::std_to_godot_string(province.get_identifier())
 		)
 	);
 
@@ -474,8 +471,8 @@ TypedArray<Dictionary> ModelSingleton::get_buildings() {
 			for (BuildingInstance const& building : province.get_buildings()) {
 				if (!add_building_dict(building, province, ret)) {
 					UtilityFunctions::push_error(
-						"Error adding building \"", std_view_to_godot_string(building.get_identifier()), "\" to province \"",
-						std_view_to_godot_string(province.get_identifier()), "\""
+						"Error adding building \"", Utilities::std_to_godot_string(building.get_identifier()),
+						"\" to province \"", Utilities::std_to_godot_string(province.get_identifier()), "\""
 					);
 				}
 			}

--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -13,8 +13,6 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::std_view_to_godot_string;
-
 /* POPULATION MENU */
 
 Error MenuSingleton::_population_menu_update_provinces() {
@@ -152,7 +150,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 
 				province_dict[type_key] = population_menu_t::LIST_ENTRY_PROVINCE;
 				province_dict[index_key] = index;
-				province_dict[name_key] = std_view_to_godot_string(province_entry.province.get_identifier());
+				province_dict[name_key] = Utilities::std_to_godot_string(province_entry.province.get_identifier());
 				province_dict[size_key] = province_entry.province.get_total_population();
 				province_dict[change_key] = 0;
 				province_dict[selected_key] = province_entry.selected;
@@ -541,7 +539,7 @@ Error MenuSingleton::population_menu_update_locale_sort_cache() {
 		sorted_items.resize(items.size());
 
 		for (size_t idx = 0; idx < items.size(); ++idx) {
-			String identifier = std_view_to_godot_string(items[idx].get_identifier());
+			String identifier = Utilities::std_to_godot_string(items[idx].get_identifier());
 			if constexpr (std::is_same_v<T, ProvinceInstance>) {
 				identifier = GUINode::format_province_name(identifier);
 			}
@@ -676,10 +674,10 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_rows(int32_t start
 
 		pop_dict[pop_size_key] = pop->get_size();
 		pop_dict[pop_type_icon_key] = pop->get_type().get_sprite();
-		pop_dict[pop_culture_key] = std_view_to_godot_string(pop->get_culture().get_identifier());
+		pop_dict[pop_culture_key] = Utilities::std_to_godot_string(pop->get_culture().get_identifier());
 		pop_dict[pop_religion_icon_key] = pop->get_religion().get_icon();
 		if (pop->get_location() != nullptr) {
-			pop_dict[pop_location_key] = std_view_to_godot_string(pop->get_location()->get_identifier());
+			pop_dict[pop_location_key] = Utilities::std_to_godot_string(pop->get_location()->get_identifier());
 		}
 		pop_dict[pop_militancy_key] = pop->get_militancy().to_float();
 		pop_dict[pop_consciousness_key] = pop->get_consciousness().to_float();

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -26,15 +26,11 @@
 using namespace godot;
 using namespace OpenVic;
 
-using OpenVic::Utilities::godot_to_std_string;
-using OpenVic::Utilities::std_view_to_godot_string;
-using OpenVic::Utilities::std_view_to_godot_string_name;
-
 GFX::Sprite const* UITools::get_gfx_sprite(String const& gfx_sprite) {
 	GameSingleton* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
 	GFX::Sprite const* sprite = game_singleton->get_definition_manager().get_ui_manager().get_sprite_by_identifier(
-		godot_to_std_string(gfx_sprite)
+		Utilities::godot_to_std_string(gfx_sprite)
 	);
 	ERR_FAIL_NULL_V_MSG(sprite, nullptr, vformat("GFX sprite not found: %s", gfx_sprite));
 	return sprite;
@@ -43,10 +39,11 @@ GFX::Sprite const* UITools::get_gfx_sprite(String const& gfx_sprite) {
 GUI::Element const* UITools::get_gui_element(String const& gui_scene, String const& gui_element) {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
-	GUI::Scene const* scene =
-		game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(godot_to_std_string(gui_scene));
+	GUI::Scene const* scene = game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(
+		Utilities::godot_to_std_string(gui_scene)
+	);
 	ERR_FAIL_NULL_V_MSG(scene, nullptr, vformat("Failed to find GUI scene %s", gui_scene));
-	GUI::Element const* element = scene->get_scene_element_by_identifier(godot_to_std_string(gui_element));
+	GUI::Element const* element = scene->get_scene_element_by_identifier(Utilities::godot_to_std_string(gui_element));
 	ERR_FAIL_NULL_V_MSG(element, nullptr, vformat("Failed to find GUI element %s in GUI scene %s", gui_element, gui_scene));
 	return element;
 }
@@ -54,10 +51,11 @@ GUI::Element const* UITools::get_gui_element(String const& gui_scene, String con
 GUI::Position const* UITools::get_gui_position(String const& gui_scene, String const& gui_position) {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
-	GUI::Scene const* scene =
-		game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(godot_to_std_string(gui_scene));
+	GUI::Scene const* scene = game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(
+		Utilities::godot_to_std_string(gui_scene)
+	);
 	ERR_FAIL_NULL_V_MSG(scene, nullptr, vformat("Failed to find GUI scene %s", gui_scene));
-	GUI::Position const* position = scene->get_scene_position_by_identifier(godot_to_std_string(gui_position));
+	GUI::Position const* position = scene->get_scene_position_by_identifier(Utilities::godot_to_std_string(gui_position));
 	ERR_FAIL_NULL_V_MSG(position, nullptr, vformat("Failed to find GUI position %s in GUI scene %s", gui_position, gui_scene));
 	return position;
 }
@@ -91,7 +89,7 @@ static bool new_control(T*& node, GUI::Element const& element, String const& nam
 	};
 
 	if (name.is_empty()) {
-		node->set_name(std_view_to_godot_string(element.get_name()));
+		node->set_name(Utilities::std_to_godot_string(element.get_name()));
 	} else {
 		node->set_name(name);
 	}
@@ -101,7 +99,9 @@ static bool new_control(T*& node, GUI::Element const& element, String const& nam
 	if (it != orientation_map.end()) {
 		node->set_anchors_and_offsets_preset(it->second);
 	} else {
-		UtilityFunctions::push_error("Invalid orientation for GUI element ", std_view_to_godot_string(element.get_name()));
+		UtilityFunctions::push_error(
+			"Invalid orientation for GUI element ", Utilities::std_to_godot_string(element.get_name())
+		);
 		ret = false;
 	}
 
@@ -141,7 +141,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 
 	GUI::Icon const& icon = static_cast<GUI::Icon const&>(args.element);
 
-	const String icon_name = std_view_to_godot_string(icon.get_name());
+	const String icon_name = Utilities::std_to_godot_string(icon.get_name());
 
 	/* Change to use sprite type to choose Godot node type! */
 	bool ret = true;
@@ -202,7 +202,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 
 			Ref<ImageTexture> back_texture;
 			if (!progress_bar->get_back_texture_file().empty()) {
-				const StringName back_texture_file = std_view_to_godot_string_name(progress_bar->get_back_texture_file());
+				const StringName back_texture_file = Utilities::std_to_godot_string(progress_bar->get_back_texture_file());
 				back_texture = args.asset_manager.get_texture(back_texture_file, LOAD_FLAG_CACHE_TEXTURE | LOAD_FLAG_FLIP_Y);
 				if (back_texture.is_null()) {
 					UtilityFunctions::push_error(
@@ -235,7 +235,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			Ref<ImageTexture> progress_texture;
 			if (!progress_bar->get_progress_texture_file().empty()) {
 				const StringName progress_texture_file =
-					std_view_to_godot_string_name(progress_bar->get_progress_texture_file());
+					Utilities::std_to_godot_string(progress_bar->get_progress_texture_file());
 				progress_texture =
 					args.asset_manager.get_texture(progress_texture_file, LOAD_FLAG_CACHE_TEXTURE | LOAD_FLAG_FLIP_Y);
 				if (progress_texture.is_null()) {
@@ -297,7 +297,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			// TODO - generate line chart
 		} else {
 			UtilityFunctions::push_error(
-				"Invalid sprite type ", std_view_to_godot_string(icon.get_sprite()->get_type()),
+				"Invalid sprite type ", Utilities::std_to_godot_string(icon.get_sprite()->get_type()),
 				" for GUI icon ", icon_name
 			);
 			ret = false;
@@ -325,7 +325,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 	GUI::Button const& button = static_cast<GUI::Button const&>(args.element);
 
 	// TODO - shortcut, clicksound, rotation (?)
-	const String button_name = std_view_to_godot_string(button.get_name());
+	const String button_name = Utilities::std_to_godot_string(button.get_name());
 
 	Button* godot_button = nullptr;
 	bool ret = new_control(godot_button, button, args.name);
@@ -333,7 +333,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 
 	godot_button->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 
-	godot_button->set_text(std_view_to_godot_string(button.get_text()));
+	godot_button->set_text(Utilities::std_to_godot_string(button.get_text()));
 
 	if (button.get_sprite() != nullptr) {
 		Ref<GFXButtonStateHavingTexture> texture;
@@ -352,8 +352,10 @@ static bool generate_button(generate_gui_args_t&& args) {
 				ret = false;
 			}
 		} else {
-			UtilityFunctions::push_error("Invalid sprite type ", std_view_to_godot_string(button.get_sprite()->get_type()),
-				" for GUI button ", button_name);
+			UtilityFunctions::push_error(
+				"Invalid sprite type ", Utilities::std_to_godot_string(button.get_sprite()->get_type()),
+				" for GUI button ", button_name
+			);
 			ret = false;
 		}
 
@@ -385,7 +387,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 	}
 
 	if (button.get_font() != nullptr) {
-		const StringName font_file = std_view_to_godot_string_name(button.get_font()->get_fontname());
+		const StringName font_file = Utilities::std_to_godot_string(button.get_font()->get_fontname());
 		const Ref<Font> font = args.asset_manager.get_font(font_file);
 		if (font.is_valid()) {
 			static const StringName font_theme = "font";
@@ -412,13 +414,13 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 	GUI::Checkbox const& checkbox = static_cast<GUI::Checkbox const&>(args.element);
 
 	// TODO - shortcut
-	const String checkbox_name = std_view_to_godot_string(checkbox.get_name());
+	const String checkbox_name = Utilities::std_to_godot_string(checkbox.get_name());
 
 	Button* godot_button = nullptr;
 	bool ret = new_control(godot_button, checkbox, args.name);
 	ERR_FAIL_NULL_V_MSG(godot_button, false, vformat("Failed to create Button for GUI checkbutton %s", checkbox_name));
 
-	godot_button->set_text(std_view_to_godot_string(checkbox.get_text()));
+	godot_button->set_text(Utilities::std_to_godot_string(checkbox.get_text()));
 
 	godot_button->set_toggle_mode(true);
 
@@ -463,7 +465,7 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 			}
 		} else {
 			UtilityFunctions::push_error(
-				"Invalid sprite type ", std_view_to_godot_string(checkbox.get_sprite()->get_type()),
+				"Invalid sprite type ", Utilities::std_to_godot_string(checkbox.get_sprite()->get_type()),
 				" for GUI checkbox ", checkbox_name
 			);
 			ret = false;
@@ -474,7 +476,7 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 	}
 
 	if (checkbox.get_font() != nullptr) {
-		const StringName font_file = std_view_to_godot_string_name(checkbox.get_font()->get_fontname());
+		const StringName font_file = Utilities::std_to_godot_string(checkbox.get_font()->get_fontname());
 		const Ref<Font> font = args.asset_manager.get_font(font_file);
 		if (font.is_valid()) {
 			static const StringName font_theme = "font";
@@ -502,13 +504,13 @@ static bool generate_text(generate_gui_args_t&& args) {
 
 	GUI::Text const& text = static_cast<GUI::Text const&>(args.element);
 
-	const String text_name = std_view_to_godot_string(text.get_name());
+	const String text_name = Utilities::std_to_godot_string(text.get_name());
 
 	Label* godot_label = nullptr;
 	bool ret = new_control(godot_label, text, args.name);
 	ERR_FAIL_NULL_V_MSG(godot_label, false, vformat("Failed to create Label for GUI text %s", text_name));
 
-	godot_label->set_text(std_view_to_godot_string(text.get_text()));
+	godot_label->set_text(Utilities::std_to_godot_string(text.get_text()));
 
 	static const Vector2 default_padding { 1.0_real, 0.0_real };
 	const Vector2 border_size = Utilities::to_godot_fvec2(text.get_border_size()) + default_padding;
@@ -532,7 +534,7 @@ static bool generate_text(generate_gui_args_t&& args) {
 	}
 
 	if (text.get_font() != nullptr) {
-		const StringName font_file = std_view_to_godot_string_name(text.get_font()->get_fontname());
+		const StringName font_file = Utilities::std_to_godot_string(text.get_font()->get_fontname());
 		const Ref<Font> font = args.asset_manager.get_font(font_file);
 		if (font.is_valid()) {
 			static const StringName font_theme = "font";
@@ -553,7 +555,7 @@ static bool generate_text(generate_gui_args_t&& args) {
 static bool generate_overlapping_elements(generate_gui_args_t&& args) {
 	GUI::OverlappingElementsBox const& overlapping_elements = static_cast<GUI::OverlappingElementsBox const&>(args.element);
 
-	const String overlapping_elements_name = std_view_to_godot_string(overlapping_elements.get_name());
+	const String overlapping_elements_name = Utilities::std_to_godot_string(overlapping_elements.get_name());
 
 	GUIOverlappingElementsBox* box = nullptr;
 	bool ret = new_control(box, overlapping_elements, args.name);
@@ -570,7 +572,7 @@ static bool generate_overlapping_elements(generate_gui_args_t&& args) {
 static bool generate_listbox(generate_gui_args_t&& args) {
 	GUI::ListBox const& listbox = static_cast<GUI::ListBox const&>(args.element);
 
-	const String listbox_name = std_view_to_godot_string(listbox.get_name());
+	const String listbox_name = Utilities::std_to_godot_string(listbox.get_name());
 
 	GUIListBox* gui_listbox = nullptr;
 	bool ret = new_control(gui_listbox, listbox, args.name);
@@ -590,7 +592,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 
 	GUI::TextEditBox const& text_edit_box = static_cast<GUI::TextEditBox const&>(args.element);
 
-	const String text_edit_box_name = std_view_to_godot_string(text_edit_box.get_name());
+	const String text_edit_box_name = Utilities::std_to_godot_string(text_edit_box.get_name());
 
 	LineEdit* godot_line_edit = nullptr;
 	bool ret = new_control(godot_line_edit, text_edit_box, args.name);
@@ -602,7 +604,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 	godot_line_edit->set_caret_blink_enabled(true);
 	godot_line_edit->set_focus_mode(Control::FOCUS_CLICK);
 
-	godot_line_edit->set_text(std_view_to_godot_string(text_edit_box.get_text()));
+	godot_line_edit->set_text(Utilities::std_to_godot_string(text_edit_box.get_text()));
 
 	static const Vector2 default_position_padding { -4.0_real, 1.0_real };
 	static const Vector2 default_size_padding { 2.0_real, 2.0_real };
@@ -616,7 +618,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 	godot_line_edit->add_theme_color_override(caret_color_theme, caret_colour);
 
 	if (text_edit_box.get_font() != nullptr) {
-		const StringName font_file = std_view_to_godot_string_name(text_edit_box.get_font()->get_fontname());
+		const StringName font_file = Utilities::std_to_godot_string(text_edit_box.get_font()->get_fontname());
 		const Ref<Font> font = args.asset_manager.get_font(font_file);
 		if (font.is_valid()) {
 			static const StringName font_theme = "font";
@@ -630,7 +632,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 		godot_line_edit->add_theme_color_override(font_color_theme, colour);
 	}
 
-	const StringName texture_file = std_view_to_godot_string_name(text_edit_box.get_texture_file());
+	const StringName texture_file = Utilities::std_to_godot_string(text_edit_box.get_texture_file());
 	if (!texture_file.is_empty()) {
 		Ref<ImageTexture> texture = args.asset_manager.get_texture(texture_file);
 
@@ -662,7 +664,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 static bool generate_scrollbar(generate_gui_args_t&& args) {
 	GUI::Scrollbar const& scrollbar = static_cast<GUI::Scrollbar const&>(args.element);
 
-	const String scrollbar_name = std_view_to_godot_string(scrollbar.get_name());
+	const String scrollbar_name = Utilities::std_to_godot_string(scrollbar.get_name());
 
 	GUIScrollbar* gui_scrollbar = nullptr;
 	bool ret = new_control(gui_scrollbar, scrollbar, args.name);
@@ -686,7 +688,7 @@ static bool generate_window(generate_gui_args_t&& args) {
 	GUI::Window const& window = static_cast<GUI::Window const&>(args.element);
 
 	// TODO - moveable, fullscreen, dontRender (disable visibility?)
-	const String window_name = std_view_to_godot_string(window.get_name());
+	const String window_name = Utilities::std_to_godot_string(window.get_name());
 
 	Panel* godot_panel = nullptr;
 	bool ret = new_control(godot_panel, window, args.name);
@@ -702,7 +704,9 @@ static bool generate_window(generate_gui_args_t&& args) {
 			godot_panel->add_child(node);
 		}
 		if (!element_ret) {
-			UtilityFunctions::push_error("Errors generating GUI element ", std_view_to_godot_string(element->get_name()));
+			UtilityFunctions::push_error(
+				"Errors generating GUI element ", Utilities::std_to_godot_string(element->get_name())
+			);
 			ret = false;
 		}
 	}
@@ -726,7 +730,8 @@ static bool generate_element(GUI::Element const* element, String const& name, As
 	};
 	const decltype(type_map)::const_iterator it = type_map.find(element->get_type());
 	ERR_FAIL_COND_V_MSG(
-		it == type_map.end(), false, vformat("Invalid GUI element type: %s", std_view_to_godot_string(element->get_type()))
+		it == type_map.end(), false,
+		vformat("Invalid GUI element type: %s", Utilities::std_to_godot_string(element->get_type()))
 	);
 	return it->second({ *element, name, asset_manager, result });
 }

--- a/extension/src/openvic-extension/utility/Utilities.cpp
+++ b/extension/src/openvic-extension/utility/Utilities.cpp
@@ -65,7 +65,7 @@ String Utilities::float_to_string_dp(float val, int32_t decimal_places) {
 
 /* Date formatted like this: "January 1, 1836" (with the month localised, if possible). */
 String Utilities::date_to_formatted_string(Date date) {
-	const String month_name = std_view_to_godot_string_name(date.get_month_name());
+	const String month_name = Utilities::std_to_godot_string(date.get_month_name());
 	const String day_and_year = " " + String::num_int64(date.get_day()) + ", " + String::num_int64(date.get_year());
 	TranslationServer const* server = TranslationServer::get_singleton();
 	if (server != nullptr) {

--- a/extension/src/openvic-extension/utility/Utilities.hpp
+++ b/extension/src/openvic-extension/utility/Utilities.hpp
@@ -14,23 +14,11 @@
 namespace OpenVic::Utilities {
 
 	_FORCE_INLINE_ std::string godot_to_std_string(godot::String const& str) {
-		return str.ascii().get_data();
+		return str.utf8().get_data();
 	}
 
-	_FORCE_INLINE_ godot::String std_to_godot_string(std::string const& str) {
-		return str.c_str();
-	}
-
-	_FORCE_INLINE_ godot::String std_view_to_godot_string(std::string_view const& str) {
-		return std_to_godot_string(static_cast<std::string>(str));
-	}
-
-	_FORCE_INLINE_ godot::StringName std_to_godot_string_name(std::string const& str) {
-		return str.c_str();
-	}
-
-	_FORCE_INLINE_ godot::StringName std_view_to_godot_string_name(std::string_view const& str) {
-		return std_to_godot_string_name(static_cast<std::string>(str));
+	_FORCE_INLINE_ godot::String std_to_godot_string(std::string_view const& str) {
+		return godot::String::utf8(str.data(), str.length());
 	}
 
 	godot::String int_to_string_suffixed(int64_t val);

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -2,7 +2,7 @@ extends GUINode
 
 # Header
 var _province_name_label : Label
-var _region_name_label : Label
+var _state_name_label : Label
 var _slave_status_icon : TextureRect
 var _colony_status_button : Button
 var _colony_status_button_texture : GFXSpriteTexture
@@ -137,7 +137,10 @@ func _ready() -> void:
 
 	# Header
 	_province_name_label = get_label_from_nodepath(^"./province_view/province_view_header/province_name")
-	_region_name_label = get_label_from_nodepath(^"./province_view/province_view_header/state_name")
+	_state_name_label = get_label_from_nodepath(^"./province_view/province_view_header/state_name")
+	if _state_name_label:
+		# State names are already translated in the MenuSingleton
+		_state_name_label.auto_translate = false
 	_slave_status_icon = get_texture_rect_from_nodepath(^"./province_view/province_view_header/slave_state_icon")
 	var slave_status_icon_texture : GFXSpriteTexture = get_gfx_sprite_texture_from_nodepath(^"./province_view/province_view_header/slave_state_icon")
 	if slave_status_icon_texture:
@@ -257,9 +260,8 @@ func _update_info() -> void:
 		if _province_name_label:
 			_province_name_label.text = GUINode.format_province_name(_province_info.get(_province_info_province_key, _missing_suffix))
 
-		if _region_name_label:
-			_region_name_label.text = _province_info.get(_province_info_state_key,
-				_province_info_state_key + _missing_suffix)
+		if _state_name_label:
+			_state_name_label.text = _province_info.get(_province_info_state_key, tr(_province_info_state_key + _missing_suffix))
 
 		if _slave_status_icon:
 			_slave_status_icon.visible = _province_info.get(_province_info_slave_status_key, false)

--- a/game/src/Game/GameSession/SearchPanel.gd
+++ b/game/src/Game/GameSession/SearchPanel.gd
@@ -103,6 +103,8 @@ func _add_result_button() -> bool:
 		return false
 
 	button.pressed.connect(_result_selected.bind(_result_buttons.size()))
+	# Country/State/Province display names are already translated in the MenuSingleton
+	button.auto_translate = false
 
 	_results_list_box.add_child(child)
 	_result_buttons.push_back(button)


### PR DESCRIPTION
Fixes #180: Province names do not convert non-ascii characters to Unicode