### PR TITLE
Correct Maximum regiments per soldier POP

### DIFF
--- a/docs/simulation/calculations.yaml
+++ b/docs/simulation/calculations.yaml
@@ -71,7 +71,7 @@ Military:
   Maximum regiments per soldier POP:
     if POP size < defines.military.POP_MIN_SIZE_FOR_REGIMENT: 0
     else:
-      formula: ceil(POP size / (POP_SIZE_PER_REGIMENT * location factor))
+      formula: 1 + trunc(POP size / (POP_SIZE_PER_REGIMENT * location factor))
       POP_SIZE_PER_REGIMENT: defines.military.POP_SIZE_PER_REGIMENT
       location factor:
         if is protectorate: defines.military.POP_MIN_SIZE_FOR_REGIMENT_PROTECTORATE_MULTIPLIER


### PR DESCRIPTION
The Second Appearance — Today at 14:49
Also try setting FOR and PER regiment to 3000 - you will be able to recruit 2 brigades from a single 3000 pop, but each 3k further will only provide 1 brigade

General WVPM — Today at 15:01
Weird. When POP_MIN_SIZE_FOR_REGIMENT = 4500 & POP_SIZE_PER_REGIMENT = 5000 a pop with 4500 can support max 1 regiment.
When POP_MIN_SIZE_FOR_REGIMENT = 5000 & POP_SIZE_PER_REGIMENT = 5000 a pop with 5000 can support max 2 regiments.
So maybe instead of ceil() it should be 1 + trunc().