### PR TITLE
Model loader Fixes

### DIFF
--- a/game/src/Game/Model/XSMLoader.gd
+++ b/game/src/Game/Model/XSMLoader.gd
@@ -46,7 +46,8 @@ static func _load_xsm_animation(source_file : String) -> Animation:
 			0xC9: #Metadata
 				metadataChunk = readMetadataChunk(file)
 			0xCA: #Bone Animation
-				boneAnimationChunks.push_back(readBoneAnimationChunk(file, metadataChunk.use_quat_16()))
+				# v1 is float32 quaternions, v2 is int16 quaternions
+				boneAnimationChunks.push_back(readBoneAnimationChunk(file, version == 2))
 			_:
 				push_error(">> INVALID XSM CHUNK TYPE %X" % type)
 				break
@@ -155,11 +156,8 @@ class MetadataChunk:
 	func debugPrint() -> void:
 		print("FileName: %s, sourceApp: %s, exportDate: %s, ExporterV:%d.%d" %
 			[origFileName, sourceApp, exportDate, exporterMajorVersion, exporterMinorVersion])
-		print("MotionName: %s, fps: %d, MaxError: %s, Use 16-bit int Quaternions?:%s" %
-			[motionName, fps, fMaxAcceptableError, use_quat_16()])
-
-	func use_quat_16() -> bool:
-		return pad == 0x0
+		print("MotionName: %s, fps: %d, MaxError: %s" %
+			[motionName, fps, fMaxAcceptableError])
 
 static func readPosKey(file : FileAccess) -> PosKey:
 	return PosKey.new(FileAccessUtils.read_pos(file), file.get_float())


### PR DESCRIPTION
Fixes the following problems:
- Arab_infantry_helmet
- Parts of units being culled when near edge of screen (added cull margin)
- Improper method of determining when to use int16 or float32 quaternions for xsm animations.

Background of Arab_infantry_helmet
Paradox made the helmet models directly on the infantry units they go with. These helmet models are properly separated to their own .xac files so they are normally reuseable attachments. However, the mesh for the arab_infantry_helmet was never removed from the infantry model, so it was appearing twice. So a check was made so that we skip building the helmet's mesh if it is in a file with other mesh chunks (ie. the infantry model)

New method of determining whether to use int16 or float32 for xsm quaternions is to check the chunk version, as opposed to the previous hack of looking in the header chunk's padding for data.

Cull margin was added as a const at the top of the xac loader file, this value can be played with, but I found `= 2` to work best (`= 1` was too small, larger seems unnecessary).