### PR TITLE
Set GUILineChart's mouse_filter to ignore

### DIFF
--- a/extension/doc_classes/GUILineChart.xml
+++ b/extension/doc_classes/GUILineChart.xml
@@ -51,5 +51,6 @@
 	</methods>
 	<members>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="2" />
 	</members>
 </class>

--- a/extension/src/openvic-extension/classes/GUILineChart.cpp
+++ b/extension/src/openvic-extension/classes/GUILineChart.cpp
@@ -26,6 +26,7 @@ void GUILineChart::_bind_methods() {
 
 GUILineChart::GUILineChart() {
 	set_clip_contents(true);
+	set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 }
 
 void GUILineChart::clear() {


### PR DESCRIPTION
Fixes GUILineChart preventing the mouse from passing to Controls underneath.