### PR TITLE
Add Map Billboards

### DIFF
--- a/extension/doc_classes/MapItemSingleton.xml
+++ b/extension/doc_classes/MapItemSingleton.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MapItemSingleton" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_billboards" qualifiers="const">
+			<return type="Dictionary[]" />
+			<description>
+			</description>
+		</method>
+		<method name="get_capital_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_capital_positions" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_crime_icons" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+			</description>
+		</method>
+		<method name="get_national_focus_icons" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+			</description>
+		</method>
+		<method name="get_province_positions" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_rgo_icons" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/extension/src/openvic-extension/classes/GUILabel.cpp
+++ b/extension/src/openvic-extension/classes/GUILabel.cpp
@@ -7,6 +7,7 @@
 #include "openvic-extension/singletons/AssetManager.hpp"
 #include "openvic-extension/utility/ClassBindings.hpp"
 #include "openvic-extension/utility/Utilities.hpp"
+#include "openvic-simulation/types/TextFormat.hpp"
 
 using namespace OpenVic;
 using namespace godot;
@@ -241,12 +242,13 @@ Error GUILabel::set_gui_text(GUI::Text const* new_gui_text, GFX::Font::colour_co
 
 	set_text(Utilities::std_to_godot_string(gui_text->get_text()));
 
-	using enum GUI::AlignedElement::format_t;
-	static const ordered_map<GUI::AlignedElement::format_t, HorizontalAlignment> format_map {
+	using enum text_format_t;
+	static const ordered_map<text_format_t, HorizontalAlignment> format_map {
 		{ left, HORIZONTAL_ALIGNMENT_LEFT },
 		{ centre, HORIZONTAL_ALIGNMENT_CENTER },
 		{ right, HORIZONTAL_ALIGNMENT_RIGHT }
 	};
+
 	const decltype(format_map)::const_iterator it = format_map.find(gui_text->get_format());
 	set_horizontal_alignment(it != format_map.end() ? it->second : HORIZONTAL_ALIGNMENT_LEFT);
 

--- a/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
@@ -5,6 +5,7 @@
 #include "openvic-extension/utility/ClassBindings.hpp"
 #include "openvic-extension/utility/UITools.hpp"
 #include "openvic-extension/utility/Utilities.hpp"
+#include "openvic-simulation/types/TextFormat.hpp"
 
 using namespace OpenVic;
 using namespace godot;
@@ -30,7 +31,7 @@ Error GUIOverlappingElementsBox::_update_child_positions() {
 
 	float starting_x = 0.0f;
 	Error err = OK;
-	using enum GUI::AlignedElement::format_t;
+	using enum text_format_t;
 	switch (gui_overlapping_elements_box->get_format()) {
 		case left:
 			break;

--- a/extension/src/openvic-extension/register_types.cpp
+++ b/extension/src/openvic-extension/register_types.cpp
@@ -24,6 +24,7 @@
 #include "openvic-extension/singletons/Checksum.hpp"
 #include "openvic-extension/singletons/GameSingleton.hpp"
 #include "openvic-extension/singletons/LoadLocalisation.hpp"
+#include "openvic-extension/singletons/MapItemSingleton.hpp"
 #include "openvic-extension/singletons/MenuSingleton.hpp"
 #include "openvic-extension/singletons/ModelSingleton.hpp"
 #include "openvic-extension/singletons/SoundSingleton.hpp"
@@ -34,6 +35,7 @@ using namespace OpenVic;
 static Checksum* _checksum_singleton = nullptr;
 static LoadLocalisation* _load_localisation = nullptr;
 static GameSingleton* _game_singleton = nullptr;
+static MapItemSingleton* _map_item_singleton = nullptr;
 static MenuSingleton* _menu_singleton = nullptr;
 static ModelSingleton* _model_singleton = nullptr;
 static AssetManager* _asset_manager_singleton = nullptr;
@@ -55,6 +57,10 @@ void initialize_openvic_types(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<GameSingleton>();
 	_game_singleton = memnew(GameSingleton);
 	Engine::get_singleton()->register_singleton("GameSingleton", GameSingleton::get_singleton());
+
+	ClassDB::register_class<MapItemSingleton>();
+	_map_item_singleton = memnew(MapItemSingleton);
+	Engine::get_singleton()->register_singleton("MapItemSingleton", MapItemSingleton::get_singleton());
 
 	ClassDB::register_class<MenuSingleton>();
 	_menu_singleton = memnew(MenuSingleton);
@@ -116,6 +122,9 @@ void uninitialize_openvic_types(ModuleInitializationLevel p_level) {
 
 	Engine::get_singleton()->unregister_singleton("GameSingleton");
 	memdelete(_game_singleton);
+
+	Engine::get_singleton()->unregister_singleton("MapItemSingleton");
+	memdelete(_map_item_singleton);
 
 	Engine::get_singleton()->unregister_singleton("MenuSingleton");
 	memdelete(_menu_singleton);

--- a/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
@@ -1,0 +1,237 @@
+#include "MapItemSingleton.hpp"
+#include <string_view>
+
+#include "godot_cpp/variant/packed_int32_array.hpp"
+#include "godot_cpp/variant/packed_vector2_array.hpp"
+#include "godot_cpp/variant/typed_array.hpp"
+#include "godot_cpp/variant/utility_functions.hpp"
+#include "godot_cpp/variant/vector2.hpp"
+#include "openvic-extension/singletons/GameSingleton.hpp"
+#include "openvic-extension/utility/ClassBindings.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
+#include "openvic-simulation/DefinitionManager.hpp"
+#include "openvic-simulation/country/CountryDefinition.hpp"
+#include "openvic-simulation/country/CountryInstance.hpp"
+#include "openvic-simulation/interface/GFXObject.hpp"
+#include "openvic-simulation/map/ProvinceDefinition.hpp"
+#include "openvic-simulation/map/ProvinceInstance.hpp"
+#include "openvic-simulation/map/State.hpp"
+#include "openvic-simulation/types/Vector.hpp"
+
+using namespace godot;
+using namespace OpenVic;
+
+void MapItemSingleton::_bind_methods() {
+	OV_BIND_METHOD(MapItemSingleton::get_billboards);
+	OV_BIND_METHOD(MapItemSingleton::get_province_positions);
+	OV_BIND_METHOD(MapItemSingleton::get_capital_count);
+	OV_BIND_METHOD(MapItemSingleton::get_capital_positions);
+	OV_BIND_METHOD(MapItemSingleton::get_crime_icons);
+	OV_BIND_METHOD(MapItemSingleton::get_rgo_icons);
+	OV_BIND_METHOD(MapItemSingleton::get_national_focus_icons);
+}
+
+MapItemSingleton* MapItemSingleton::get_singleton() {
+	return singleton;
+}
+
+MapItemSingleton::MapItemSingleton() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+}
+
+MapItemSingleton::~MapItemSingleton() {
+	ERR_FAIL_COND(singleton != this);
+	singleton = nullptr;
+}
+
+// Get the billboard object from the loaded objects
+
+GFX::Billboard const* MapItemSingleton::get_billboard(std::string_view name, bool error_on_fail) const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, nullptr);
+
+	GFX::Billboard const* billboard =
+		game_singleton->get_definition_manager().get_ui_manager().get_cast_object_by_identifier<GFX::Billboard>(name);
+
+	if (error_on_fail) {
+		ERR_FAIL_NULL_V_MSG(billboard, nullptr, vformat("Failed to find billboard \"%s\"", Utilities::std_to_godot_string(name)));
+	}
+
+	return billboard;
+}
+
+// repackage the billboard object into a godot dictionnary for the Billboard manager to work with
+bool MapItemSingleton::add_billboard_dict(std::string_view name, TypedArray<Dictionary>& billboard_dict_array) const {
+
+	static const StringName name_key = "name";
+	static const StringName texture_key = "texture";
+	static const StringName scale_key = "scale";
+	static const StringName noOfFrames_key = "noFrames";
+
+	GFX::Billboard const* billboard = get_billboard(name,false);
+
+	ERR_FAIL_NULL_V_MSG(
+		billboard, false, "Failed to find billboard"
+	);
+
+	Dictionary dict;
+
+	dict[name_key] = Utilities::std_to_godot_string(billboard->get_name());
+	dict[texture_key] = Utilities::std_to_godot_string(billboard->get_texture_file());
+	dict[scale_key] = billboard->get_scale().to_float();
+	dict[noOfFrames_key] = billboard->get_no_of_frames();
+
+	billboard_dict_array.push_back(dict);
+
+	return true;
+}
+
+
+//get an array of all the billboard dictionnaries
+TypedArray<Dictionary> MapItemSingleton::get_billboards() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, {});
+
+	TypedArray<Dictionary> ret;
+
+	for (std::unique_ptr<GFX::Object> const& obj : game_singleton->get_definition_manager().get_ui_manager().get_objects()) {
+		if (obj->is_type<GFX::Billboard>()) {
+			add_billboard_dict(obj->get_name(), ret);
+		}
+	}
+	
+	return ret;
+}
+
+PackedVector2Array MapItemSingleton::get_province_positions() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, PackedVector2Array());
+
+	PackedVector2Array billboard_pos {};
+	
+	for(ProvinceDefinition const& prov : game_singleton->get_definition_manager().get_map_definition().get_province_definitions()){
+		if(prov.is_water()) continue; //billboards dont appear over water, skip
+
+		fvec2_t city_pos = prov.get_city_position();
+		Vector2 pos = Utilities::to_godot_fvec2(city_pos) / game_singleton->get_map_dims();
+		billboard_pos.push_back(pos);
+
+	}
+	
+	return billboard_pos;
+}
+
+//includes non-existent countries, used for setting the billboard buffer size
+int32_t MapItemSingleton::get_capital_count() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, 0);
+
+	return game_singleton->get_definition_manager().get_country_definition_manager().get_country_definition_count();
+}
+
+PackedVector2Array MapItemSingleton::get_capital_positions() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, PackedVector2Array());
+
+	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
+	ERR_FAIL_NULL_V(instance_manager, PackedVector2Array());
+
+	PackedVector2Array billboard_pos {};
+
+	for(CountryInstance const& country : instance_manager->get_country_instance_manager().get_country_instances()){
+		if(!country.exists()) continue; //skip non-existant countries
+
+		fvec2_t city_pos = country.get_capital()->get_province_definition().get_city_position();
+		Vector2 pos = Utilities::to_godot_fvec2(city_pos) / game_singleton->get_map_dims();
+		billboard_pos.push_back(pos);
+
+	}
+
+	return billboard_pos;
+}
+
+PackedByteArray MapItemSingleton::get_crime_icons() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, PackedByteArray());
+
+	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
+	ERR_FAIL_NULL_V(instance_manager, PackedByteArray());
+
+	PackedByteArray icons {};
+
+	for(ProvinceInstance const& prov_inst : instance_manager->get_map_instance().get_province_instances()){
+		if (prov_inst.get_province_definition().is_water()) continue; //billboards dont appear over water, skip
+
+		if(prov_inst.get_crime() == nullptr){
+			icons.push_back(0); //no crime on the province
+		}
+		else {
+			icons.push_back(prov_inst.get_crime()->get_icon());
+		}
+		
+	}
+
+	return icons;
+
+}
+
+PackedByteArray MapItemSingleton::get_rgo_icons() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, PackedByteArray());
+
+	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
+	ERR_FAIL_NULL_V(instance_manager, PackedByteArray());
+
+	PackedByteArray icons {};
+
+	for(ProvinceInstance const& prov_inst : instance_manager->get_map_instance().get_province_instances()){
+		if (prov_inst.get_province_definition().is_water()) continue; //billboards dont appear over water, skip
+
+		if(prov_inst.get_rgo_good() == nullptr){
+			icons.push_back(0); //no good on the province
+		}
+		else{
+			icons.push_back(prov_inst.get_rgo_good()->get_index()+1);
+		}
+	}
+
+	return icons;
+
+}
+
+/*
+TODO: National focus isn't implemented yet. It could be done at the country instance, or the province instance
+ So this function just returns dummy data.
+ So in the future...
+ - Return the icon of the current national focus of the state
+ if there is a focus on that state, else return 0 to indicate no focus.
+*/
+
+PackedByteArray MapItemSingleton::get_national_focus_icons() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+	ERR_FAIL_NULL_V(game_singleton, PackedByteArray());
+
+	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
+	ERR_FAIL_NULL_V(instance_manager, PackedByteArray());
+
+	PackedByteArray icons {};
+
+	for(ProvinceInstance const& prov_inst : instance_manager->get_map_instance().get_province_instances()){
+		if (prov_inst.get_province_definition().is_water()) continue; //billboards dont appear over water, skip
+
+		State const* state = prov_inst.get_state();
+		if (state == nullptr) {
+			icons.push_back(0);
+			UtilityFunctions::push_warning(
+				"State for province ", Utilities::std_to_godot_string(prov_inst.get_identifier()), " was null"
+			);
+		} else if (&prov_inst == state->get_capital()) {
+			icons.push_back(1);
+		} else {
+			icons.push_back(0);
+		}
+	}
+
+	return icons;
+}

--- a/extension/src/openvic-extension/singletons/MapItemSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MapItemSingleton.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <openvic-simulation/interface/GFXObject.hpp>
+#include <openvic-simulation/types/OrderedContainers.hpp>
+
+//billboards, projections, and progress bar
+//for now though, only billboards
+
+namespace OpenVic {
+	class MapItemSingleton : public godot::Object {
+		GDCLASS(MapItemSingleton, godot::Object)
+
+		static inline MapItemSingleton* singleton = nullptr;
+
+	protected:
+		static void _bind_methods();
+
+	public:
+		static MapItemSingleton* get_singleton();
+
+		MapItemSingleton();
+		~MapItemSingleton();
+
+	private:
+		GFX::Billboard const* get_billboard(std::string_view name, bool error_on_fail = true) const;
+		bool add_billboard_dict(std::string_view name, godot::TypedArray<godot::Dictionary>& billboard_dict_array) const;
+		godot::TypedArray<godot::Dictionary> get_billboards() const;
+		godot::PackedVector2Array get_province_positions() const;
+		int32_t get_capital_count() const;
+		godot::PackedVector2Array get_capital_positions() const;
+
+		godot::PackedByteArray get_crime_icons() const;
+		godot::PackedByteArray get_rgo_icons() const;
+		godot::PackedByteArray get_national_focus_icons() const;
+
+	};
+
+}

--- a/game/src/Game/GameSession/BillboardManager.gd
+++ b/game/src/Game/GameSession/BillboardManager.gd
@@ -1,0 +1,198 @@
+extends MultiMeshInstance3D
+
+#given a name: get the index for the texture in the shader
+# this is to reduce the number of magic indeces in the code
+# to get the proper billboard image
+var billboard_names : Dictionary = {}
+
+@export var _map_view : MapView
+
+const SCALE_FACTOR : float = 1.0/96.0
+
+enum ProvinceBillboards { NONE, INVISIBLE, RGO, CRIME, NATIONAL_FOCUS }
+enum MapModes { REVOLT_RISK = 2, INFRASTRUCTURE = 5, COLONIAL = 6, NATIONAL_FOCUS = 9, RGO_OUTPUT = 10 }
+
+var provinces_size : int = 0
+var total_capitals_size : int = 0
+
+var textures : Array[Texture2D] = []
+var frames : Array[int] = []
+var scales : Array[float] = []
+
+var current_province_billboard : ProvinceBillboards = ProvinceBillboards.NONE
+
+# ============== Billboards =============
+# Billboards are displayed using a multimesh (batch drawn mesh)
+#  with positions set to every province and every nation capital.
+# A shader controls which billboard and frame from icon strips are displayed
+#  at each province. It also makes billboards "look at" the camera
+# To ensure billboards are displayed ontop of the map and units, it is contained in 
+#  a subviewport which renders above the main viewport, with a camera set to follow the primary camera
+
+# multimesh only lets us send custom data to the shader as a single float vec4/Color variable
+#  So we need to make the most of it.
+# Info send to the shader is as follows:
+# x: image to use from imageArray
+# y: frame from selected image for icon strips. 0 indicate invisible (alpha = 0.0)
+# z: unused, perhaps progress for progress bars if this shader is reused?
+# w: unused
+
+# "Province billboards" refer to billboards positioned on every province
+#  for map modes such as RGO output, while "Capital billboards" refers to the 
+#  to country capitals.
+
+func _ready() -> void:
+	const name_key : StringName = &"name"
+	const texture_key : StringName = &"texture"
+	const scale_key : StringName = &"scale"
+	const noOfFrames_key : StringName = &"noFrames"
+	
+	var billboards : Array[Dictionary] = MapItemSingleton.get_billboards()
+	for j : int in billboards.size():
+		var billboard : Dictionary = billboards[j]
+		
+		var billboard_name : String = billboard[name_key]
+		var texture_name : String = billboard[texture_key]
+		var billboard_scale : float = billboard[scale_key]
+		var noFrames : int = billboard[noOfFrames_key]
+		
+		#fix the alpha edges of the billboard textures
+		var texture : Texture2D = AssetManager.get_texture(texture_name)
+		var image : Image = texture.get_image()
+		image.fix_alpha_edges()
+		texture.set_image(image)
+		
+		textures.push_back(texture)
+		frames.push_back(noFrames)
+		scales.push_back(billboard_scale*SCALE_FACTOR)
+		billboard_names[billboard_name] = j
+	
+	var material : ShaderMaterial = multimesh.mesh.surface_get_material(0)
+	if material == null:
+		push_error("ShaderMaterial for billboards was null")
+		return
+	
+	material.set_shader_parameter("billboards",textures)
+	material.set_shader_parameter("numframes",frames)
+	material.set_shader_parameter("sizes",scales)
+	multimesh.mesh.surface_set_material(0,material)
+	
+	var positions : PackedVector2Array = MapItemSingleton.get_province_positions()
+	provinces_size = positions.size()
+	total_capitals_size = MapItemSingleton.get_capital_count()
+	
+	# 1) setting instance_count clears and resizes the buffer
+	# so we want to find the max size once and leave it
+	# 2) resize must occur after setting the transform format
+	multimesh.instance_count = provinces_size + total_capitals_size
+	multimesh.visible_instance_count = provinces_size + total_capitals_size
+
+	set_capitals()
+
+	var map_positions : PackedVector3Array = to_map_coords(positions)
+
+	for i : int in positions.size():
+		multimesh.set_instance_transform(i + total_capitals_size, Transform3D(Basis(), 
+			map_positions[i]
+		))
+
+	GameSingleton.mapmode_changed.connect(_on_map_mode_changed)
+	GameSingleton.gamestate_updated.connect(_on_game_state_changed)
+
+#TODO: Get rid of the vertical stretch, proper capitals placement
+
+#fetch the nation capitals and setup billboards for them
+func set_capitals() -> void:
+	var positions : PackedVector2Array = MapItemSingleton.get_capital_positions()
+	var capital_positions : PackedVector3Array = to_map_coords(positions)
+	var image_index : int = billboard_names["capital"]
+	
+	#multimesh.visible_instance_count = capitals_begin_index + capital_positions.size()
+	for i : int in capital_positions.size():
+		multimesh.set_instance_transform(i,Transform3D(Basis(),
+			capital_positions[i]
+		))
+		
+		#capital image, frame=1 ,2x unused
+		#frame=1 because frame=0 would cause capitals not to show
+		#and as an index its fine, since the shader UVs will wrap around
+		# 1.0 to 2.0 --> 0.0 to 1.0 so the capital image is preserved
+		multimesh.set_instance_custom_data(i,Color(#capital_index,Color(
+			image_index,1.0,0,0
+		))
+	# For every country that doesn't exist, make the capital invisible
+	for i : int in total_capitals_size - capital_positions.size():
+		multimesh.set_instance_custom_data(capital_positions.size() + i, Color(
+			image_index,0.0,0,0
+		))
+
+# should provinces display RGO, crime, ..., or no billboard
+func set_province_billboards(display : ProvinceBillboards = ProvinceBillboards.INVISIBLE) -> void:
+	var image_index : int = 0
+	var icons : PackedByteArray = PackedByteArray()
+	icons.resize(provinces_size)
+	icons.fill(0) #by default, display nothing (invisible)
+	match display:
+		ProvinceBillboards.RGO:
+			image_index = billboard_names["tradegoods"]
+			icons = MapItemSingleton.get_rgo_icons()
+			current_province_billboard = display
+		ProvinceBillboards.CRIME:
+			image_index = billboard_names["crimes"]
+			icons = MapItemSingleton.get_crime_icons()
+			current_province_billboard = display
+		ProvinceBillboards.NATIONAL_FOCUS:
+			image_index = billboard_names["national_focus"]
+			icons = MapItemSingleton.get_national_focus_icons()
+			current_province_billboard = display
+		ProvinceBillboards.NONE:
+			current_province_billboard = display
+		_: #display nothing, but keep the current billboard setting
+			pass
+	# capitals are first in the array, so start iterating after them
+	for i : int in provinces_size:
+		multimesh.set_instance_custom_data(i + total_capitals_size,Color(
+			image_index,icons[i],0,0
+		))
+
+func _on_game_state_changed() -> void:
+	set_province_billboards(current_province_billboard)
+	set_capitals()
+
+# There are essentially 3 visibility states we can be in
+# 1: parchment view -> no billboards visible
+# 2: not parchment nor detail -> only capitals visible
+# 3: detail map -> province and capital billboards visible
+# So set_visible here is essentially to toggle the visibility of capitals
+
+func detailed_map(visible : bool) -> void:
+	if visible:
+		set_visible(true)
+		set_province_billboards(current_province_billboard)
+	else:
+		set_visible(true)
+		set_province_billboards()
+
+func parchment_view(is_parchment : bool) -> void:
+	if is_parchment:
+		set_visible(false)
+	else:
+		detailed_map(false)
+
+func _on_map_mode_changed(map_mode : int) -> void:
+	match map_mode:
+		MapModes.INFRASTRUCTURE, MapModes.COLONIAL, MapModes.RGO_OUTPUT:
+			set_province_billboards(ProvinceBillboards.RGO)
+		MapModes.REVOLT_RISK:
+			set_province_billboards(ProvinceBillboards.CRIME)
+		MapModes.NATIONAL_FOCUS:
+			set_province_billboards(ProvinceBillboards.NATIONAL_FOCUS)
+		_:
+			set_province_billboards(ProvinceBillboards.NONE)
+
+func to_map_coords(positions : PackedVector2Array) -> PackedVector3Array:
+	var map_positions : PackedVector3Array = PackedVector3Array()
+	for pos_in : Vector2 in positions:
+		var pos : Vector3 = _map_view._map_to_world_coords(pos_in)
+		map_positions.push_back(pos)
+	return map_positions

--- a/game/src/Game/GameSession/GameSession.tscn
+++ b/game/src/Game/GameSession/GameSession.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=22 format=3 uid="uid://bgnupcshe1m7r"]
+[gd_scene load_steps=27 format=3 uid="uid://bgnupcshe1m7r"]
 
 [ext_resource type="Script" path="res://src/Game/GameSession/GameSession.gd" id="1_eklvp"]
 [ext_resource type="PackedScene" uid="uid://cvl76duuym1wq" path="res://src/Game/MusicConductor/MusicPlayer.tscn" id="2_kt6aa"]
 [ext_resource type="PackedScene" uid="uid://dvdynl6eir40o" path="res://src/Game/GameSession/GameSessionMenu.tscn" id="3_bvmqh"]
 [ext_resource type="Script" path="res://src/Game/GameSession/ModelManager.gd" id="3_qwk4j"]
 [ext_resource type="Script" path="res://src/Game/GameSession/Topbar.gd" id="4_2kbih"]
+[ext_resource type="Script" path="res://src/Game/GameSession/BillboardManager.gd" id="4_b3l7b"]
 [ext_resource type="PackedScene" uid="uid://dkehmdnuxih2r" path="res://src/Game/GameSession/MapView.tscn" id="4_xkg5j"]
+[ext_resource type="Shader" path="res://src/Game/GameSession/billboard.gdshader" id="5_7yrtq"]
 [ext_resource type="Script" path="res://src/Game/GameSession/NationManagementScreen/ProductionMenu.gd" id="5_16755"]
 [ext_resource type="Script" path="res://src/Game/GameSession/ProvinceOverviewPanel.gd" id="5_lfv8l"]
 [ext_resource type="Script" path="res://src/Game/GameSession/SearchPanel.gd" id="5_t260f"]
@@ -21,6 +23,21 @@
 [ext_resource type="Script" path="res://src/Game/GameSession/Ledger.gd" id="15_vhb1p"]
 [ext_resource type="Script" path="res://src/Game/GameSession/Tooltip.gd" id="20_3306e"]
 [ext_resource type="Script" path="res://src/Game/GameSession/Menubar.gd" id="20_s1i71"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ghmi8"]
+render_priority = 0
+shader = ExtResource("5_7yrtq")
+shader_parameter/numframes = null
+shader_parameter/sizes = null
+shader_parameter/billboards = null
+
+[sub_resource type="QuadMesh" id="QuadMesh_fm6ks"]
+material = SubResource("ShaderMaterial_ghmi8")
+
+[sub_resource type="MultiMesh" id="MultiMesh_c56es"]
+transform_format = 1
+use_custom_data = true
+mesh = SubResource("QuadMesh_fm6ks")
 
 [node name="GameSession" type="Control" node_paths=PackedStringArray("_model_manager", "_game_session_menu")]
 editor_description = "SS-102, UI-546"
@@ -39,6 +56,13 @@ _game_session_menu = NodePath("UICanvasLayer/UI/GameSessionMenu")
 
 [node name="ModelManager" type="Node3D" parent="." node_paths=PackedStringArray("_map_view")]
 script = ExtResource("3_qwk4j")
+_map_view = NodePath("../MapView")
+
+[node name="BillboardManager" type="MultiMeshInstance3D" parent="." node_paths=PackedStringArray("_map_view")]
+sorting_offset = 10.0
+cast_shadow = 0
+multimesh = SubResource("MultiMesh_c56es")
+script = ExtResource("4_b3l7b")
 _map_view = NodePath("../MapView")
 
 [node name="UICanvasLayer" type="CanvasLayer" parent="."]
@@ -164,7 +188,9 @@ anchors_preset = 15
 script = ExtResource("20_3306e")
 
 [connection signal="detailed_view_changed" from="MapView" to="ModelManager" method="set_visible"]
+[connection signal="detailed_view_changed" from="MapView" to="BillboardManager" method="detailed_map"]
 [connection signal="map_view_camera_changed" from="MapView" to="UICanvasLayer/UI/Menubar" method="_on_map_view_camera_changed"]
+[connection signal="parchment_view_changed" from="MapView" to="BillboardManager" method="parchment_view"]
 [connection signal="game_session_menu_button_pressed" from="UICanvasLayer/UI/Menubar" to="." method="_on_game_session_menu_button_pressed"]
 [connection signal="ledger_button_pressed" from="UICanvasLayer/UI/Menubar" to="UICanvasLayer/UI/Ledger" method="toggle_visibility"]
 [connection signal="minimap_clicked" from="UICanvasLayer/UI/Menubar" to="MapView" method="_on_minimap_clicked"]

--- a/game/src/Game/GameSession/billboard.gdshader
+++ b/game/src/Game/GameSession/billboard.gdshader
@@ -1,0 +1,35 @@
+shader_type spatial;
+//depth_test_disabled along with the sorting offset of 10
+//ensures this will be drawn in front of other objects in 
+//3d space.
+render_mode unshaded, depth_test_disabled;
+
+//vic2 only ever loads a max of 12 BillboardType
+//Of these, only 4 are actually used
+uniform sampler2D billboards[12] : source_color;
+uniform uint numframes[12];
+uniform float sizes[12];
+
+//COLOR/INSTANCE_CUSTOM is our custom data, used as follows:
+// x=image index
+// y=frame in image index
+// z,w are unused for now
+
+void vertex() {
+	COLOR = INSTANCE_CUSTOM; //send instance_custom info to fragment
+	float size = sizes[uint(COLOR.x + 0.5)];
+	VERTEX = (vec4(VERTEX * size, 1.0) * VIEW_MATRIX).xyz;
+}
+
+void fragment() {
+	uint image_index = uint(COLOR.x + 0.5);
+	//Color.y == 0 >> invisible, otherwise use the specified frame
+	//COLOR.y is frame index otherwise
+	float visibility = min(COLOR.y,1.0);
+
+	float uv_x_space = 1.0/float(numframes[image_index]);
+	vec2 uv_out = vec2(uv_x_space * (COLOR.y + UV.x), UV.y);
+	vec4 billboard_color = texture( billboards[image_index] ,uv_out);
+	ALBEDO.rgb = billboard_color.rgb;
+	ALPHA = billboard_color.a * visibility;
+}


### PR DESCRIPTION
Billboards are used for various mapmodes, and for displaying nation capitals on the map.
Bunch of TODOS:
- Move billboards to own viewport so they don't clip into unit models or occlude them
- hide billboards when zoomed out
- Make billboards correspond to the map mode
- Stop capital billboards and map mode billboards from occluding eachother
- Fix billboard lighting
- Get billboards to display in the proper order if possible (occasionally a billboard will display behind another one which is further back)