### PR TITLE
Allow pie chart tooltip customisation and fix Population Menu over-scaling

### DIFF
--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
@@ -13,6 +13,10 @@ StringName const& GFXPieChartTexture::_slice_identifier_key() {
 	static const StringName slice_identifier_key = "identifier";
 	return slice_identifier_key;
 }
+StringName const& GFXPieChartTexture::_slice_tooltip_key() {
+	static const StringName slice_tooltip_key = "tooltip";
+	return slice_tooltip_key;
+}
 StringName const& GFXPieChartTexture::_slice_colour_key() {
 	static const StringName slice_colour_key = "colour";
 	return slice_colour_key;
@@ -113,12 +117,13 @@ Error GFXPieChartTexture::set_slices_array(godot_pie_chart_data_t const& new_sli
 	for (int32_t i = 0; i < new_slices.size(); ++i) {
 		Dictionary const& slice_dict = new_slices[i];
 		ERR_CONTINUE_MSG(
-			!slice_dict.has(_slice_identifier_key()) || !slice_dict.has(_slice_colour_key())
-				|| !slice_dict.has(_slice_weight_key()),
+			!slice_dict.has(_slice_identifier_key()) || !slice_dict.has(_slice_tooltip_key()) ||
+				!slice_dict.has(_slice_colour_key()) || !slice_dict.has(_slice_weight_key()),
 			vformat("Invalid slice keys at index %d", i)
 		);
 		const slice_t slice {
-			slice_dict[_slice_identifier_key()], slice_dict[_slice_colour_key()], slice_dict[_slice_weight_key()]
+			slice_dict[_slice_identifier_key()], slice_dict[_slice_tooltip_key()], slice_dict[_slice_colour_key()],
+			slice_dict[_slice_weight_key()]
 		};
 		if (slice.weight > 0.0f) {
 			total_weight += slice.weight;

--- a/extension/src/openvic-extension/classes/GUIPieChart.cpp
+++ b/extension/src/openvic-extension/classes/GUIPieChart.cpp
@@ -2,7 +2,6 @@
 
 #include <godot_cpp/classes/input_event_mouse_motion.hpp>
 
-#include "openvic-extension/classes/GUILabel.hpp"
 #include "openvic-extension/singletons/MenuSingleton.hpp"
 #include "openvic-extension/utility/ClassBindings.hpp"
 
@@ -18,24 +17,7 @@ void GUIPieChart::_update_tooltip() {
 		GFXPieChartTexture::slice_t const* slice = gfx_pie_chart_texture->get_slice(tooltip_position);
 
 		if (slice != nullptr) {
-			static const String tooltip_identifier_key = "ID";
-			static const String tooltip_percent_key = "PC";
-			// "§Y$ID$§!: $PC$%"
-			static const String tooltip_string =
-				GUILabel::get_colour_marker() + String { "Y" } + GUILabel::get_substitution_marker() + tooltip_identifier_key
-				+ GUILabel::get_substitution_marker() + GUILabel::get_colour_marker() + "!: "
-				+ GUILabel::get_substitution_marker() + tooltip_percent_key + GUILabel::get_substitution_marker() + "%";
-
-			Dictionary substitution_dict;
-			substitution_dict[tooltip_identifier_key] = slice->name;
-
-			float percent = slice->weight * 100.0f;
-			if (gfx_pie_chart_texture->get_total_weight() > 0.0f) {
-				percent /= gfx_pie_chart_texture->get_total_weight();
-			}
-			substitution_dict[tooltip_percent_key] = Utilities::float_to_string_dp(percent, 2);
-
-			menu_singleton->show_control_tooltip(tooltip_string, substitution_dict, this);
+			menu_singleton->show_control_tooltip(slice->tooltip, {}, this);
 
 			tooltip_active = true;
 			return;

--- a/extension/src/openvic-extension/singletons/MenuSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.cpp
@@ -997,20 +997,31 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 
 	ret[province_info_total_population_key] = province->get_total_population();
 
+	const auto make_pie_chart_tooltip = [this](
+		HasGetIdentifierAndGetColour auto const* key, float weight, float total_weight
+	) -> String {
+		static const String format_key = "%d%% %s";
+		return  vformat(
+			format_key,
+			static_cast<int32_t>(100.0f * weight / total_weight),
+			tr(Utilities::std_to_godot_string(key->get_identifier()))
+		);
+	};
+
 	GFXPieChartTexture::godot_pie_chart_data_t pop_types =
-		GFXPieChartTexture::distribution_to_slices_array(province->get_pop_type_distribution());
+		GFXPieChartTexture::distribution_to_slices_array(province->get_pop_type_distribution(), make_pie_chart_tooltip);
 	if (!pop_types.is_empty()) {
 		ret[province_info_pop_types_key] = std::move(pop_types);
 	}
 
 	GFXPieChartTexture::godot_pie_chart_data_t ideologies =
-		GFXPieChartTexture::distribution_to_slices_array(province->get_ideology_distribution());
+		GFXPieChartTexture::distribution_to_slices_array(province->get_ideology_distribution(), make_pie_chart_tooltip);
 	if (!ideologies.is_empty()) {
 		ret[province_info_pop_ideologies_key] = std::move(ideologies);
 	}
 
 	GFXPieChartTexture::godot_pie_chart_data_t cultures =
-		GFXPieChartTexture::distribution_to_slices_array(province->get_culture_distribution());
+		GFXPieChartTexture::distribution_to_slices_array(province->get_culture_distribution(), make_pie_chart_tooltip);
 	if (!cultures.is_empty()) {
 		ret[province_info_pop_cultures_key] = std::move(cultures);
 	}

--- a/extension/src/openvic-extension/singletons/MenuSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.hpp
@@ -10,6 +10,8 @@
 #include <openvic-simulation/types/PopSize.hpp>
 #include <openvic-simulation/types/OrderedContainers.hpp>
 
+#include "openvic-extension/classes/GFXPieChartTexture.hpp"
+
 namespace OpenVic {
 	struct CountryInstance;
 	struct State;
@@ -219,6 +221,10 @@ namespace OpenVic {
 		godot::Error _population_menu_sort_pops();
 		godot::Error population_menu_update_locale_sort_cache();
 		godot::Error population_menu_select_sort_key(PopSortKey sort_key);
+		template<IsPieChartDistribution Container>
+		GFXPieChartTexture::godot_pie_chart_data_t generate_population_menu_pop_row_pie_chart_data(
+			Container const& distribution
+		) const;
 		godot::TypedArray<godot::Dictionary> get_population_menu_pop_rows(int32_t start, int32_t count) const;
 		int32_t get_population_menu_pop_row_count() const;
 

--- a/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
+++ b/game/src/Game/GameSession/NationManagementScreen/PopulationMenu.gd
@@ -481,6 +481,7 @@ func _update_pop_filters() -> void:
 
 func _update_distributions():
 	const slice_identifier_key : StringName = &"identifier"
+	const slice_tooltip_key : StringName = &"tooltip"
 	const slice_colour_key : StringName = &"colour"
 	const slice_weight_key : StringName = &"weight"
 
@@ -515,13 +516,7 @@ func _update_distributions():
 				var colour_icon : GUIIcon = GUINode.get_gui_icon_from_node(child.get_node(^"./legend_color"))
 				if colour_icon:
 					colour_icon.set_modulate(distribution_row[slice_colour_key])
-					colour_icon.set_tooltip_string_and_substitution_dict(
-						"§Y$ID$§!: $PC$%" + "\nTEST: colour_icon",
-						{
-							"ID": distribution_row[slice_identifier_key],
-							"PC": GUINode.float_to_string_dp(distribution_row[slice_weight_key] * 100.0, 2)
-						}
-					)
+					colour_icon.set_tooltip_string(distribution_row[slice_tooltip_key])
 
 				var identifier_label : GUILabel = GUINode.get_gui_label_from_node(child.get_node(^"./legend_title"))
 				if identifier_label:


### PR DESCRIPTION
Relies on `IndexedMap` fix from [OpenVic-Simulation#339](https://github.com/OpenVicProject/OpenVic-Simulation/pull/339)

Fixes a bug with Population Menu where ideology, issue and vote distributions for all currently selected pops (based on selected states/provinces and pop type filters) had mis-scaling and overflow issues due to each pop's contribution being multiplied by its size despite the pop's ideology/issue/vote distribution already being scaled so that it's total weight equals its size.