### PR TITLE
Add tooltip for RGO_employment

### DIFF
--- a/extension/src/openvic-extension/classes/GUILabel.cpp
+++ b/extension/src/openvic-extension/classes/GUILabel.cpp
@@ -587,8 +587,8 @@ std::vector<GUILabel::line_t> GUILabel::generate_lines_and_segments(
 	unwrapped_lines.emplace_back();
 
 	for (int64_t idx = 0; idx < display_text.length(); ++idx) {
-		if (colour_it != colour_instructions.end() && idx == colour_it->first) {
-			Color new_colour = current_colour;
+		Color new_colour = current_colour;
+		while (colour_it != colour_instructions.end() && idx == colour_it->first) {
 			if (colour_it->second == RESET_COLOUR_CODE) {
 				new_colour = default_colour;
 			} else {
@@ -598,16 +598,16 @@ std::vector<GUILabel::line_t> GUILabel::generate_lines_and_segments(
 				}
 			}
 			++colour_it;
+		}
 
-			if (current_colour != new_colour) {
-				if (section_start < idx) {
-					separate_lines(
-						display_text.substr(section_start, idx - section_start), current_colour, unwrapped_lines
-					);
-					section_start = idx;
-				}
-				current_colour = new_colour;
+		if (current_colour != new_colour) {
+			if (section_start < idx) {
+				separate_lines(
+					display_text.substr(section_start, idx - section_start), current_colour, unwrapped_lines
+				);
+				section_start = idx;
 			}
+			current_colour = new_colour;
 		}
 	}
 

--- a/game/src/Game/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/Game/GameSession/ProvinceOverviewPanel.gd
@@ -242,6 +242,7 @@ func _update_info() -> void:
 	const _province_info_rgo_icon_key         : StringName = &"rgo_icon"
 	const _province_info_rgo_total_employees_key : StringName = &"rgo_total_employees"
 	const _province_info_rgo_employment_percentage_key : StringName = &"rgo_employment_percentage"
+	const _province_info_rgo_employment_tooltip_key : StringName = &"rgo_employment_tooltip"
 	const _province_info_rgo_output_quantity_yesterday_key : StringName = &"rgo_output_quantity_yesterday"
 	const _province_info_rgo_revenue_yesterday_key : StringName = &"rgo_revenue_yesterday"
 	const _province_info_crime_name_key       : StringName = &"crime_name"
@@ -314,14 +315,19 @@ func _update_info() -> void:
 		if _rgo_income_label:
 			_rgo_income_label.text = "%s¤" % GUINode.float_to_string_dp(_province_info.get(_province_info_rgo_revenue_yesterday_key, 0), 3)
 
+		var rgo_employment_tooltip : String = _province_info.get(_province_info_rgo_employment_tooltip_key, "")
+
 		if _rgo_employment_percentage_icon:
 			_rgo_employment_percentage_icon.set_icon_index(int(_province_info.get(_province_info_rgo_employment_percentage_key, 0) / 10) + 1)
+			_rgo_employment_percentage_icon.set_tooltip_string(rgo_employment_tooltip)
 
 		if _rgo_employment_population_label:
 			_rgo_employment_population_label.text = GUINode.int_to_string_suffixed(_province_info.get(_province_info_rgo_total_employees_key, 0))
+			_rgo_employment_population_label.set_tooltip_string(rgo_employment_tooltip)
 
 		if _rgo_employment_percentage_label:
 			_rgo_employment_percentage_label.text = "%d%%" % _province_info.get(_province_info_rgo_employment_percentage_key, 0)
+			_rgo_employment_percentage_label.set_tooltip_string(rgo_employment_tooltip)
 
 		if _crime_name_label:
 			_crime_name_label.text = _province_info.get(_province_info_crime_name_key, "")


### PR DESCRIPTION
This adds the tooltip to the rgo_employment_population_label. The other ones have a test message. I am having some trouble with accessing the modifier_effect_cache since there is no getter for it unless there is a different place where that information is stored.