### PR TITLE
Add map projections

### DIFF
--- a/extension/doc_classes/MapItemSingleton.xml
+++ b/extension/doc_classes/MapItemSingleton.xml
@@ -3,6 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
+		This singleton provides methods of optaining [code]billboard[/code] and [code]projection[/code] type graphics objects. It also provides methods for getting the proper location of these objects on the map.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,36 +11,70 @@
 		<method name="get_billboards" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
+				Returns an array of Dictionaries. Each dictionary contains the keys [code]name[/code] [StringName], [code]texture[/code] [StringName], [code]scale[/code] [float], [code]noOfFrames[/code] [int] used to make a billboard object. [code]texture[/code] is a [StringName] path to the billboard texture. [code]noOfFrames[/code] is a [float] scaling factor. [code]noOfFrames[/code] is an [int] specifying how many icons are in the texture image.
 			</description>
 		</method>
 		<method name="get_capital_positions" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
+				Returns an array of the positions of country capital billboards for all existing countries. The capital billboard position is the [code]city[/code] property of a province which is a capital in the game defines.
+			</description>
+		</method>
+		<method name="get_clicked_port_province_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="position" type="Vector2" />
+			<description>
+				Searches the mouse map coordinate for any port within a radius. Returns the province index of a found port, or [code]0[/code] if no port was found within the radius of the click.
 			</description>
 		</method>
 		<method name="get_crime_icons" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
+				Returns an array of icon indices to use on the crimes texture to get the appropriate crime icons for every land province. An index of [code]0[/code] indicates there is no crime for that province.
 			</description>
 		</method>
 		<method name="get_max_capital_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the size of the number of defined countries. This is the maximum possible number of capital billboards the game could have to display.
 			</description>
 		</method>
 		<method name="get_national_focus_icons" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
+				TODO: WIP Function awaiting implementation of national focuses. Returns an array of icon indices used with the national focus icons texture for every province. For provinces which aren't state capitals, or don't have have a national focus applied, this will be [code]0[/code].
+			</description>
+		</method>
+		<method name="get_port_position_by_province_index" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Given a province [param index], returns the position of the province's port. Emits an error and returns [code]0,0[/code] if the province does not have a port.
+			</description>
+		</method>
+		<method name="get_projections" qualifiers="const">
+			<return type="Dictionary[]" />
+			<description>
+				Returns an array of Dictionaries. Each dictionary contains the keys [code]name[/code] [StringName], [code]texture[/code] [StringName], [code]size[/code] [float], [code]spin[/code] [float], [code]expanding[/code] [float], [code]duration[/code] [float], [code]additative[/code] [bool].
 			</description>
 		</method>
 		<method name="get_province_positions" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
+				Returns an array of billboard positions for every land province. This corresponds to a province's [code]city[/code] define.
 			</description>
 		</method>
 		<method name="get_rgo_icons" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
+				Returns an array of icon indices used with the trade goods (RGO) icons texture for every land province. If the province the province does not have an RGO, it will be 0.
+			</description>
+		</method>
+		<method name="get_unit_position_by_province_index" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Given a province [param index], returns the province's unit position.
 			</description>
 		</method>
 	</methods>

--- a/extension/src/openvic-extension/singletons/AssetManager.cpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.cpp
@@ -51,6 +51,9 @@ Ref<Image> AssetManager::_load_image(StringName const& path, bool flip_y) {
 		image.is_null() || image->is_empty(), nullptr,
 		vformat("Failed to load image: %s (looked up: %s)", path, lookedup_path)
 	);
+	if (image->detect_alpha() != Image::ALPHA_NONE) {
+		image->fix_alpha_edges();
+	}
 
 	if (flip_y) {
 		image->flip_y();

--- a/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
@@ -1,17 +1,18 @@
 #include "MapItemSingleton.hpp"
 #include <string_view>
 
+#include "godot_cpp/core/error_macros.hpp"
 #include "godot_cpp/variant/packed_int32_array.hpp"
 #include "godot_cpp/variant/packed_vector2_array.hpp"
 #include "godot_cpp/variant/typed_array.hpp"
-#include "godot_cpp/variant/utility_functions.hpp"
 #include "godot_cpp/variant/vector2.hpp"
 #include "openvic-extension/singletons/GameSingleton.hpp"
 #include "openvic-extension/utility/ClassBindings.hpp"
 #include "openvic-extension/utility/Utilities.hpp"
-#include "openvic-simulation/DefinitionManager.hpp"
 #include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/country/CountryInstance.hpp"
+#include "openvic-simulation/DefinitionManager.hpp"
+#include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/interface/GFXObject.hpp"
 #include "openvic-simulation/map/ProvinceDefinition.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
@@ -20,6 +21,7 @@
 
 using namespace godot;
 using namespace OpenVic;
+using namespace OpenVic::Utilities::literals;
 
 void MapItemSingleton::_bind_methods() {
 	OV_BIND_METHOD(MapItemSingleton::get_billboards);
@@ -29,6 +31,11 @@ void MapItemSingleton::_bind_methods() {
 	OV_BIND_METHOD(MapItemSingleton::get_crime_icons);
 	OV_BIND_METHOD(MapItemSingleton::get_rgo_icons);
 	OV_BIND_METHOD(MapItemSingleton::get_national_focus_icons);
+	OV_BIND_METHOD(MapItemSingleton::get_projections);
+	OV_BIND_METHOD(MapItemSingleton::get_unit_position_by_province_index,{"index"});
+	OV_BIND_METHOD(MapItemSingleton::get_port_position_by_province_index,{"index"});
+	OV_BIND_METHOD(MapItemSingleton::get_clicked_port_province_index, {"position"});
+	
 }
 
 MapItemSingleton* MapItemSingleton::get_singleton() {
@@ -45,57 +52,72 @@ MapItemSingleton::~MapItemSingleton() {
 	singleton = nullptr;
 }
 
-// Get the billboard object from the loaded objects
-GFX::Billboard const* MapItemSingleton::get_billboard(std::string_view name, bool error_on_fail) const {
-	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, nullptr);
-
-	GFX::Billboard const* billboard =
-		game_singleton->get_definition_manager().get_ui_manager().get_cast_object_by_identifier<GFX::Billboard>(name);
-
-	if (error_on_fail) {
-		ERR_FAIL_NULL_V_MSG(
-			billboard, nullptr, vformat("Failed to find billboard \"%s\"", Utilities::std_to_godot_string(name))
-		);
-	}
-
-	return billboard;
-}
-
 // repackage the billboard object into a godot dictionary for the Billboard manager to work with
-bool MapItemSingleton::add_billboard_dict(std::string_view name, TypedArray<Dictionary>& billboard_dict_array) const {
+void MapItemSingleton::add_billboard_dict(GFX::Billboard const& billboard, TypedArray<Dictionary>& billboard_dict_array) const {
 
 	static const StringName name_key = "name";
 	static const StringName texture_key = "texture";
 	static const StringName scale_key = "scale";
 	static const StringName noOfFrames_key = "noFrames";
 
-	GFX::Billboard const* billboard = get_billboard(name, false);
-
-	ERR_FAIL_NULL_V_MSG(billboard, false, vformat("Failed to find billboard \"%s\"", Utilities::std_to_godot_string(name)));
-
 	Dictionary dict;
 
-	dict[name_key] = Utilities::std_to_godot_string(billboard->get_name());
-	dict[texture_key] = Utilities::std_to_godot_string(billboard->get_texture_file());
-	dict[scale_key] = billboard->get_scale().to_float();
-	dict[noOfFrames_key] = billboard->get_no_of_frames();
+	dict[name_key] = Utilities::std_to_godot_string(billboard.get_name());
+	dict[texture_key] = Utilities::std_to_godot_string(billboard.get_texture_file());
+	dict[scale_key] = billboard.get_scale().to_float();
+	dict[noOfFrames_key] = billboard.get_no_of_frames();
 
 	billboard_dict_array.push_back(dict);
-
-	return true;
 }
 
 //get an array of all the billboard dictionaries
 TypedArray<Dictionary> MapItemSingleton::get_billboards() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
+
 
 	TypedArray<Dictionary> ret;
 
 	for (std::unique_ptr<GFX::Object> const& obj : game_singleton->get_definition_manager().get_ui_manager().get_objects()) {
-		if (obj->is_type<GFX::Billboard>()) {
-			add_billboard_dict(obj->get_name(), ret);
+		GFX::Billboard const* billboard = obj->cast_to<GFX::Billboard>();
+		if (billboard != nullptr) {
+			add_billboard_dict(*billboard, ret);
+		}
+	}
+
+	return ret;
+}
+
+void MapItemSingleton::add_projection_dict(GFX::Projection const& projection, TypedArray<Dictionary>& projection_dict_array) const {
+	static const StringName name_key = "name";
+	static const StringName texture_key = "texture";
+	static const StringName size_key = "size";
+	static const StringName spin_key = "spin";
+	static const StringName expanding_key = "expanding";
+	static const StringName duration_key = "duration";
+	static const StringName additative_key = "additative";
+
+	Dictionary dict;
+
+	dict[name_key] = Utilities::std_to_godot_string(projection.get_name());
+	dict[texture_key] = Utilities::std_to_godot_string(projection.get_texture_file());
+	dict[size_key] = projection.get_size().to_float();
+	dict[spin_key] = projection.get_spin().to_float();
+	dict[expanding_key] = projection.get_expanding().to_float();
+	dict[duration_key] = projection.get_duration().to_float();
+	dict[additative_key] = projection.get_additative();
+
+	projection_dict_array.push_back(dict);
+}
+
+TypedArray<Dictionary> MapItemSingleton::get_projections() const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+
+	TypedArray<Dictionary> ret;
+
+	for (std::unique_ptr<GFX::Object> const& obj : game_singleton->get_definition_manager().get_ui_manager().get_objects()) {
+		GFX::Projection const* projection = obj->cast_to<GFX::Projection>();
+		if (projection != nullptr) {
+			add_projection_dict(*projection, ret);
 		}
 	}
 
@@ -104,8 +126,6 @@ TypedArray<Dictionary> MapItemSingleton::get_billboards() const {
 
 PackedVector2Array MapItemSingleton::get_province_positions() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
-
 	MapDefinition const& map_definition = game_singleton->get_definition_manager().get_map_definition();
 
 	PackedVector2Array billboard_pos {};
@@ -128,16 +148,11 @@ PackedVector2Array MapItemSingleton::get_province_positions() const {
 
 //includes non-existent countries, used for setting the billboard buffer size
 int32_t MapItemSingleton::get_max_capital_count() const {
-	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, 0);
-
-	return game_singleton->get_definition_manager().get_country_definition_manager().get_country_definition_count();
+	return GameSingleton::get_singleton()->get_definition_manager().get_country_definition_manager().get_country_definition_count();
 }
 
 PackedVector2Array MapItemSingleton::get_capital_positions() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
-
 	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
 	ERR_FAIL_NULL_V(instance_manager, {});
 
@@ -165,8 +180,6 @@ PackedVector2Array MapItemSingleton::get_capital_positions() const {
 
 PackedByteArray MapItemSingleton::get_crime_icons() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
-
 	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
 	ERR_FAIL_NULL_V(instance_manager, {});
 
@@ -193,8 +206,6 @@ PackedByteArray MapItemSingleton::get_crime_icons() const {
 
 PackedByteArray MapItemSingleton::get_rgo_icons() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
-
 	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
 	ERR_FAIL_NULL_V(instance_manager, {});
 
@@ -230,8 +241,6 @@ TODO: National focus isn't implemented yet. It could be done at the country inst
 
 PackedByteArray MapItemSingleton::get_national_focus_icons() const {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V(game_singleton, {});
-
 	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
 	ERR_FAIL_NULL_V(instance_manager, {});
 
@@ -254,4 +263,67 @@ PackedByteArray MapItemSingleton::get_national_focus_icons() const {
 	}
 
 	return icons;
+}
+
+
+Vector2 MapItemSingleton::get_unit_position_by_province_index(int32_t province_index) const { 
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+
+	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
+		.get_province_definition_by_index(province_index);
+	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get unit position - invalid province index: %d", province_index));
+
+	return game_singleton->normalise_map_position(province->get_unit_position());
+}
+
+Vector2 MapItemSingleton::get_port_position_by_province_index(int32_t province_index) const { 
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+
+	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
+		.get_province_definition_by_index(province_index);
+	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get port position - invalid province index: %d", province_index));
+	ERR_FAIL_COND_V_MSG(!province->has_port(), {},vformat("Cannot get port position, province has no port, index: %d", province_index) ); 
+
+	BuildingType const* port_building_type = game_singleton->get_definition_manager().get_economy_manager().get_building_type_manager().get_port_building_type();
+	fvec2_t const* port_position = province->get_building_position(port_building_type);
+
+	//no null check because province->has_port() condition passed, already verifying that this isn't null
+	return game_singleton->normalise_map_position(*port_position);
+}
+
+static constexpr real_t port_radius = 0.0006_real; //how close we have to click for a detection
+
+//Searches provinces near the one clicked and attempts to find a port within the port_radius of the click position
+int32_t MapItemSingleton::get_clicked_port_province_index(Vector2 click_position) const {
+	GameSingleton const* game_singleton = GameSingleton::get_singleton();
+
+	int32_t initial_province_index = game_singleton->get_province_index_from_uv_coords(click_position);
+
+	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
+		.get_province_definition_by_index(initial_province_index);
+	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get port position - invalid province index: %d", initial_province_index));
+
+	BuildingType const* port_building_type = game_singleton->get_definition_manager().get_economy_manager().get_building_type_manager().get_port_building_type();
+	
+	if(province->has_port()){
+		Vector2 port_position = game_singleton->normalise_map_position(*province->get_building_position(port_building_type));
+		if(click_position.distance_to(port_position) <= port_radius){
+			return province->get_index();
+		}
+	}
+	else if(province->is_water()){
+		// search the adjacent provinces for ones with ports
+		for(ProvinceDefinition::adjacency_t const& adjacency : province->get_adjacencies()) {
+			ProvinceDefinition const* adjacent_province = adjacency.get_to();
+			if(!adjacent_province->has_port()) { 
+				continue; // skip provinces without ports (ie. other water provinces)
+			}
+			Vector2 port_position = game_singleton->normalise_map_position(*adjacent_province->get_building_position(port_building_type));
+			if(click_position.distance_to(port_position) <= port_radius){
+				return adjacent_province->get_index();
+			}
+		}
+	}
+
+	return 0;
 }

--- a/extension/src/openvic-extension/singletons/MapItemSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MapItemSingleton.hpp
@@ -5,8 +5,7 @@
 #include <openvic-simulation/interface/GFXObject.hpp>
 #include <openvic-simulation/types/OrderedContainers.hpp>
 
-//billboards, projections, and progress bar
-//for now though, only billboards
+//billboards, projections, and progress bar (no progress bar yet)
 
 namespace OpenVic {
 	class MapItemSingleton : public godot::Object {
@@ -24,9 +23,12 @@ namespace OpenVic {
 		~MapItemSingleton();
 
 	private:
-		GFX::Billboard const* get_billboard(std::string_view name, bool error_on_fail = true) const;
-		bool add_billboard_dict(std::string_view name, godot::TypedArray<godot::Dictionary>& billboard_dict_array) const;
+		void add_billboard_dict(GFX::Billboard const& billboard, godot::TypedArray<godot::Dictionary>& billboard_dict_array) const;
 		godot::TypedArray<godot::Dictionary> get_billboards() const;
+
+		void add_projection_dict(GFX::Projection const& projection, godot::TypedArray<godot::Dictionary>& projection_dict_array) const;
+		godot::TypedArray<godot::Dictionary> get_projections() const;		
+
 		godot::PackedVector2Array get_province_positions() const;
 		int32_t get_max_capital_count() const;
 		godot::PackedVector2Array get_capital_positions() const;
@@ -34,5 +36,9 @@ namespace OpenVic {
 		godot::PackedByteArray get_crime_icons() const;
 		godot::PackedByteArray get_rgo_icons() const;
 		godot::PackedByteArray get_national_focus_icons() const;
+
+		godot::Vector2 get_unit_position_by_province_index(int32_t province_index) const;
+		godot::Vector2 get_port_position_by_province_index(int32_t province_index) const;
+		int32_t get_clicked_port_province_index(godot::Vector2 click_position) const;
 	};
 }

--- a/game/project.godot
+++ b/game/project.godot
@@ -142,6 +142,11 @@ menu_pause={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+select_add={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 
 [internationalization]
 
@@ -164,6 +169,7 @@ limits/message_queue/max_size_kb=16384
 settings/settings_file_path="user://settings.cfg"
 data/saves_directory="user://saves"
 project_file_req_comment.editor="FS-2, FS-20, FS-21, FS-22"
+settings/ips_file_path="user://ips.cfg"
 
 [rendering]
 

--- a/game/src/Game/GameSession/BillboardManager.gd
+++ b/game/src/Game/GameSession/BillboardManager.gd
@@ -79,14 +79,10 @@ func _ready() -> void:
 		var billboard_scale : float = billboard[scale_key]
 		var no_of_frames : int = billboard[no_of_frames_key]
 
-		#fix the alpha edges of the billboard textures
 		var texture : ImageTexture = AssetManager.get_texture(texture_name)
 		if texture == null:
 			push_error("Texture for billboard \"", billboard_name, "\" was null!")
 			continue
-		var image : Image = texture.get_image()
-		image.fix_alpha_edges()
-		texture.set_image(image)
 
 		# We use the texture array size (which will be the same as frames and scales' sizes)
 		# rather than billboard_index as the former only counts billboards we're actually using,

--- a/game/src/Game/GameSession/MapView.gd
+++ b/game/src/Game/GameSession/MapView.gd
@@ -18,6 +18,7 @@ const _action_zoom_out : StringName = &"map_zoom_out"
 const _action_drag : StringName = &"map_drag"
 const _action_click : StringName = &"map_click"
 const _action_right_click : StringName = &"map_right_click"
+const _action_select_add : StringName = &"select_add"
 
 @export var _camera : Camera3D
 
@@ -63,6 +64,9 @@ var _mouse_pos_map : Vector2 = Vector2(0.5, 0.5)
 var _viewport_dims : Vector2 = Vector2(1, 1)
 
 @export var _map_text : MapText
+
+@export var validMoveMarkers : ValidMoveMarkers
+@export var selectionMarkers : SelectionMarkers
 
 # ??? Strange Godot/GDExtension Bug ???
 # Upon first opening a clone of this repo with the Godot Editor,
@@ -221,17 +225,43 @@ func _unhandled_input(event : InputEvent) -> void:
 				_action_south
 			) * _cardinal_move_speed
 
+	elif event.is_action_pressed(_action_select_add):
+		if _mouse_over_viewport:
+			if _map_mesh.is_valid_uv_coord(_mouse_pos_map):
+				GameSingleton.set_selected_province(GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map))
+				var province_index : int = GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map)
+				# TODO: Proper unit selection logic should replace this temporary behaviour
+				var port_province_index : int = MapItemSingleton.get_clicked_port_province_index(_mouse_pos_map)
+				if port_province_index != 0:
+					var port_pos : Vector2 = MapItemSingleton.get_port_position_by_province_index(port_province_index)
+					selectionMarkers.toggle_id_selected(5000 + port_province_index, _map_to_world_coords(port_pos))
+				else:
+					var unit_position : Vector2 = MapItemSingleton.get_unit_position_by_province_index(province_index)
+					selectionMarkers.toggle_id_selected(province_index,_map_to_world_coords(unit_position))
+
 	elif event.is_action_pressed(_action_click):
 		if _mouse_over_viewport:
 			# Check if the mouse is outside of bounds
 			if _map_mesh.is_valid_uv_coord(_mouse_pos_map):
 				province_clicked.emit(GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map))
+				selectionMarkers.clear_selection_markers()
 			else:
 				print("Clicked outside the map!")
 	elif event.is_action_pressed(_action_right_click):
 		if _mouse_over_viewport:
 			if _map_mesh.is_valid_uv_coord(_mouse_pos_map):
 				province_right_clicked.emit(GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map))
+				var province_index : int = GameSingleton.get_province_index_from_uv_coords(_mouse_pos_map)
+				var port_province_index : int = MapItemSingleton.get_clicked_port_province_index(_mouse_pos_map)
+				if port_province_index != 0:
+					var port_pos : Vector2 = MapItemSingleton.get_port_position_by_province_index(port_province_index)
+					validMoveMarkers.add_move_marker(_map_to_world_coords(port_pos), randi_range(0,1))
+				else:
+					var unit_position : Vector2 = MapItemSingleton.get_unit_position_by_province_index(province_index)
+					validMoveMarkers.add_move_marker(_map_to_world_coords(unit_position), randi_range(0,1))
+				# TODO - open diplomacy screen on province owner or viewed country if province has no owner
+				#Events.NationManagementScreens.open_nation_management_screen(NationManagement.Screen.DIPLOMACY)
+				GameSingleton.set_viewed_country_by_province_index(province_index)
 			else:
 				print("Right-clicked outside the map!")
 	elif event.is_action_pressed(_action_drag):

--- a/game/src/Game/GameSession/MapView.tscn
+++ b/game/src/Game/GameSession/MapView.tscn
@@ -1,8 +1,37 @@
-[gd_scene load_steps=8 format=3 uid="uid://dkehmdnuxih2r"]
+[gd_scene load_steps=16 format=3 uid="uid://dkehmdnuxih2r"]
 
 [ext_resource type="Script" path="res://src/Game/GameSession/MapView.gd" id="1_exccw"]
 [ext_resource type="Shader" path="res://src/Game/GameSession/TerrainMap.gdshader" id="1_upocn"]
 [ext_resource type="Script" path="res://src/Game/GameSession/MapText.gd" id="2_13bgq"]
+[ext_resource type="Script" path="res://src/Game/GameSession/ProjectionManager.gd" id="2_xnmdg"]
+[ext_resource type="Script" path="res://src/Game/GameSession/SelectionMarkers.gd" id="3_fi78k"]
+[ext_resource type="Shader" path="res://src/Game/GameSession/Projection.gdshader" id="4_2f4io"]
+[ext_resource type="Script" path="res://src/Game/GameSession/ValidMoveMarkers.gd" id="5_h3t3v"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_blhuf"]
+render_priority = 0
+shader = ExtResource("4_2f4io")
+shader_parameter/sizes = null
+shader_parameter/spin = null
+shader_parameter/expanding = null
+shader_parameter/duration = null
+shader_parameter/additative = null
+shader_parameter/time = 0.0
+shader_parameter/projections = null
+
+[sub_resource type="QuadMesh" id="QuadMesh_72iss"]
+material = SubResource("ShaderMaterial_blhuf")
+orientation = 1
+
+[sub_resource type="MultiMesh" id="MultiMesh_rytvv"]
+transform_format = 1
+use_custom_data = true
+mesh = SubResource("QuadMesh_72iss")
+
+[sub_resource type="MultiMesh" id="MultiMesh_cq0pk"]
+transform_format = 1
+use_custom_data = true
+mesh = SubResource("QuadMesh_72iss")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_tayeg"]
 render_priority = 0
@@ -24,17 +53,38 @@ albedo_color = Color(0, 0, 0, 1)
 material = SubResource("StandardMaterial3D_irk50")
 size = Vector2(6, 2)
 
-[node name="MapView" type="Node3D" node_paths=PackedStringArray("_camera", "_map_mesh_instance", "_map_background_instance", "_map_text")]
+[node name="MapView" type="Node3D" node_paths=PackedStringArray("_camera", "_map_mesh_instance", "_map_background_instance", "_map_text", "validMoveMarkers", "selectionMarkers")]
 editor_description = "SS-73"
 script = ExtResource("1_exccw")
 _camera = NodePath("MapCamera")
 _map_mesh_instance = NodePath("MapMeshInstance")
 _map_background_instance = NodePath("MapBackgroundInstance")
 _map_text = NodePath("MapText")
+validMoveMarkers = NodePath("ProjectionManager/ValidMoveMarkers")
+selectionMarkers = NodePath("ProjectionManager/SelectionMarkers")
 
 [node name="MapCamera" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.25, 1.5, -2.75)
 near = 0.01
+
+[node name="ProjectionManager" type="Node3D" parent="." node_paths=PackedStringArray("selectionMarkers", "moveMarkers")]
+script = ExtResource("2_xnmdg")
+selectionMarkers = NodePath("SelectionMarkers")
+moveMarkers = NodePath("ValidMoveMarkers")
+
+[node name="SelectionMarkers" type="MultiMeshInstance3D" parent="ProjectionManager" node_paths=PackedStringArray("manager")]
+cast_shadow = 0
+gi_mode = 0
+multimesh = SubResource("MultiMesh_rytvv")
+script = ExtResource("3_fi78k")
+manager = NodePath("..")
+
+[node name="ValidMoveMarkers" type="MultiMeshInstance3D" parent="ProjectionManager" node_paths=PackedStringArray("manager")]
+cast_shadow = 0
+gi_mode = 0
+multimesh = SubResource("MultiMesh_cq0pk")
+script = ExtResource("5_h3t3v")
+manager = NodePath("..")
 
 [node name="MapText" type="Node3D" parent="." node_paths=PackedStringArray("_map_view")]
 script = ExtResource("2_13bgq")
@@ -56,4 +106,6 @@ light_energy = 1.5
 light_bake_mode = 0
 sky_mode = 1
 
+[connection signal="detailed_view_changed" from="." to="ProjectionManager/SelectionMarkers" method="set_visible"]
+[connection signal="detailed_view_changed" from="." to="ProjectionManager/ValidMoveMarkers" method="set_visible"]
 [connection signal="detailed_view_changed" from="." to="MapText" method="set_visible"]

--- a/game/src/Game/GameSession/Projection.gdshader
+++ b/game/src/Game/GameSession/Projection.gdshader
@@ -1,0 +1,52 @@
+shader_type spatial;
+render_mode unshaded;
+
+uniform sampler2D projections[3] : source_color;
+uniform float sizes[3];
+uniform float spin[3];
+uniform float expanding[3];
+uniform float duration[3];
+uniform bool additative[3]; //if true, black becomes a transparency colour
+uniform float time[3];
+
+void vertex() {
+	COLOR = INSTANCE_CUSTOM;
+	uint type = uint(COLOR.x + 0.5);
+	float start_time = COLOR.y;
+
+	float vertex_size = clamp(
+		expanding[type] * (time[type]-start_time),
+		0.0,
+		sizes[type]
+	);
+
+	float rot = time[type]*spin[type];
+	float cos_rot = cos(rot) * vertex_size;
+	float sin_rot = sin(rot) * vertex_size;
+	mat3 rotation_matrix = mat3(
+		vec3(cos_rot, 0.0, -sin_rot),
+		vec3(0.0, vertex_size, 0.0),
+		vec3(sin_rot, 0.0, cos_rot)
+	);
+	VERTEX.xyz *= rotation_matrix;
+}
+
+void fragment() {
+	// Called for every pixel the material is visible on.
+	uint type = uint(COLOR.x + 0.5);
+	vec4 sample = texture(projections[type],UV);
+	ALBEDO.rgb = sample.rgb;
+
+	float start_time = COLOR.y;
+	//duration == 0 -> 1, duration == 1 -> 0
+	float unlimited = float(duration[type] == 0.0);
+	float is_finished = unlimited + ceil(clamp(duration[type] - time[type] + start_time,0.0,1.0));
+
+	//if additative (bool), then black = transparent, otherwise use alpha
+	float additative_transparency = float(additative[type]);
+	ALPHA = COLOR.z * is_finished * mix(
+		sample.a,
+		sample.r+sample.g+sample.b,
+		additative_transparency
+	);
+}

--- a/game/src/Game/GameSession/ProjectionManager.gd
+++ b/game/src/Game/GameSession/ProjectionManager.gd
@@ -1,0 +1,116 @@
+extends Node3D
+class_name ProjectionManager
+
+enum ProjectionType {INVALIDTYPE, SELECTED, LEGAL_MOVE, ILLEGAL_MOVE}
+const PROJECTION_NAME_TO_TYPES : Dictionary = {
+	&"selection_projection": ProjectionType.SELECTED,
+	&"legal_selection_projection": ProjectionType.LEGAL_MOVE,
+	&"illegal_selection_projection": ProjectionType.ILLEGAL_MOVE
+}
+
+@export var selectionMarkers : SelectionMarkers
+@export var moveMarkers : ValidMoveMarkers
+
+var Type_to_Index : Dictionary
+
+var material : ShaderMaterial
+var textures : Array[Texture2D]
+var sizes : PackedFloat32Array
+var spins : PackedFloat32Array
+var expansions : PackedFloat32Array
+var durations : PackedFloat32Array
+var transparency_mode : PackedByteArray
+
+const SCALE_FACTOR : float = 1.0 / 256.0
+const SPIN_FACTOR : float = 4.0
+const HEIGHT_ADD_FACTOR : Vector3 = Vector3(0,0.002,0)
+const GROW_FACTOR : float = 0.25
+
+var times : PackedFloat32Array = [0,0,0]
+var loop_times : PackedFloat32Array = [0,0,0]
+
+# For the markers (selection compass, legal/illegal move markers)
+# this class handles the setup of the projection shader, and the maintenance
+# of the time variable for all 3 scripts.
+#  the two multimeshes handle the individual instances.
+
+
+func _ready() -> void:
+	const name_key : StringName  = &"name";
+	const texture_key : StringName  = &"texture";
+	const size_key : StringName  = &"size";
+	const spin_key : StringName  = &"spin";
+	const expanding_key : StringName  = &"expanding";
+	const duration_key : StringName  = &"duration";
+	const additative_key : StringName  = &"additative";
+	
+	for projection : Dictionary in MapItemSingleton.get_projections():
+		var projection_name : StringName = projection[name_key]
+
+		#keep only projections we are currently handling
+		var projection_type : ProjectionType = PROJECTION_NAME_TO_TYPES.get(projection_name, ProjectionType.INVALIDTYPE)
+		if projection_type == ProjectionType.INVALIDTYPE:
+			continue
+
+		var texture_name : StringName = projection[texture_key]
+		var size : float = projection[size_key]
+		var spin : float = projection[spin_key]
+		var expanding : float = projection[expanding_key]
+		var duration : float = projection[duration_key]
+		var additative : bool = projection[additative_key]
+
+		#fix the alpha edges of the projection textures
+		var texture : ImageTexture = AssetManager.get_texture(texture_name)
+		if texture == null:
+			push_error("Texture for projection \"", projection_name, "\" was null!")
+			continue
+
+		# We use the texture array size (which will be the same as frames and scales' sizes)
+		# rather than projection_index as the former only counts projections we're actually using,
+		# while the latter counts all projections defined in the game's GFX files
+		Type_to_Index[projection_type] = textures.size()
+
+		textures.push_back(texture)
+		sizes.push_back(size * SCALE_FACTOR)
+		spins.push_back(spin * SPIN_FACTOR)
+		expansions.push_back(expanding * GROW_FACTOR)
+		durations.push_back(duration)
+		transparency_mode.push_back(additative)
+		
+		var loop_time : float = 2*PI*size/(expanding*GROW_FACTOR)
+		if duration != 0:
+			loop_time *= duration
+		loop_times[Type_to_Index[projection_type]] = loop_time
+
+	material = moveMarkers.multimesh.mesh.surface_get_material(0)
+	if material == null:
+		push_error("ShaderMaterial for projections was null")
+		return
+
+	material.set_shader_parameter(&"projections", textures)
+	material.set_shader_parameter(&"sizes", sizes)
+	material.set_shader_parameter(&"spin", spins)
+	material.set_shader_parameter(&"expanding", expansions)
+	material.set_shader_parameter(&"additative", transparency_mode)
+	material.set_shader_parameter(&"duration",durations)
+	material.set_shader_parameter(&"time", times)
+	
+	# to be safe, set selectionMarkers to be the same material
+	selectionMarkers.multimesh.mesh.surface_set_material(0, material)
+
+	moveMarkers.setup(loop_times)
+	selectionMarkers.setup(loop_times[Type_to_Index[ProjectionType.SELECTED]])
+
+func _process(delta : float) -> void:
+	for i : int in times.size():
+		times[i] += delta
+	
+	material.set_shader_parameter(&"time", times)
+	moveMarkers.set_time(times)
+	selectionMarkers.set_time(times[Type_to_Index[ProjectionType.SELECTED]])
+	
+	for i : int in times.size():
+		if times[i] >= loop_times[i]:
+			# use this instead of setting to 0 so that any fractional
+			# component rolls over with the projection
+			times[i] -= loop_times[i]

--- a/game/src/Game/GameSession/SelectionMarkers.gd
+++ b/game/src/Game/GameSession/SelectionMarkers.gd
@@ -1,0 +1,162 @@
+class_name SelectionMarkers
+extends MultiMeshInstance3D
+
+@export var manager : ProjectionManager
+
+var time : float = 0.0
+var loop_time : float = 0.0
+const MIN_INSTANCE_COUNT : int = 32
+# above this size, and clearing the selection will reset the buffer size to the min
+#  so that it isn't kept large indefinitely
+const INSTANCE_SOFT_CAP : int = 128 
+
+#When the number of selections exceeds the current instance count, grow the instance buffer size
+# by this much. Larger the number, the less often the buffer is resized, but there is a less fine grained number of instances.
+const INSTANCE_COUNT_GROW_AMOUNT : int = 8 
+const HEIGHT_ADD_FACTOR : Vector3 = ProjectionManager.HEIGHT_ADD_FACTOR
+
+# we can control the multimesh buffer directly
+# 12 floats for transform, 4 floats for colour, 4 floats for custom data
+# colour and custom data are optional
+const TR_CUSTOM_SIZE : int = 16
+const MULTIMESH_START_TIME_OFFSET : int = 13
+
+var id_to_index : Dictionary #int to int
+var unused_indices : PackedInt32Array
+
+const SELECT_TYPE : ProjectionManager.ProjectionType = ProjectionManager.ProjectionType.SELECTED
+var select_index : int = 0
+
+# Called when the node enters the scene tree for the first time.
+func setup(loop_time_in : float = loop_time) -> void:
+	select_index = manager.Type_to_Index[SELECT_TYPE]
+	loop_time = loop_time_in
+	# 1) setting instance_count clears and resizes the buffer
+	# so we want to find the max size once and leave it
+	# 2) resize must occur after setting the transform format
+	
+	#unlike billboards, we don't know how many of these we'll need. Quads are pretty small
+	# and multimesh means we can have a lot of them, so be generous, and resize later if we have to
+	multimesh.instance_count = MIN_INSTANCE_COUNT
+	multimesh.visible_instance_count = MIN_INSTANCE_COUNT
+	
+	unused_indices.resize(MIN_INSTANCE_COUNT)
+	for i : int in unused_indices.size():
+		unused_indices[i] = i
+		multimesh.set_instance_custom_data(i,Color(
+			select_index,time,0.0,0.0
+		))
+
+#interface for the instance uniforms is 
+#INSTANCE_CUSTOM (COLOR).x = type selection, .y = start time, .z = transparent override
+
+func add_selection_marker(unit_id : int, unit_position : Vector3) -> bool:
+	var index_to_use : int = -1
+	if(id_to_index.get(unit_id,-1) != -1):
+		return false # already has that id!
+	
+	for index : int in unused_indices:
+		if index != -1:
+			index_to_use = index
+			unused_indices[index] = -1
+			break
+	if index_to_use == -1:
+		index_to_use = unused_indices.size()
+		_grow_buffer()
+		unused_indices[index_to_use] = -1
+	
+	id_to_index[unit_id] = index_to_use
+	multimesh.set_instance_transform(
+		index_to_use,Transform3D(Basis(), unit_position + HEIGHT_ADD_FACTOR)
+	)
+	multimesh.set_instance_custom_data(index_to_use,Color(
+		select_index,time,1.0,0.0
+	))
+	
+	return true
+
+func update_selection_marker(unit_id : int, unit_position : Vector3) -> bool:
+	var index : int = id_to_index.get(unit_id,-1)
+	if index == -1:
+		return false #doesn't have that id!
+	
+	multimesh.set_instance_transform(
+		index,Transform3D(Basis(), unit_position + HEIGHT_ADD_FACTOR)
+	)
+	return true
+
+#TODO: Perhaps there's a more efficient method...
+func add_selection_markers(unit_ids : PackedInt32Array, unit_positions : PackedVector3Array) -> bool:
+	assert(unit_ids.size() == unit_positions.size())
+	# don't increase visible count all at once here, in-case an id is invalid
+	var ret : bool = true
+	for index : int in unit_ids.size():
+		if not add_selection_marker(unit_ids[index],unit_positions[index]):
+			ret = false
+	return ret
+
+func update_selection_markers(unit_ids : PackedInt32Array, unit_positions : PackedVector3Array) -> bool:
+	assert(unit_ids.size() == unit_positions.size())
+	var ret : bool = true
+	for index : int in unit_ids.size():
+		if not update_selection_marker(unit_ids[index],unit_positions[index]):
+			ret = false
+	return ret
+
+func clear_selection_markers() -> void:
+	#no units should display
+	if multimesh.buffer.size() > INSTANCE_SOFT_CAP*TR_CUSTOM_SIZE:
+		#we exceeded the soft cap, reset instances to the minimum
+		# now that we are clearing
+		setup() 
+		return
+	else:
+		for i : int in unused_indices.size():
+			unused_indices[i] = i
+	id_to_index.clear()
+	for i : int in unused_indices.size():
+		unused_indices[i] = i
+		multimesh.set_instance_custom_data(i,Color(
+			select_index,time,0.0,0.0
+		))
+
+func remove_selection_marker(unit_id : int) -> bool:
+	var index : int = id_to_index.get(unit_id,-1)
+	if index == -1:
+		return false # doesn't have that id!
+	unused_indices[index] = index #mark that index as unused
+	id_to_index.erase(unit_id)
+	multimesh.set_instance_custom_data(index,Color(
+		select_index,time,0.0,0.0
+	))
+	return true
+
+func is_id_selected(unit_id : int) -> bool:
+	return id_to_index.has(unit_id)
+
+func toggle_id_selected(unit_id : int, unit_position : Vector3) -> bool:
+	if is_id_selected(unit_id):
+		return remove_selection_marker(unit_id)
+	else:
+		return add_selection_marker(unit_id, unit_position)
+
+func set_time(timeIn : float) -> void:
+	time = timeIn
+	if timeIn > loop_time:
+		for i : int in id_to_index.values():
+			if multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_START_TIME_OFFSET] > 0:
+				multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_START_TIME_OFFSET] -= loop_time
+
+#Grow the multimesh without losing the current data
+func _grow_buffer(amount : int = INSTANCE_COUNT_GROW_AMOUNT) -> void:
+	var temp_buffer : PackedFloat32Array = multimesh.buffer
+	temp_buffer.resize(temp_buffer.size() + amount*TR_CUSTOM_SIZE)
+	
+	multimesh.instance_count += amount
+	multimesh.visible_instance_count += amount
+	multimesh.set_buffer(temp_buffer)
+	
+	var offset : int = unused_indices.size()
+	unused_indices.resize(offset + amount)
+	for i : int in amount:
+		unused_indices[offset+i] = offset+i

--- a/game/src/Game/GameSession/ValidMoveMarkers.gd
+++ b/game/src/Game/GameSession/ValidMoveMarkers.gd
@@ -1,0 +1,103 @@
+class_name ValidMoveMarkers
+extends MultiMeshInstance3D
+
+@export var manager : ProjectionManager
+
+var projection_type_to_index : Dictionary
+
+var time_legal : float = 0.0
+var time_illegal : float = 0.0
+var loop_time_legal : float = 0.0
+var loop_time_illegal : float = 0.0
+
+const INSTANCE_COUNT : int = 64
+const HEIGHT_ADD_FACTOR : Vector3 = ProjectionManager.HEIGHT_ADD_FACTOR
+var ages : PackedFloat32Array
+
+const LEGAL_TYPE : ProjectionManager.ProjectionType = ProjectionManager.ProjectionType.LEGAL_MOVE
+const ILLEGAL_TYPE : ProjectionManager.ProjectionType = ProjectionManager.ProjectionType.ILLEGAL_MOVE
+var legal_index : int = 0
+var illegal_index : int = 0
+
+# Called when the node enters the scene tree for the first time.
+func setup(loop_times : PackedFloat32Array) -> void:
+	legal_index = manager.Type_to_Index[LEGAL_TYPE]
+	illegal_index = manager.Type_to_Index[ILLEGAL_TYPE]
+
+	loop_time_legal = loop_times[legal_index]
+	loop_time_illegal = loop_times[illegal_index]
+
+	ages.resize(INSTANCE_COUNT)
+	ages.fill(0.0)
+	
+	#unlike billboards, we don't know how many of these we'll need. Quads are pretty small
+	# and multimesh means we can have a lot of them, so be generous, and resize later if we have to
+	multimesh.instance_count = INSTANCE_COUNT
+	multimesh.visible_instance_count = INSTANCE_COUNT
+	
+	for i : int in INSTANCE_COUNT:
+		multimesh.set_instance_transform(
+			i,Transform3D(Basis(), Vector3(float(i),0.0,0.0))
+		)
+
+#interface for the instance uniforms is 
+#INSTANCE_CUSTOM (COLOR).x = type selection, .y = start time, .z = transparent override
+
+func add_move_marker(marker_position : Vector3, was_legal_move : bool) -> void:
+	var type : ProjectionManager.ProjectionType = ILLEGAL_TYPE
+	var time : float = time_illegal
+	if was_legal_move:
+		type = LEGAL_TYPE
+		time = time_legal
+	
+	var duration : float = float(manager.durations[manager.Type_to_Index[type]])
+
+	var oldest : int = 0
+	var oldest_age : float = 0
+	for i : int in ages.size():
+		var age : float = ages[i]
+		if age <= 0:
+			multimesh.set_instance_transform(
+				i,Transform3D(Basis(), marker_position + HEIGHT_ADD_FACTOR)
+			)
+			multimesh.set_instance_custom_data(i,Color(
+				manager.Type_to_Index[type],time,1.0,0.0
+			))
+			ages[i] = duration
+			return
+		if age < oldest_age:
+			oldest_age = age
+			oldest = i
+	# all slots were filled, use the oldest
+	multimesh.set_instance_transform(
+		oldest,Transform3D(Basis(), marker_position + HEIGHT_ADD_FACTOR)
+	)
+	multimesh.set_instance_custom_data(oldest,Color(
+		manager.Type_to_Index[type],time,1.0,0.0
+	))
+	ages[oldest] = duration
+
+const TR_CUSTOM_SIZE : int = 16
+const MULTIMESH_TYPE_OFFSET : int = 12
+const MULTIMESH_START_TIME_OFFSET : int = 13
+
+func set_time(times : PackedFloat32Array) -> void:
+	time_legal = times[legal_index]
+	time_illegal = times[illegal_index]
+	
+	var do_loop_legal : bool = time_legal > loop_time_legal
+	var do_loop_illegal : bool = time_illegal > loop_time_illegal
+	if do_loop_legal or do_loop_illegal:
+		for i : int in ages.size():
+			var type : int = multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_TYPE_OFFSET] as int
+			var start_time := multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_START_TIME_OFFSET] 
+			# note: only do the subtraction if start_time was not already looped
+			# (which we can check by looking for a negative start_time)
+			if do_loop_legal and type == legal_index and start_time > 0:
+				multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_START_TIME_OFFSET] = start_time-loop_time_legal
+			elif do_loop_illegal and type == illegal_index and start_time > 0:
+				multimesh.buffer[TR_CUSTOM_SIZE*i + MULTIMESH_START_TIME_OFFSET] = start_time-loop_time_illegal
+
+func _process(delta : float) -> void:
+	for i : int in ages.size():
+		ages[i] -= delta


### PR DESCRIPTION
Adds support for the unit selection and valid/invalid move markers (which in vic2 are ProjectionType).
- To see the selection markers: shift+left-click to add a marker at a unit position. left-click to clear the projections.
- Right click on provinces to add valid/invalid movement markers.
A main limitation is that the selection markers do not follow units, but are placed wherever a province is shift+clicked. This won't be fixeable until we have proper unit selection