### PR TITLE
Ensure rtti is always enabled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -12,6 +12,7 @@ env = SConscript("scripts/SConstruct")
 
 env.PrependENVPath("PATH", os.getenv("PATH"))
 
+env["disable_rtti"] = False
 opts = env.SetupOptions()
 
 env.FinalizeOptions()


### PR DESCRIPTION
Godot relies on dynamic_casts, extensions require RTTI

This is waiting for scripts dependency to be updated.