### PR TITLE
When setting a tooltip, automatically switch mouse filter to PASS if it's IGNORE

### DIFF
--- a/extension/src/openvic-extension/classes/GUIHasTooltip.hpp
+++ b/extension/src/openvic-extension/classes/GUIHasTooltip.hpp
@@ -2,14 +2,11 @@
 
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/variant/string.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
-#include <godot_cpp/variant/vector2.hpp>
 
 #include <openvic-simulation/utility/Getters.hpp>
 
 #include "openvic-extension/singletons/MenuSingleton.hpp"
 #include "openvic-extension/utility/ClassBindings.hpp"
-#include "openvic-extension/utility/Utilities.hpp"
 
 /* To add tooltip functionality to a class:
  *  - the class must be derived from Control.
@@ -40,7 +37,7 @@
 		String const& new_tooltip_string, Dictionary const& new_tooltip_substitution_dict \
 	) { \
 		if (get_mouse_filter() == MOUSE_FILTER_IGNORE) { \
-			UtilityFunctions::push_error("Tooltips won't work for \"", get_name(), "\" as it has MOUSE_FILTER_IGNORE"); \
+			set_mouse_filter(MOUSE_FILTER_PASS); \
 		} \
 		if (tooltip_string != new_tooltip_string || tooltip_substitution_dict != new_tooltip_substitution_dict) { \
 			tooltip_string = new_tooltip_string; \
@@ -52,7 +49,7 @@
 	} \
 	void CLASS::set_tooltip_string(String const& new_tooltip_string) { \
 		if (get_mouse_filter() == MOUSE_FILTER_IGNORE) { \
-			UtilityFunctions::push_error("Tooltips won't work for \"", get_name(), "\" as it has MOUSE_FILTER_IGNORE"); \
+			set_mouse_filter(MOUSE_FILTER_PASS); \
 		} \
 		if (tooltip_string != new_tooltip_string) { \
 			tooltip_string = new_tooltip_string; \
@@ -63,7 +60,7 @@
 	} \
 	void CLASS::set_tooltip_substitution_dict(Dictionary const& new_tooltip_substitution_dict) { \
 		if (get_mouse_filter() == MOUSE_FILTER_IGNORE) { \
-			UtilityFunctions::push_error("Tooltips won't work for \"", get_name(), "\" as it has MOUSE_FILTER_IGNORE"); \
+			set_mouse_filter(MOUSE_FILTER_PASS); \
 		} \
 		if (tooltip_substitution_dict != new_tooltip_substitution_dict) { \
 			tooltip_substitution_dict = new_tooltip_substitution_dict; \

--- a/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
@@ -317,30 +317,15 @@ func _setup_pop_list() -> void:
 
 		_pop_list_producing_icons.push_back(GUINode.get_gui_icon_from_node(pop_row_panel.get_node(^"./pop_producing_icon")))
 
-		var culture_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_nation"))
-		_pop_list_culture_labels.push_back(culture_label)
-		if culture_label:
-			culture_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_culture_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_nation")))
 
-		var religion_icon : GUIIcon = GUINode.get_gui_icon_from_node(pop_row_panel.get_node(^"./pop_religion"))
-		_pop_list_religion_icons.push_back(religion_icon)
-		if religion_icon:
-			religion_icon.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_religion_icons.push_back(GUINode.get_gui_icon_from_node(pop_row_panel.get_node(^"./pop_religion")))
 
-		var location_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_location"))
-		_pop_list_location_labels.push_back(location_label)
-		if location_label:
-			location_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_location_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_location")))
 
-		var militancy_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_mil"))
-		_pop_list_militancy_labels.push_back(militancy_label)
-		if militancy_label:
-			militancy_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_militancy_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_mil")))
 
-		var consciousness_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_con"))
-		_pop_list_consciousness_labels.push_back(consciousness_label)
-		if consciousness_label:
-			consciousness_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_consciousness_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_con")))
 
 		_pop_list_ideology_charts.push_back(GUINode.get_gui_pie_chart_from_node(pop_row_panel.get_node(^"./pop_ideology")))
 
@@ -348,10 +333,7 @@ func _setup_pop_list() -> void:
 
 		_pop_list_unemployment_progressbars.push_back(GUINode.get_gui_progress_bar_from_node(pop_row_panel.get_node(^"./pop_unemployment_bar")))
 
-		var cash_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_cash"))
-		_pop_list_cash_labels.push_back(cash_label)
-		if cash_label:
-			cash_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_cash_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_cash")))
 
 		var pop_list_life_needs_progressbar : GUIProgressBar = GUINode.get_gui_progress_bar_from_node(pop_row_panel.get_node(^"./lifeneed_progress"))
 		_pop_list_life_needs_progressbars.push_back(pop_list_life_needs_progressbar)
@@ -373,15 +355,9 @@ func _setup_pop_list() -> void:
 
 		_pop_list_national_movement_flags.push_back(GUINode.get_gui_masked_flag_from_node(pop_row_panel.get_node(^"./pop_movement_flag")))
 
-		var size_change_icon : GUIIcon = GUINode.get_gui_icon_from_node(pop_row_panel.get_node(^"./growth_indicator"))
-		_pop_list_size_change_icons.push_back(size_change_icon)
-		if size_change_icon:
-			size_change_icon.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_size_change_icons.push_back(GUINode.get_gui_icon_from_node(pop_row_panel.get_node(^"./growth_indicator")))
 
-		var literacy_label : GUILabel = GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_literacy"))
-		_pop_list_literacy_labels.push_back(literacy_label)
-		if literacy_label:
-			literacy_label.set_mouse_filter(MOUSE_FILTER_PASS)
+		_pop_list_literacy_labels.push_back(GUINode.get_gui_label_from_node(pop_row_panel.get_node(^"./pop_literacy")))
 
 func _notification(what : int) -> void:
 	match what:
@@ -536,10 +512,13 @@ func _update_distributions():
 				var colour_icon : GUIIcon = GUINode.get_gui_icon_from_node(child.get_node(^"./legend_color"))
 				if colour_icon:
 					colour_icon.set_modulate(distribution_row[slice_colour_key])
-					colour_icon.set_mouse_filter(MOUSE_FILTER_PASS)
-					colour_icon.set_tooltip_string_and_substitution_dict("§Y$ID$§!: $PC$%", {
-						"ID": distribution_row[slice_identifier_key], "PC": GUINode.float_to_string_dp(distribution_row[slice_weight_key] * 100.0, 2)
-					})
+					colour_icon.set_tooltip_string_and_substitution_dict(
+						"§Y$ID$§!: $PC$%" + "\nTEST: colour_icon",
+						{
+							"ID": distribution_row[slice_identifier_key],
+							"PC": GUINode.float_to_string_dp(distribution_row[slice_weight_key] * 100.0, 2)
+						}
+					)
 
 				var identifier_label : GUILabel = GUINode.get_gui_label_from_node(child.get_node(^"./legend_title"))
 				if identifier_label:

--- a/game/src/Game/GameSession/Topbar.gd
+++ b/game/src/Game/GameSession/Topbar.gd
@@ -102,29 +102,13 @@ func _ready() -> void:
 	_country_flag_overlay_icon = get_gui_icon_from_nodepath(^"./topbar/topbar_flag_overlay")
 	_country_name_label = get_gui_label_from_nodepath(^"./topbar/CountryName")
 	_country_rank_label = get_gui_label_from_nodepath(^"./topbar/nation_totalrank")
-	if _country_rank_label:
-		_country_rank_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_prestige_label = get_gui_label_from_nodepath(^"./topbar/country_prestige")
-	if _country_prestige_label:
-		_country_prestige_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_prestige_rank_label = get_gui_label_from_nodepath(^"./topbar/selected_prestige_rank")
-	if _country_prestige_rank_label:
-		_country_prestige_rank_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_industrial_power_label = get_gui_label_from_nodepath(^"./topbar/country_economic")
-	if _country_industrial_power_label:
-		_country_industrial_power_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_industrial_power_rank_label = get_gui_label_from_nodepath(^"./topbar/selected_industry_rank")
-	if _country_industrial_power_rank_label:
-		_country_industrial_power_rank_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_military_power_label = get_gui_label_from_nodepath(^"./topbar/country_military")
-	if _country_military_power_label:
-		_country_military_power_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_military_power_rank_label = get_gui_label_from_nodepath(^"./topbar/selected_military_rank")
-	if _country_military_power_rank_label:
-		_country_military_power_rank_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_country_colonial_power_label = get_gui_label_from_nodepath(^"./topbar/country_colonial_power")
-	if _country_colonial_power_label:
-		_country_colonial_power_label.set_mouse_filter(MOUSE_FILTER_PASS)
 
 	# Time controls
 	_speed_up_button = get_gui_icon_button_from_nodepath(^"./topbar/button_speedup")
@@ -184,20 +168,14 @@ func _ready() -> void:
 	if _technology_progress_bar and tech_button:
 		_technology_progress_bar.reparent(tech_button)
 	_technology_current_research_label = get_gui_label_from_nodepath(^"./topbar/tech_current_research")
-	if _technology_current_research_label:
-		_technology_current_research_label.set_mouse_filter(MOUSE_FILTER_PASS)
-		if tech_button:
-			_technology_current_research_label.reparent(tech_button)
+	if _technology_current_research_label and tech_button:
+		_technology_current_research_label.reparent(tech_button)
 	_technology_literacy_label = get_gui_label_from_nodepath(^"./topbar/tech_literacy_value")
-	if _technology_literacy_label:
-		_technology_literacy_label.set_mouse_filter(MOUSE_FILTER_PASS)
-		if tech_button:
-			_technology_literacy_label.reparent(tech_button)
+	if _technology_literacy_label and tech_button:
+		_technology_literacy_label.reparent(tech_button)
 	_technology_research_points_label = get_gui_label_from_nodepath(^"./topbar/topbar_researchpoints_value")
-	if _technology_research_points_label:
-		_technology_research_points_label.set_mouse_filter(MOUSE_FILTER_PASS)
-		if tech_button:
-			_technology_research_points_label.reparent(tech_button)
+	if _technology_research_points_label and tech_button:
+		_technology_research_points_label.reparent(tech_button)
 
 	# Politics
 	_politics_party_icon = get_gui_icon_from_nodepath(^"./topbar/politics_party_icon")
@@ -264,18 +242,11 @@ func _ready() -> void:
 	# Military
 	_military_army_size_label = get_gui_label_from_nodepath(^"./topbar/military_army_value")
 	if _military_army_size_label:
-		_military_army_size_label.set_mouse_filter(MOUSE_FILTER_PASS)
 		_military_army_size_label.set_text("§Y$CURR$/$MAX$")
 		_military_army_size_label.set_tooltip_string("TOPBAR_ARMY_TOOLTIP")
 	_military_navy_size_label = get_gui_label_from_nodepath(^"./topbar/military_navy_value")
-	if _military_navy_size_label:
-		_military_navy_size_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_military_mobilisation_size_label = get_gui_label_from_nodepath(^"./topbar/military_manpower_value")
-	if _military_mobilisation_size_label:
-		_military_mobilisation_size_label.set_mouse_filter(MOUSE_FILTER_PASS)
 	_military_leadership_points_label = get_gui_label_from_nodepath(^"./topbar/military_leadership_value")
-	if _military_leadership_points_label:
-		_military_leadership_points_label.set_mouse_filter(MOUSE_FILTER_PASS)
 
 	_update_info()
 	_update_speed_controls()
@@ -539,6 +510,7 @@ func _update_info() -> void:
 
 	if _military_navy_size_label:
 		_military_navy_size_label.set_text("§Y%d/%d" % [0, 0])
+		# TODO - navy size tooltip
 
 	const mobilised_key : StringName = &"mobilised"
 	const mobilisation_regiments_key : StringName = &"mobilisation_regiments"
@@ -565,6 +537,7 @@ func _update_info() -> void:
 
 	if _military_leadership_points_label:
 		_military_leadership_points_label.set_text("§Y%d" % 0)
+		# TODO - leadership points tooltip
 
 func _update_speed_controls() -> void:
 	var paused : bool = MenuSingleton.is_paused()


### PR DESCRIPTION
Since we now no longer have to change the mouse filter of nodes with tooltips but default mouse filter IGNORE manually, I have removed that code for the following nodes:
- Topbar
  - Total rank label
  - Prestige label
  - Prestige rank label
  - Industrial power label
  - Industrial power rank label
  - Military power label
  - Military power rank label
  - Colonial power label
  - Current research label
  - National literacy label
  - Research points label
  - Army size label
  - Navy size label (tooltip not yet implemented)
  - Mobilisation size label
  - Leadership points label (tooltip not yet implemented)
- Population Menu
  - Culture labels
  - Religion icons
  - Localtion labels
  - Militancy labels
  - Consciousness labels
  - Cash labels
  - Size change icons
  - Literacy labels
  - Distribution legend colour icons