### PR TITLE
Narrow the scope of class reference checks to xml files

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -214,7 +214,7 @@ jobs:
           cd game
           ${{ steps.export_game.outputs.executable_path }} --doctool --headless ../extension --gdextension-docs 2>&1 > /dev/null || true
           cd ..
-          git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
+          git diff --color --exit-code -- '*.xml' && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
       - name: Upload pack artifact
         uses: actions/upload-artifact@v4.3.0


### PR DESCRIPTION
Fixes the occasional failure caused by considering the godot.project file erroneously for the class reference check.