### PR TITLE
Load xac and xsm with cpp

### DIFF
--- a/extension/doc_classes/ModelSingleton.xml
+++ b/extension/doc_classes/ModelSingleton.xml
@@ -35,5 +35,41 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_xac_model">
+			<return type="Node3D" />
+			<param index="0" name="model_name" type="String" />
+			<param index="1" name="is_unit" type="bool" />
+			<description>
+				Gets the animation from an internal cache or file system using the provided file path.
+			</description>
+		</method>
+		<method name="get_xsm_animation">
+			<return type="Animation" />
+			<param index="0" name="animation_name" type="String" />
+			<description>
+				Gets the animation from an internal cache or file system using the provided file path.
+			</description>
+		</method>
+		<method name="set_scroll_material_texture">
+			<return type="int" />
+			<param index="0" name="texture_name" type="String" />
+			<description>
+				Adds the texture from the [code]gfx/anims[/code] folder to the scrolling textures shader's texture array and returns the index of the texture.
+			</description>
+		</method>
+		<method name="set_unit_material_texture">
+			<return type="int" />
+			<param index="0" name="type" type="int" />
+			<param index="1" name="texture_name" type="String" />
+			<description>
+				Adds the texture from the [code]gfx/anims[/code] folder to the unit shader's texture array and returns the index of the texture. [param type] specifies whether this is being inserted as a specular texture, or a diffuse texture.
+			</description>
+		</method>
+		<method name="setup_flag_shader">
+			<return type="int" enum="Error" />
+			<description>
+				Initializes the flag shader with the flags texture sheet and flags dimensions.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/extension/src/openvic-extension/singletons/ModelSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/ModelSingleton.hpp
@@ -1,12 +1,21 @@
 #pragma once
 
+#include <cstdint>
+#include <string_view>
+#include <godot_cpp/classes/animation.hpp>
 #include <godot_cpp/classes/object.hpp>
 
 #include <openvic-simulation/interface/GFXObject.hpp>
 #include <openvic-simulation/military/UnitInstanceGroup.hpp>
 #include <openvic-simulation/types/OrderedContainers.hpp>
+//#include "../utility/XSMLoader.hpp"
+#include "../utility/XACLoader.hpp"
+#include "godot_cpp/classes/shader.hpp"
+#include "godot_cpp/classes/shader_material.hpp"
+#include "godot_cpp/classes/node3d.hpp"
 
 namespace OpenVic {
+
 	struct BuildingInstance;
 
 	class ModelSingleton : public godot::Object {
@@ -31,9 +40,22 @@ namespace OpenVic {
 
 		using animation_map_t = deque_ordered_map<GFX::Actor::Animation const*, godot::Dictionary>;
 		using model_map_t = deque_ordered_map<GFX::Actor const*, godot::Dictionary>;
+		using xsm_map_t = deque_ordered_map<godot::StringName, godot::Ref<godot::Animation>>;
+		using xac_map_t = deque_ordered_map<godot::StringName, godot::Node3D*>;
+		using shader_array_index_map_t = deque_ordered_map<godot::StringName, int32_t>;
 
 		animation_map_t animation_cache;
 		model_map_t model_cache;
+
+		xsm_map_t xsm_cache;
+		xac_map_t xac_cache;
+
+		godot::Ref<godot::ShaderMaterial> unit_shader;
+		godot::Ref<godot::ShaderMaterial> scroll_shader;
+		shader_array_index_map_t diffuse_texture_index_map;
+		shader_array_index_map_t specular_texture_index_map;
+		//shader_array_index_map_t shadow_texture_index_map;
+		shader_array_index_map_t scroll_index_map;
 
 		godot::Dictionary get_animation_dict(GFX::Actor::Animation const& animation);
 		godot::Dictionary get_model_dict(GFX::Actor const& actor);
@@ -56,5 +78,14 @@ namespace OpenVic {
 		godot::Dictionary get_flag_model(bool floating);
 
 		godot::TypedArray<godot::Dictionary> get_buildings();
+
+		godot::Ref<godot::Animation> get_xsm_animation(godot::String source_file);
+		godot::Node3D* get_xac_model(godot::String source_file, bool is_unit=false);
+		godot::Error setup_flag_shader();
+
+		godot::Ref<godot::ShaderMaterial> get_unit_shader();
+		godot::Ref<godot::ShaderMaterial> get_scroll_shader();
+		int32_t set_unit_material_texture(int32_t type, godot::String name); //MAP_TYPE::Values
+		int32_t set_scroll_material_texture(godot::String texture_name);
 	};
 }

--- a/extension/src/openvic-extension/utility/XACLoader.cpp
+++ b/extension/src/openvic-extension/utility/XACLoader.cpp
@@ -1,0 +1,659 @@
+#include "XACLoader.hpp"
+#include <cstdint>
+#include <vector>
+
+#include "XACUtilities.hpp"
+#include "godot_cpp/classes/array_mesh.hpp"
+#include "godot_cpp/classes/mesh_instance3d.hpp"
+#include "godot_cpp/classes/resource_loader.hpp"
+#include "godot_cpp/classes/resource_preloader.hpp"
+#include "godot_cpp/classes/script.hpp"
+#include "godot_cpp/classes/shader.hpp"
+#include "godot_cpp/classes/shader_material.hpp"
+#include "godot_cpp/classes/skeleton3d.hpp"
+#include "godot_cpp/classes/surface_tool.hpp"
+
+#include "godot_cpp/variant/array.hpp"
+#include "godot_cpp/variant/dictionary.hpp"
+#include "godot_cpp/variant/packed_float32_array.hpp"
+#include "godot_cpp/variant/packed_int32_array.hpp"
+#include "godot_cpp/variant/packed_int64_array.hpp"
+#include "godot_cpp/variant/packed_vector2_array.hpp"
+#include "godot_cpp/variant/packed_vector3_array.hpp"
+#include "godot_cpp/variant/packed_vector4_array.hpp"
+#include "godot_cpp/variant/plane.hpp"
+#include "godot_cpp/variant/transform3d.hpp"
+#include "godot_cpp/variant/variant.hpp"
+
+#include "openvic-simulation/utility/Logger.hpp"
+
+using namespace::OpenVic;
+using namespace::godot;
+
+bool XacLoader::_read_xac_header(Ref<FileAccess> const& file) {
+	xac_header_t header = {};
+	ERR_FAIL_COND_V(!read_struct(file, header), false);
+
+	ERR_FAIL_COND_V_MSG(
+		header.format_identifier != XAC_FORMAT_SPECIFIER, false, vformat(
+			"Invalid XAC format identifier: %x (should be %x)", header.format_identifier, XAC_FORMAT_SPECIFIER
+		)
+	);
+
+	ERR_FAIL_COND_V_MSG(
+		header.version_major != XAC_VERSION_MAJOR || header.version_minor != XAC_VERSION_MINOR, false, vformat(
+			"Invalid XAC version: %d.%d (should be %d.%d)",
+			header.version_major, header.version_minor, XAC_VERSION_MAJOR, XAC_VERSION_MINOR
+		)
+	);
+
+	ERR_FAIL_COND_V_MSG(
+		header.big_endian != 0, false, "Invalid XAC endianness: big endian (only little endian is supported)"
+	);
+
+	/*ERR_FAIL_COND_V_MSG(
+		header.multiply_order != 0, false, "Invalid XAC multiply order: ???"
+	);*/
+
+	return true;
+}
+
+bool XacLoader::_read_xac_metadata(Ref<FileAccess> const& file, xac_metadata_v2_t& metadata) {
+	bool ret = read_struct(file, metadata.packed);
+	ret &= read_string(file, metadata.source_app, false);
+	ret &= read_string(file, metadata.original_file_name, false);
+	ret &= read_string(file, metadata.export_date, false);
+	ret &= read_string(file, metadata.actor_name, true);
+	return ret;
+}
+
+bool XacLoader::_read_node_data(Ref<FileAccess> const& file, node_data_t& node_data) {
+	bool ret = read_struct(file, node_data.packed);
+	ret &= read_string(file, node_data.name);
+	return ret;
+}
+
+bool XacLoader::_read_node_hierarchy(Ref<FileAccess> const& file, node_hierarchy_t& hierarchy) {
+	bool ret = read_struct(file, hierarchy.packed);
+	for(int32_t i=0; i<hierarchy.packed.node_count; i++) {
+		node_data_t node;
+		ret &= _read_node_data(file, node);
+		hierarchy.node_data.push_back(node);
+	}
+	return ret;
+}
+
+bool XacLoader::_read_material_totals(Ref<FileAccess> const& file, material_totals_t& totals) {
+	return read_struct(file, totals);
+}
+
+bool XacLoader::_read_layer(Ref<FileAccess> const& file, material_layer_t& layer) {
+	bool ret = true;
+	ret &= read_struct(file, layer.packed);
+	ret &= read_string(file, layer.texture, false);
+	return ret;
+}
+
+bool XacLoader::_read_material_definition(Ref<FileAccess> const& file, material_definition_t& def, int32_t version) {
+	bool ret = read_struct(file, def.packed);
+	ret &= read_string(file, def.name, false);
+	if (version > 1) { //in version 1, the layers are defined in separate chunks of type 0x4
+		for(uint32_t i=0; i<def.packed.layers_count; i++) {
+			material_layer_t layer;
+			ret &= _read_layer(file, layer);
+			def.layers.push_back(layer);
+		}
+	}
+	return ret;
+}
+
+bool XacLoader::_read_vertices_attribute(Ref<FileAccess> const& file, vertices_attribute_t& attribute, int32_t vertices_count) {
+	bool ret = read_struct(file, attribute.packed);
+	ret &= read_struct_array(file, attribute.data, vertices_count*attribute.packed.attribute_size);
+	return ret;
+}
+
+bool XacLoader::_read_submesh(Ref<FileAccess> const& file, submesh_t& submesh) {
+	bool ret = read_struct(file, submesh.packed);
+	ret &= read_struct_array(file, submesh.relative_indices, submesh.packed.indices_count);
+	ret &= read_struct_array(file, submesh.bone_ids, submesh.packed.bones_count);
+	return ret;
+}
+
+bool XacLoader::_read_mesh(Ref<FileAccess> const& file, mesh_t& mesh) {
+	bool ret = read_struct(file, mesh.packed);
+	for(uint32_t i=0; i<mesh.packed.attribute_layers_count; i++) {
+		vertices_attribute_t attribute;
+		ret &= _read_vertices_attribute(file, attribute, mesh.packed.vertices_count);
+		mesh.vertices_attributes.push_back(attribute);
+	}
+	for(uint32_t i=0; i<mesh.packed.submeshes_count; i++) {
+		submesh_t submesh;
+		ret &= _read_submesh(file, submesh);
+		mesh.submeshes.push_back(submesh);
+	}
+	return ret;
+}
+
+bool XacLoader::_read_skinning(Ref<FileAccess> const& file, skinning_t& skin, std::vector<mesh_t> const& meshes, int32_t version) {
+	bool ret = read_struct(file, skin.node_id);
+	if (version == 3) {
+		ret &= read_struct(file, skin.local_bones_count);
+	}
+	ret &= read_struct(file, skin.packed);
+	ret &= read_struct_array(file, skin.influence_data, skin.packed.influences_count);
+	bool found = false;
+	for(mesh_t const& mesh : meshes) {
+		if (mesh.packed.is_collision_mesh == skin.packed.is_for_collision && mesh.packed.node_id == skin.node_id) {
+			ret &= read_struct_array(file, skin.influence_ranges, mesh.packed.influence_ranges_count);
+			found = true;
+			break;
+		}
+	}
+	ret &= found;
+	return ret;
+}
+
+bool XacLoader::_read_node_chunk(Ref<FileAccess> const& file, node_chunk_t& node) {
+	bool ret = read_struct(file, node.packed);
+	ret &= read_string(file, node.name);
+	return ret;
+}
+
+/*
+====================================
+Skeleton helper functions
+
+====================================
+*/
+
+static Transform3D _make_transform(vec3d_t const& position, quat_v1_t const& quaternion, vec3d_t const& scale) {
+	Basis basis = Basis();
+	basis.set_quaternion(quat_v1_to_godot(quaternion));
+	basis.scale(vec3d_to_godot(scale));
+
+	return Transform3D(basis,vec3d_to_godot(position, true));
+}
+
+//TODO: do we want to use node's bone id instead of current_id?
+Skeleton3D* XacLoader::_build_armature_hierarchy(node_hierarchy_t const& hierarchy) {
+	static const StringName skeleton_name = "skeleton";
+	Skeleton3D* skeleton = memnew(Skeleton3D);
+	skeleton->set_name(skeleton_name);
+
+	uint32_t current_id = 0;
+
+	for(node_data_t const& node : hierarchy.node_data) {
+		skeleton->add_bone(node.name);
+		skeleton->set_bone_parent(current_id, node.packed.parent_node_id);
+		
+		Transform3D transform = _make_transform(node.packed.position, node.packed.rotation, node.packed.scale);
+		skeleton->set_bone_rest(current_id, transform);
+		skeleton->set_bone_pose(current_id, transform);
+
+		current_id += 1;
+	}
+
+	return skeleton;
+}
+
+Skeleton3D* XacLoader::_build_armature_nodes(std::vector<node_chunk_t> const& nodes) {
+	static const StringName skeleton_name = "skeleton";
+	Skeleton3D* skeleton = memnew(Skeleton3D);
+	skeleton->set_name(skeleton_name);
+
+	uint32_t current_id = 0;
+
+	for(node_chunk_t const& node : nodes) {
+		skeleton->add_bone(node.name);
+		skeleton->set_bone_parent(current_id, node.packed.parent_node_id);
+		
+		Transform3D transform = _make_transform(node.packed.position, node.packed.rotation, node.packed.scale);
+		skeleton->set_bone_rest(current_id, transform);
+		skeleton->set_bone_pose(current_id, transform);
+
+		current_id += 1;
+	}
+
+	return skeleton;
+}
+
+/*
+====================================
+Material helper functions
+
+====================================
+*/
+
+XacLoader::model_texture_set XacLoader::_get_model_textures(material_definition_t const& material) {
+	static const StringName Texture_skip_nospec = "nospec";
+	static const StringName Texture_skip_flag = "unionjacksquare";
+	static const StringName Texture_skip_diff = "test256texture";
+
+	model_texture_set texture_set;
+
+	for(material_layer_t const& layer : material.layers) {
+		if (layer.texture == Texture_skip_diff || layer.texture == Texture_skip_flag) { //|| layer.texture == Texture_skip_nospec
+			continue;
+		}
+		//Get the texture names
+		switch(static_cast<MAP_TYPE>(layer.packed.map_type)) {
+			case MAP_TYPE::DIFFUSE:
+				texture_set.diffuse_name = layer.texture;
+				break;
+			case MAP_TYPE::SPECULAR:
+				texture_set.specular_name = layer.texture;
+				break;
+			case MAP_TYPE::NORMAL:
+				texture_set.normal_name = layer.texture;
+				break;
+			case MAP_TYPE::SHADOW:
+				/*UtilityFunctions::print(
+					vformat("Shadow layer: %s", layer.texture)
+				);*/
+				break;
+			default:
+				UtilityFunctions::print(
+					vformat("Unknown layer type: %x, texture: %s", layer.packed.map_type, layer.texture)
+				);
+				break;
+		}
+	}
+	if(texture_set.specular_name.is_empty()) { texture_set.specular_name = Texture_skip_nospec; }
+	return texture_set;
+}
+
+//unit colours not working, likely due to improper setup of the unit script
+std::vector<XacLoader::material_mapping> XacLoader::_build_materials(std::vector<material_definition_t> const& materials) {
+
+	// Scrolling textures (smoke, tank tracks)
+	static const StringName tracks = "TexAnim";
+	static const StringName smoke = "Smoke";
+
+	//General
+	ResourceLoader* loader = ResourceLoader::get_singleton();		
+	std::vector<material_mapping> mappings;
+	ModelSingleton* model_singleton = ModelSingleton::get_singleton();
+
+
+	for(material_definition_t const& mat : materials) {
+		model_texture_set texture_names = _get_model_textures(mat);
+		material_mapping mapping = {};
+
+		// *** Determine the correct material to use, and set it up ***
+		// Note all 3 of these materials correspond to different compile targets of avatar.fx
+		//  it has techniques for TexAnim (tracks), Smoke, Shadow, Flag, Standard (we combine TexAnim+smoke, shadow+standard),
+		// in the original shader, shadow = just sample the color, smoke and flag share speed properties
+
+		//flag TODO: perhaps flag should be determined by hard-coding so that other models can have a normal texture?
+		//There shouldn't be a specular texture
+		if (!texture_names.normal_name.is_empty() && texture_names.diffuse_name.is_empty()) {
+			static const StringName Param_texture_normal = "texture_normal";
+			static const Ref<ShaderMaterial> flag_shader = loader->load("res://src/Game/Model/flag_mat.tres");
+			flag_shader->set_shader_parameter(Param_texture_normal, get_model_texture(texture_names.normal_name));
+			mapping.godot_material = flag_shader;
+		}
+		//Scrolling texture
+		else if (!texture_names.diffuse_name.is_empty() && (mat.name == tracks || mat.name == smoke)) {
+			mapping.scroll_index = model_singleton->set_scroll_material_texture(texture_names.diffuse_name);
+			mapping.godot_material = model_singleton->get_scroll_shader();
+		}
+		//standard material (diffuse optionally with a specular/unit colours)
+		else if(!texture_names.diffuse_name.is_empty()){
+			mapping.diffuse_texture_index = model_singleton->set_unit_material_texture(2, texture_names.diffuse_name); //MAP_TYPE::DIFFUSE
+			mapping.specular_texture_index = model_singleton->set_unit_material_texture(3, texture_names.specular_name); //MAP_TYPE::SPECULAR
+			mapping.godot_material = model_singleton->get_unit_shader();
+		}
+
+		else {
+			UtilityFunctions::push_warning(
+				vformat("Material %s did not have a diffuse texture! Skipping", mat.name)
+			);
+		}
+
+		mappings.push_back(mapping);
+	}
+	
+
+	return mappings;
+}
+
+/*
+====================================
+Mesh helper functions
+
+====================================
+*/
+
+template<typename T>
+struct byte_array_wrapper : std::span<const T> {
+	byte_array_wrapper() = default;
+	byte_array_wrapper(std::vector<uint8_t> const& source) :
+		std::span<const T>(reinterpret_cast<T const* const>(source.data()), source.size() / sizeof(T)) {}
+};
+
+std::vector<MeshInstance3D*> XacLoader::_build_mesh(mesh_t const& mesh_chunk, skinning_t* skin, std::vector<material_mapping> const& materials) {
+	static const uint32_t EXTRA_CULL_MARGIN = 2;
+
+	std::vector<MeshInstance3D*> meshes = {}; //return value 
+
+	byte_array_wrapper<vec3d_t> verts;
+	byte_array_wrapper<vec3d_t> normals;
+	byte_array_wrapper<vec4d_t> tangents;
+	uint32_t uvs_read = 0;
+	byte_array_wrapper<vec2d_t> uv1;
+	byte_array_wrapper<vec2d_t> uv2;
+	byte_array_wrapper<uint32_t> influence_range_indices;
+
+	for(vertices_attribute_t const& attribute : mesh_chunk.vertices_attributes) {
+		switch(attribute.packed.type) {
+			case ATTRIBUTE::POSITION:
+				verts = attribute.data;
+				break;
+			case ATTRIBUTE::NORMAL:
+				normals = attribute.data;
+				break;
+			case ATTRIBUTE::TANGENT:
+				tangents = attribute.data;
+				break;
+			case ATTRIBUTE::UV:
+				if (uvs_read == 0) {
+					uv1 = attribute.data;
+				} 
+				else if (uvs_read == 1) {
+					uv2 = attribute.data;
+				}
+				uvs_read += 1;
+				break;
+			case ATTRIBUTE::INFLUENCE_RANGE:
+				if (skin == nullptr) {
+					Logger::warning("Mesh chunk has influence attribute but no corresponding skinning chunk");
+					break;
+				}
+				influence_range_indices = attribute.data;
+				break;
+			//for now, ignore color data
+			case ATTRIBUTE::COL_32:
+			case ATTRIBUTE::COL_128:
+			default:
+				break;
+		}
+	}
+
+	uint32_t vert_total = 0;
+	static const StringName key_diffuse = "tex_index_diffuse";
+	static const StringName key_specular = "tex_index_specular";
+	static const StringName key_scroll = "scroll_tex_index_diffuse";
+	
+	Ref<SurfaceTool> st = Ref<SurfaceTool>();
+	st.instantiate();
+
+	//for now we treat a submesh as a godot mesh surface
+	for(submesh_t const& submesh : mesh_chunk.submeshes) {
+		// one mesh per submesh so that they can use different instance uniform parameters on the same material
+		Ref<ArrayMesh> mesh = Ref<ArrayMesh>();
+		mesh.instantiate();
+	
+		MeshInstance3D* mesh_inst = memnew(MeshInstance3D);
+		mesh_inst->set_extra_cull_margin(EXTRA_CULL_MARGIN);
+		mesh_inst->set_mesh(mesh);
+
+
+		st->begin(Mesh::PRIMITIVE_TRIANGLES);
+
+		for(int j=0; j<submesh.relative_indices.size(); j++) {
+			int32_t rel_index = submesh.relative_indices[j] + vert_total;
+			if(!normals.empty()) {
+				st->set_normal(vec3d_to_godot(normals[rel_index],true));
+			}
+			if(!tangents.empty()) {
+				vec4d_t const& v4 = tangents[rel_index];
+				st->set_tangent(Plane(-v4.x,v4.y,v4.z,v4.w));
+			}
+			if(!uv1.empty()) {
+				st->set_uv(vec2d_to_godot(uv1[rel_index]));
+			}
+			if(!uv2.empty()) {
+				st->set_uv2(vec2d_to_godot(uv2[rel_index]));
+			}
+			if(skin != nullptr && !influence_range_indices.empty()) {
+				PackedInt32Array boneIds = {0,0,0,0};
+				PackedFloat32Array weights = {0,0,0,0};
+
+				influence_range_t const& infl_range = skin->influence_ranges[influence_range_indices[rel_index]];
+				int32_t first = infl_range.first_influence_index;
+				int32_t count = Math::min(infl_range.influences_count,4);
+
+				for(int32_t i=0; i<count; i++){
+					influence_data_t const& infl_data = skin->influence_data[first + i];
+					boneIds[i] = infl_data.bone_id;
+					weights[i] = infl_data.weight;
+				}
+
+				st->set_bones(boneIds);
+				st->set_weights(weights);
+			}
+			st->add_vertex(vec3d_to_godot(verts[rel_index],true));
+		}
+
+		material_mapping const& material_mapping = materials[submesh.packed.material_id];
+		st->set_material(material_mapping.godot_material);
+
+		mesh = st->commit(mesh); // add a new surface to the mesh
+		st->clear();
+
+		vert_total += submesh.packed.vertices_count;
+
+		//setup materials for the surface
+		if (material_mapping.diffuse_texture_index != -1) {
+			mesh_inst->set_instance_shader_parameter(key_diffuse, material_mapping.diffuse_texture_index);
+		}
+		if (material_mapping.specular_texture_index != -1) {
+			mesh_inst->set_instance_shader_parameter(key_specular, material_mapping.specular_texture_index);
+		}
+		if (material_mapping.scroll_index != -1) {
+			mesh_inst->set_instance_shader_parameter(key_scroll, material_mapping.scroll_index);
+		}
+
+		meshes.push_back(mesh_inst);
+	}
+
+	return meshes;
+}
+
+/*
+====================================
+Main loading function
+
+====================================
+*/
+
+Node3D* XacLoader::load_xac_model(Ref<FileAccess> const& file, bool is_unit) {
+	bool res = _read_xac_header(file);	
+
+	ResourceLoader* loader = ResourceLoader::get_singleton();
+
+	Node3D* base = memnew(Node3D);
+
+	if (!res) {
+		return base;
+	}
+
+	xac_metadata_v2_t metadata;
+	
+	bool hierarchy_read = false;
+	node_hierarchy_t hierarchy;
+	std::vector<node_chunk_t> nodes; //other way of making a bone hierarchy
+	
+	material_totals_t material_totals = {};
+	std::vector<material_definition_t> materials;
+
+	std::vector<mesh_t> meshes;
+	std::vector<skinning_t> skinnings;
+
+	bool log_all = false;
+
+	//0xA unknown (ex. Spanish_Helmet1.xac), only 2 bytes long...
+	//0x6 unknown (ex. ...)
+	//0x8 junk data (ie. old versions of the file duplicated in append mode)
+	//	(ex. Port_Empty.xac)
+	//0xC morphtargets (not used in vic2)
+
+	while (!file->eof_reached()) {
+		chunk_header_t header = {};
+		if (!read_chunk_header(file, header)) {
+			break;
+		}
+
+		if (log_all) {
+			UtilityFunctions::print(
+			vformat("XAC chunk: type = %x, length = %x, version = %d at %x", header.type, header.length, header.version, file->get_position())
+			);
+		}
+
+		if (header.type == 0x7 && header.version == 2) {
+			_read_xac_metadata(file, metadata);
+		}
+		else if (header.type == 0xB && header.version == 1) {
+			hierarchy_read = _read_node_hierarchy(file, hierarchy);
+		} 
+		else if (header.type == 0x0 && header.version == 3) {
+			node_chunk_t node;
+			_read_node_chunk(file, node);
+			nodes.push_back(node);
+		}
+		else if (header.type == 0x1 && header.version == 1) {
+			mesh_t mesh;
+			_read_mesh(file, mesh);
+			meshes.push_back(mesh);
+		}
+		else if (header.type == 0x2) {
+			skinning_t skin;
+			_read_skinning(file, skin, meshes, header.version);
+			skinnings.push_back(skin);
+		}
+		else if (header.type == 0x3) {
+			material_definition_t mat;
+			_read_material_definition(file, mat, header.version);
+			materials.push_back(mat);
+		}
+		else if (header.type == 0x4 && header.version == 2) {
+			material_layer_t layer;
+			_read_layer(file, layer);
+			if (layer.packed.material_id < materials.size()) {
+				materials[layer.packed.material_id].layers.push_back(layer);
+			}
+			else{
+				Logger::error("No material of id ", layer.packed.material_id, " to attach layer to");
+			}
+		}
+		else if (header.type == 0xD && header.version == 1) {
+			_read_material_totals(file, material_totals);
+		}
+		else if (header.type == 0x8 || header.type == 0xA) { //skip junk data and whatever 0xA is...
+			if (header.length + file->get_position() < file->get_length()) {
+				file->get_buffer(header.length);
+			}
+			else {
+				res = false;
+				break;
+			} 
+		}
+		else {
+			UtilityFunctions::print(
+			vformat("Unsupported XAC chunk: type = %x, length = %x, version = %d at %x", header.type, header.length, header.version, file->get_position())
+			);
+			log_all = true;
+			// Skip unsupported chunks by using get_buffer, make sure this doesn't break anything, since chunk length can be wrong
+			if (header.length + file->get_position() < file->get_length()) {
+				file->get_buffer(header.length);
+			}
+			else {
+				res = false;
+				break;
+			} 
+		}
+	}
+	
+	base->set_name(metadata.original_file_name.get_file().get_basename());
+
+	//Setup skeleton
+	Skeleton3D* skeleton = nullptr;
+	if(!skinnings.empty()) {
+		if (hierarchy_read) {
+			skeleton = _build_armature_hierarchy(hierarchy);
+			base->add_child(skeleton);
+		}
+		else if (!nodes.empty()) {
+			skeleton = _build_armature_nodes(nodes);
+			base->add_child(skeleton);
+		}
+	}
+
+	//Setup materials
+	std::vector<material_mapping> const& material_mappings = _build_materials(materials);
+
+	bool has_specular = false;
+	for(material_mapping const& material : material_mappings) {
+		if(material.specular_texture_index != -1){
+			has_specular = true;
+			break;
+		}
+	}
+
+	//don't set the unit script if we don't have one of:
+	// -specular (unit colours) texture
+	// -skeleton with animation
+	static const Ref<godot::Script> unit_script = loader->load("res://src/Game/Model/UnitModel.gd");
+	if(is_unit || has_specular) {
+		base->set_script(unit_script);
+	}
+
+	//setup mesh
+	for(mesh_t const& mesh : meshes) {
+		if (mesh.packed.is_collision_mesh) { continue; } //we'll use our own collision meshes where needed
+
+		skinning_t* mesh_skin = nullptr;
+		for(uint32_t i=0; i < skinnings.size(); i++) {
+			skinning_t& skin = skinnings[i];
+			if (skin.node_id == mesh.packed.node_id && skin.packed.is_for_collision == mesh.packed.is_collision_mesh) {
+				mesh_skin = &skin;
+				break;
+			}
+		}
+
+		if (skeleton != nullptr && mesh_skin == nullptr) { continue; }
+
+		std::vector<MeshInstance3D*> mesh_instances = _build_mesh(mesh, mesh_skin, material_mappings);
+		for(MeshInstance3D* mesh_inst : mesh_instances){
+			base->add_child(mesh_inst);
+			mesh_inst->set_owner(base);
+			
+			if (skeleton != nullptr) {
+				mesh_inst->set_skeleton_path(mesh_inst->get_path_to(skeleton));
+				int32_t node_id = mesh.packed.node_id;
+				if (hierarchy_read && node_id < hierarchy.node_data.size()) {
+					mesh_inst->set_name(hierarchy.node_data[node_id].name);
+				}
+				else if (!nodes.empty() && node_id < nodes.size()) {
+					mesh_inst->set_name(nodes[node_id].name);
+				}
+			}
+		}
+		/*base->add_child(mesh_inst);
+		mesh_inst->set_owner(base);
+		
+		if (skeleton != nullptr) {
+			mesh_inst->set_skeleton_path(mesh_inst->get_path_to(skeleton));
+			int32_t node_id = mesh.packed.node_id;
+			if (hierarchy_read && node_id < hierarchy.node_data.size()) {
+				mesh_inst->set_name(hierarchy.node_data[node_id].name);
+			}
+			else if (!nodes.empty() && node_id < nodes.size()) {
+				mesh_inst->set_name(nodes[node_id].name);
+			}
+		} */
+	}
+
+	return base;
+}

--- a/extension/src/openvic-extension/utility/XACLoader.hpp
+++ b/extension/src/openvic-extension/utility/XACLoader.hpp
@@ -1,0 +1,321 @@
+#pragma once
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+#include "XACUtilities.hpp"
+
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/classes/node3d.hpp>
+
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/vector3.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "godot_cpp/classes/mesh_instance3d.hpp"
+#include "godot_cpp/classes/skeleton3d.hpp"
+#include <openvic-extension/singletons/ModelSingleton.hpp>
+#include <openvic-extension/singletons/AssetManager.hpp>
+#include <openvic-extension/singletons/GameSingleton.hpp>
+
+
+namespace OpenVic {
+
+	//needed for material loading functions, which use modelSingleton to track state between calls
+	struct ModelSingleton;
+	
+	/*enum struct MAP_TYPE {
+		DIFFUSE = 2,
+		SPECULAR,
+		SHADOW,
+		NORMAL
+	};*/
+	/*struct MAP_TYPE {
+		enum Values : int32_t {
+			DIFFUSE = 2,
+			SPECULAR,
+			SHADOW,
+			NORMAL
+		};
+	};*/
+
+	class XacLoader {
+		static constexpr uint32_t XAC_FORMAT_SPECIFIER = ' CAX'; // Order reversed due to little endian
+		static constexpr uint8_t XAC_VERSION_MAJOR = 1, XAC_VERSION_MINOR = 0;
+
+		//TODO: How do we get this enum to work both here and in modelSingleton?
+		//public:
+		enum class MAP_TYPE {
+			DIFFUSE = 2,
+			SPECULAR,
+			SHADOW,
+			NORMAL
+		};
+		/*struct MAP_TYPE {
+			enum Values : int32_t {
+				DIFFUSE = 2,
+				SPECULAR,
+				SHADOW,
+				NORMAL
+			};
+		};
+		private:*/
+
+		#pragma pack(push)
+		#pragma pack(1)
+
+		struct xac_header_t {
+			uint32_t format_identifier;
+			uint8_t version_major;
+			uint8_t version_minor;
+			uint8_t big_endian;
+			uint8_t multiply_order;
+		};
+
+		struct xac_metadata_v2_pack_t {
+			uint32_t reposition_mask; //1=position, 2=rotation, 4=scale
+			int32_t repositioning_node;
+			uint8_t exporter_major_version;
+			uint8_t exporter_minor_version;
+			uint16_t pad;
+			float retarget_root_offset;
+		};
+
+		struct node_hierarchy_pack_t { //v1
+			int32_t node_count;
+			int32_t root_node_count; //nodes with parent_id == -1
+		};
+
+		struct node_data_pack_t { //v1
+			quat_v1_t rotation;
+			quat_v1_t scale_rotation;
+			vec3d_t position;
+			vec3d_t scale;
+			float unused[3];
+			int32_t unknown[2];
+			int32_t parent_node_id;
+			int32_t child_nodes_count;
+			int32_t include_in_bounds_calculation; //bool
+			matrix44_t transform;
+			float importance_factor;
+		};
+
+		struct material_totals_t { //v1
+			int32_t total_materials_count;
+			int32_t standard_materials_count;
+			int32_t fx_materials_count;
+		};
+
+		struct material_definition_pack_t {
+			vec4d_t ambient_color;
+			vec4d_t diffuse_color;
+			vec4d_t specular_color;
+			vec4d_t emissive_color;
+			float shine;
+			float shine_strength;
+			float opacity;
+			float ior; 				//index of refraction
+			uint8_t double_sided; 	//bool
+			uint8_t wireframe; 		//bool
+			uint8_t unused;			//in v1, unknown, but used
+			uint8_t layers_count; 	//in v1, unknown, but used
+		};
+
+		struct material_layer_pack_t { //also chunk 0x4, v2
+			float amount;
+			vec2d_t uv_offset;
+			vec2d_t uv_tiling;
+			float rotation_in_radians;
+			int16_t material_id;
+			uint8_t map_type; // (1-5) enum MAP_TYPE
+			uint8_t unused;
+		};
+
+		struct mesh_pack_t {
+			int32_t node_id;
+			int32_t influence_ranges_count;
+			int32_t vertices_count;
+			int32_t indices_count;
+			int32_t submeshes_count;
+			int32_t attribute_layers_count;
+			uint8_t is_collision_mesh; //bool
+			uint8_t pad[3];
+		};
+
+		struct ATTRIBUTE {
+			enum Values : int32_t {
+				POSITION,
+				NORMAL,
+				TANGENT,
+				UV,
+				COL_32,
+				INFLUENCE_RANGE,
+				COL_128
+			};
+		};
+
+		struct vertices_attribute_pack_t {
+			int32_t type; //0-6 (enum ATTRIBUTE)
+			int32_t attribute_size;
+			uint8_t keep_originals; //bool
+			uint8_t is_scale_factor; //bool
+			uint16_t pad;
+		};
+
+		struct submesh_pack_t {
+			int32_t indices_count;
+			int32_t vertices_count;
+			int32_t material_id;
+			int32_t bones_count;
+		};
+
+		struct skinning_pack_t {
+			int32_t influences_count;
+			uint8_t is_for_collision; //bool
+			uint8_t pad[3];
+		};
+
+		struct influence_data_t {
+			float weight;
+			int16_t bone_id;
+			int16_t pad;
+		};
+
+		struct influence_range_t {
+			int32_t first_influence_index;
+			int32_t influences_count;
+		};
+
+		// 0x4, 0x6, 0xA chunk types appear in vic2, but what they do
+		// is unknown
+		// 0x8 is junk data
+		// 0x0 is the older node/bone chunk
+
+		//0x0, v3
+		struct node_chunk_pack_t {
+			quat_v1_t rotation;
+			quat_v1_t scale_rotation;
+			vec3d_t position;
+			vec3d_t scale;
+			vec3d_t unused; //-1, -1, -1
+			int32_t unknown; //-1 (0xFFFF)
+			int32_t parent_node_id;
+			float uncertain[17]; //likely a matrix44 + fimportancefactor
+		};
+
+		/*
+		0x6, v? unknown
+			12x int32?
+			09x float?
+		*/
+
+		#pragma pack(pop)
+
+		struct xac_metadata_v2_t {
+			xac_metadata_v2_pack_t packed = {};
+			godot::String source_app;
+			godot::String original_file_name;
+			godot::String export_date;
+			godot::String actor_name;
+		};
+
+		struct node_data_t { //v1
+			node_data_pack_t packed = {};
+			godot::String name;
+		};
+
+		struct node_hierarchy_t { //v1
+			node_hierarchy_pack_t packed = {};
+			std::vector<node_data_t> node_data;
+		};
+
+		struct material_layer_t {
+			material_layer_pack_t packed = {};
+			godot::String texture;
+		};
+
+		struct material_definition_t {
+			material_definition_pack_t packed = {};
+			godot::String name;
+			std::vector<material_layer_t> layers;
+		};
+
+		struct vertices_attribute_t {
+			vertices_attribute_pack_t packed = {};
+			std::vector<uint8_t> data;
+		};
+
+		struct submesh_t {
+			submesh_pack_t packed = {};
+			std::vector<int32_t> relative_indices;
+			std::vector<int32_t> bone_ids;
+		};
+
+		struct mesh_t {
+			mesh_pack_t packed = {};
+			std::vector<vertices_attribute_t> vertices_attributes;
+			std::vector<submesh_t> submeshes;
+		};
+
+		struct skinning_t {
+			int32_t node_id = 0;
+			int32_t local_bones_count = -1; //v3 only
+			skinning_pack_t packed = {};
+			std::vector<influence_data_t> influence_data;
+			std::vector<influence_range_t> influence_ranges;
+		};
+
+		struct node_chunk_t {
+			node_chunk_pack_t packed = {};
+			godot::String name;
+		};
+
+		//Dataloading functions
+		bool _read_xac_header(godot::Ref<godot::FileAccess> const& file);
+		bool _read_xac_metadata(godot::Ref<godot::FileAccess> const& file, xac_metadata_v2_t& metadata);
+		bool _read_node_data(godot::Ref<godot::FileAccess> const& file, node_data_t& node_data);
+		bool _read_node_hierarchy(godot::Ref<godot::FileAccess> const& file, node_hierarchy_t& hierarchy);
+		bool _read_material_totals(godot::Ref<godot::FileAccess> const& file, material_totals_t& totals);
+		bool _read_layer(godot::Ref<godot::FileAccess> const& file, material_layer_t& layer);
+		bool _read_material_definition(godot::Ref<godot::FileAccess> const& file, material_definition_t& def, int32_t version);
+		bool _read_vertices_attribute(godot::Ref<godot::FileAccess> const& file, vertices_attribute_t& attribute, int32_t vertices_count);
+		bool _read_submesh(godot::Ref<godot::FileAccess> const& file, submesh_t& submesh);
+		bool _read_mesh(godot::Ref<godot::FileAccess> const& file, mesh_t& mesh);
+		bool _read_skinning(godot::Ref<godot::FileAccess> const& file, skinning_t& skin, std::vector<mesh_t> const& meshes, int32_t version);
+		bool _read_node_chunk(godot::Ref<godot::FileAccess> const& file, node_chunk_t& node);
+
+		//Xac -> godot conversion functions
+		struct material_mapping {
+			//-1 means unused
+			godot::Ref<godot::Material> godot_material;
+			int32_t diffuse_texture_index = -1;
+			int32_t specular_texture_index = -1;
+			//int32_t shadow_texture_index = -1;
+			int32_t scroll_index = -1;
+		};
+
+		struct model_texture_set {
+			godot::String diffuse_name;
+			godot::String specular_name;
+			godot::String normal_name;
+			//godot::String shadow_name;
+		};
+
+		godot::Skeleton3D* _build_armature_hierarchy(node_hierarchy_t const& hierarchy);
+		godot::Skeleton3D* _build_armature_nodes(std::vector<node_chunk_t> const& nodes);
+
+		model_texture_set _get_model_textures(material_definition_t const& material);
+		std::vector<material_mapping> _build_materials(std::vector<material_definition_t> const& materials);
+		std::vector<godot::MeshInstance3D*> _build_mesh(mesh_t const& mesh_chunk, skinning_t* skin, std::vector<material_mapping> const& materials);
+
+	public:
+		static godot::Ref<godot::ImageTexture> get_model_texture(godot::String name) {
+			AssetManager* asset_manager = AssetManager::get_singleton();
+			static const godot::StringName Textures_path = "gfx/anims/%s.dds";
+			return asset_manager->get_texture(godot::vformat(Textures_path, name));
+		}
+		godot::Node3D* load_xac_model(godot::Ref<godot::FileAccess> const& file, bool is_unit=false);
+	};
+}

--- a/extension/src/openvic-extension/utility/XACUtilities.hpp
+++ b/extension/src/openvic-extension/utility/XACUtilities.hpp
@@ -1,0 +1,213 @@
+#pragma once
+#include <cstdint>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+//#include "openvic-simulation/utility/Logger.hpp"
+//#include "openvic-extension/utility/Utilities.hpp"
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/quaternion.hpp>
+
+namespace OpenVic {
+	#pragma pack(push)
+	#pragma pack(1)
+
+	struct chunk_header_t {
+		int32_t type;
+		int32_t length;
+		int32_t version;
+	};
+
+	struct vec2d_t { //not a real datatype in the files. Just using it for convenience
+		float x;
+		float y;
+	};
+
+	struct vec3d_t {
+		float x;
+		float y;
+		float z;
+	};
+
+	struct vec4d_t {
+		float x;
+		float y;
+		float z;
+		float w;
+	};
+
+	struct quat_v1_t {
+		float x;
+		float y;
+		float z;
+		float w;
+	};
+
+	struct quat_v2_t { // divide by 32767 to get proper quat
+		int16_t x;
+		int16_t y;
+		int16_t z;
+		int16_t w;
+	};
+
+	struct matrix44_t {
+		vec4d_t col1;
+		vec4d_t col2;
+		vec4d_t col3;
+		vec4d_t col4;
+	};
+
+	struct color_32_t {
+		int8_t r;
+		int8_t g;
+		int8_t b;
+		int8_t a;
+	};
+
+	struct color_128_t {
+		int32_t r;
+		int32_t g;
+		int32_t b;
+		int32_t a;
+	};
+
+	#pragma pack(pop)
+
+	static bool read_string(godot::Ref<godot::FileAccess> const& file, godot::String& str, bool replace_chars = true, bool log = false) {
+		//string = uint32 len, char[len]
+		uint32_t length = file->get_32();
+		if (file->get_length() - file->get_position() < length) {
+			return false;
+		}
+
+		str = file->get_buffer(length).get_string_from_ascii();
+		if (log) {
+			godot::UtilityFunctions::print(vformat("before %s", str));
+		}
+		if (replace_chars) {
+			str = str.replace(":", "_");
+			str = str.replace("\\", "_");
+			str = str.replace("/", "_");
+		}
+		if (log) {
+			godot::UtilityFunctions::print(vformat("after %s", str));
+		} 
+		return true;
+	}
+
+	template<typename T>
+	static bool read_struct(godot::Ref<godot::FileAccess> const& file, T& t) {
+		if (file->get_length() - file->get_position() < sizeof(T)) {
+			return false;
+		}
+		bool res = file->get_buffer(reinterpret_cast<uint8_t*>(&t), sizeof(t)) == sizeof(t);
+		return res;
+	}
+
+	//Warning: works on the assumption of it being a packed struct being loaded into the array
+	template<typename T>
+	static bool read_struct_array(godot::Ref<godot::FileAccess> const& file, std::vector<T>& t, uint32_t size) {
+		if (file->get_length() - file->get_position() < size*sizeof(T)) {
+			return false;
+		}
+		t.resize(size*sizeof(T));
+		bool res = file->get_buffer(reinterpret_cast<uint8_t*>(t.data()), sizeof(T)*size) == sizeof(t);
+		return res;
+	}
+
+	static bool read_chunk_header(godot::Ref<godot::FileAccess> const& file, chunk_header_t& header) {
+		//ERR_FAIL_COND_V(!read_struct(file, header), false);
+		bool res = read_struct(file, header);
+		return res;
+	}
+
+	static godot::Vector2 vec2d_to_godot(vec2d_t const& vec2_in) {
+		godot::Vector2 vec2_out = {
+			vec2_in.x,
+			vec2_in.y
+		};
+		return vec2_out;
+	}
+
+	static godot::Vector3 vec3d_to_godot(vec3d_t const& vec3_in, bool is_position = false) {
+		godot::Vector3 vec3_out = {
+			vec3_in.x,
+			vec3_in.y,
+			vec3_in.z
+		};
+		if (is_position) {
+			vec3_out.x *= -1;
+		}
+		return vec3_out;
+	}
+
+	static godot::Vector4 vec4d_to_godot(vec4d_t const& vec4_in) {
+		godot::Vector4 vec4_out = {
+			vec4_in.x,
+			vec4_in.y,
+			vec4_in.z,
+			vec4_in.w
+		};
+		return vec4_out;
+	}
+
+	static godot::Quaternion quat_v1_to_godot(quat_v1_t const& quat_in) {
+		godot::Quaternion quat_out = godot::Quaternion(
+			quat_in.x,
+			-quat_in.y,
+			-quat_in.z,
+			quat_in.w
+		);
+		if (!quat_out.is_normalized()) {
+			quat_out = godot::Quaternion();
+		}
+		return quat_out;
+	}
+
+	static godot::Quaternion quat_v2_to_godot(quat_v2_t const& quat_in) {
+		static const float scale = 32767;
+		godot::Quaternion quat_out = godot::Quaternion(
+			static_cast<float>(quat_in.x) / scale,
+			static_cast<float>(-quat_in.y) / scale,
+			static_cast<float>(-quat_in.z) / scale,
+			static_cast<float>(quat_in.w) / scale
+		);
+		if (!quat_out.is_normalized()) {
+			quat_out = godot::Quaternion();
+		}
+		
+		return quat_out;
+	}
+
+	static godot::Color color_32_to_godot(color_32_t const& color_in) {
+		static const float scale = 256;
+		godot::Color color_out = {
+			(float)color_in.r / scale, 
+			(float)color_in.g / scale, 
+			(float)color_in.b / scale, 
+			(float)color_in.a / scale
+		};
+		return color_out;
+	}
+
+	//TODO: verify this conversion is correct. We don't load vertex colours for now, so this is likely unnecessary
+	static godot::Color color_128_to_godot(color_128_t const& color_in) {
+		static const double scale = 2147483647;
+		godot::Color color_out = {
+			static_cast<float>(color_in.r / scale),
+			static_cast<float>(color_in.g / scale),
+			static_cast<float>(color_in.b / scale),
+			static_cast<float>(color_in.a / scale)
+		};
+		return color_out;
+	}
+
+	static godot::Color vec4d_to_godot_color(vec4d_t const& color_in) {
+		godot::Color color_out = {
+			color_in.x,
+			color_in.y,
+			color_in.z,
+			color_in.w
+		};
+		return color_out;
+	}
+}

--- a/extension/src/openvic-extension/utility/XSMLoader.cpp
+++ b/extension/src/openvic-extension/utility/XSMLoader.cpp
@@ -1,0 +1,269 @@
+#include "XSMLoader.hpp"
+
+using namespace::OpenVic;
+using namespace::godot;
+
+bool XsmLoader::_read_xsm_header(Ref<FileAccess> const& file) {
+	xsm_header_t header = {};
+	ERR_FAIL_COND_V(!read_struct(file, header), false);
+
+	//Logger::info("XSM file version: ", header.version_major, ".", header.version_minor," big endian?: ",header.big_endian);
+
+	ERR_FAIL_COND_V_MSG(
+		header.format_identifier != XSM_FORMAT_SPECIFIER, false, vformat(
+			"Invalid XSM format identifier: %x (should be %x)", header.format_identifier, XSM_FORMAT_SPECIFIER
+		)
+	);
+
+	ERR_FAIL_COND_V_MSG(
+		header.version_major != XSM_VERSION_MAJOR || header.version_minor != XSM_VERSION_MINOR, false, vformat(
+			"Invalid XSM version: %d.%d (should be %d.%d)",
+			header.version_major, header.version_minor, XSM_VERSION_MAJOR, XSM_VERSION_MINOR
+		)
+	);
+
+	ERR_FAIL_COND_V_MSG(
+		header.big_endian != 0, false, "Invalid XSM endianness: big endian (only little endian is supported)"
+	);
+
+	return true;
+}
+
+bool XsmLoader::_read_xsm_metadata(Ref<FileAccess> const& file, xsm_metadata_t& metadata, int32_t version) {
+	bool res = true;
+	if (version != 1) {
+		res &= read_struct(file, metadata.v2_data);
+		metadata.has_v2_data = true;
+	} 
+	res &= read_struct(file, metadata.packed);
+	res &= read_string(file, metadata.source_app);
+	res &= read_string(file, metadata.original_file_name);
+	res &= read_string(file, metadata.export_date);
+	res &= read_string(file, metadata.motion_name);
+
+	return res;
+}
+
+bool XsmLoader::_read_rot_keys(Ref<FileAccess> const& file, std::vector<rotation_key_t>* keys_out, int32_t count, int32_t version) {
+	bool res = true;
+
+	if (version == 1) {
+		std::vector<rotation_key_v1_t> rot_keys_v1;
+		res &= read_struct_array(file,rot_keys_v1,count);
+		for(rotation_key_v1_t const& key : rot_keys_v1) {
+			keys_out->push_back({quat_v1_to_godot(key.rotation), key.time});
+		}
+	}
+	else {
+		std::vector<rotation_key_v2_t> rot_keys_v2;
+		res &= read_struct_array(file,rot_keys_v2,count);
+		for(rotation_key_v2_t const& key : rot_keys_v2) {
+			keys_out->push_back({quat_v2_to_godot(key.rotation), key.time});
+		}
+	}
+
+	return res;
+}
+
+bool XsmLoader::_read_skeletal_submotion(Ref<FileAccess> const& file, skeletal_submotion_t& submotion, int32_t version) {
+	bool res = true;
+	if (version == 1) { //float component quats (v1)
+		submotion_rot_v1_pack_t rot_comps = {};
+		res &= read_struct(file,rot_comps);
+		submotion.pose_rotation = quat_v1_to_godot(rot_comps.pose_rotation);
+		submotion.bind_pose_rotation = quat_v1_to_godot(rot_comps.bind_pose_rotation);
+		submotion.pose_scale_rotation = quat_v1_to_godot(rot_comps.pose_scale_rotation);
+		submotion.bind_pose_scale_rotation = quat_v1_to_godot(rot_comps.bind_pose_scale_rotation);
+	}
+	else { //int16 component quats (v2)
+		submotion_rot_v2_pack_t rot_comps = {};
+		res &= read_struct(file,rot_comps);
+		submotion.pose_rotation = quat_v2_to_godot(rot_comps.pose_rotation);
+		submotion.bind_pose_rotation = quat_v2_to_godot(rot_comps.bind_pose_rotation);
+		submotion.pose_scale_rotation = quat_v2_to_godot(rot_comps.pose_scale_rotation);
+		submotion.bind_pose_scale_rotation = quat_v2_to_godot(rot_comps.bind_pose_scale_rotation);
+	}
+		
+	ERR_FAIL_COND_V(!read_struct(file, submotion.packed), false);
+	res &= read_string(file, submotion.node_name,true);
+	res &= read_struct_array(file,submotion.position_keys,submotion.packed.position_key_count);
+	res &= _read_rot_keys(file,&submotion.rotation_keys,submotion.packed.rotation_key_count, version);
+	res &= read_struct_array(file,submotion.scale_keys,submotion.packed.scale_key_count);
+	res &= _read_rot_keys(file,&submotion.scale_rotation_keys,submotion.packed.scale_rotation_key_count, version);
+
+	return res;
+}
+
+bool XsmLoader::_read_xsm_bone_animation(Ref<FileAccess> const& file, bone_animation_t& bone_animation, int32_t version) {
+	bone_animation.submotion_count = file->get_32();
+	bool ret = true;
+
+	for(uint32_t i=0; i<bone_animation.submotion_count; i++) {
+		skeletal_submotion_t submotion;
+		ret &= _read_skeletal_submotion(file, submotion, version);
+		bone_animation.submotions.push_back(submotion);
+	}
+
+	return true;
+}
+
+bool XsmLoader::_read_node_submotion(Ref<FileAccess> const& file, std::vector<node_submotion_t>* submotions) {
+	bool res = true;
+	node_submotion_t submotion;
+
+	submotion_rot_v1_pack_t rot_comps = {};
+	res &= read_struct(file,rot_comps);
+	submotion.pose_rotation = quat_v1_to_godot(rot_comps.pose_rotation);
+	submotion.bind_pose_rotation = quat_v1_to_godot(rot_comps.bind_pose_rotation);
+	submotion.pose_scale_rotation = quat_v1_to_godot(rot_comps.pose_scale_rotation);
+	submotion.bind_pose_scale_rotation = quat_v1_to_godot(rot_comps.bind_pose_scale_rotation);
+
+	res &= read_struct(file, submotion.packed);
+	res &= read_string(file, submotion.node_name);
+	res &= read_struct_array(file,submotion.position_keys,submotion.packed.position_key_count);
+	res &= _read_rot_keys(file,&submotion.rotation_keys,submotion.packed.rotation_key_count, 1);
+	res &= read_struct_array(file,submotion.scale_keys,submotion.packed.scale_key_count);
+	res &= _read_rot_keys(file,&submotion.scale_rotation_keys,submotion.packed.scale_rotation_key_count, 1);
+	submotions->push_back(submotion);
+
+	return res;
+}
+
+//returns highest time in the submotion
+template<typename T>
+float XsmLoader::_add_submotion(Ref<Animation> anim, T const& submotion) {
+	//a variable string or stringname with %s makes godot fail silently if placed outside a function
+	static const StringName SKELETON_NODE_PATH = "./skeleton:%s";
+	float max_time = 0;
+
+	//NOTE: godot uses ':' to specify properties, so we replaced such characters with '_' when we read them in
+	String skeleton_path = vformat(SKELETON_NODE_PATH, submotion.node_name);
+
+	int32_t pos_id = anim->add_track(Animation::TYPE_POSITION_3D);
+	int32_t rot_id = anim->add_track(Animation::TYPE_ROTATION_3D);
+	int32_t scale_id = anim->add_track(Animation::TYPE_SCALE_3D);
+
+	anim->track_set_path(pos_id, skeleton_path);
+	anim->track_set_path(rot_id, skeleton_path);
+	anim->track_set_path(scale_id, skeleton_path);
+
+	for(position_key_t const& key : submotion.position_keys) {
+		anim->position_track_insert_key(pos_id, key.time, vec3d_to_godot(key.position, true));
+		if (key.time > max_time) {
+			max_time = key.time;
+		}
+	}
+
+	for(rotation_key_t const& key : submotion.rotation_keys) {
+		anim->rotation_track_insert_key(rot_id, key.time, key.rotation);
+		if (key.time > max_time) {
+			max_time = key.time;
+		}
+	}
+
+	//not needed for vic2 animations, but we can still support it
+	for(scale_key_t const& key : submotion.scale_keys) {
+		anim->scale_track_insert_key(scale_id, key.time, vec3d_to_godot(key.scale));
+		if (key.time > max_time) {
+			max_time = key.time;
+		}
+	}
+
+	// TODO: SCALEROTATION (unused in vic2, so low priority)
+	for(rotation_key_t const& key : submotion.scale_rotation_keys) {
+		if (key.time > max_time) {
+			max_time = key.time;
+		}
+	}
+
+	//If you pay close attention, there's still a small jump along the loop point because of this hack
+	// this hack is in place because otherwise animations completely broken.
+	// The small animation jump is visible in vic2 aswell, so its likely something to do with bad data, rather than a problem
+	// with the loader here.
+	if (anim->track_find_key(pos_id, 0) != -1) {
+		anim->track_remove_key_at_time(pos_id, 0);
+	}
+	if (anim->track_find_key(rot_id, 0) != -1) {
+		anim->track_remove_key_at_time(rot_id, 0);
+	}
+	if (anim->track_find_key(scale_id, 0) != -1) {
+		anim->track_remove_key_at_time(scale_id, 0);
+	}
+	
+	//add the "default" positions/rotation/scale/... as keys at time 0
+	anim->position_track_insert_key(pos_id, 0, vec3d_to_godot(submotion.packed.pose_position, true));
+	anim->rotation_track_insert_key(rot_id, 0, submotion.pose_rotation);
+	anim->scale_track_insert_key(scale_id, 0, vec3d_to_godot(submotion.packed.pose_scale));
+
+
+	return max_time;
+}
+
+Ref<Animation> XsmLoader::load_xsm_animation(Ref<FileAccess> const& file) {
+
+	_read_xsm_header(file);
+
+	xsm_metadata_t metadata;
+	bone_animation_t bone_anim;
+	std::vector<node_submotion_t> node_submotions;
+
+	bool res = true;
+
+	while(!file->eof_reached()) {
+		chunk_header_t header = {};
+		if (!read_chunk_header(file, header)) { break; }
+		if (header.type == 0xC9) {
+			_read_xsm_metadata(file, metadata, header.version); //in zulu_moving.xsm, this is v1
+		}
+		else if (header.type == 0xC8) {
+			_read_node_submotion(file,&node_submotions);
+		}
+		else if (header.type == 0xCA) {
+			_read_xsm_bone_animation(file, bone_anim, header.version);
+		}
+		else {
+			UtilityFunctions::print(
+			vformat("Unsupported XSM chunk: file: %s, type = %x, length = %x, version = %d at %x", file->get_path(), header.type, header.length, header.version, file->get_position())
+			);
+			
+			// Skip unsupported chunks
+			if (header.length + file->get_position() < file->get_length()) {
+				PackedByteArray buf = file->get_buffer(header.length);
+				UtilityFunctions::print(buf);
+			}
+			else {
+				res = false;
+				break;
+			} 
+		}
+	}
+
+	float animation_length = 0.0;
+	Ref<Animation> anim = Ref<Animation>();
+	anim.instantiate();
+
+	anim->set_step(1.0/metadata.packed.fps);
+	anim->set_loop_mode(Animation::LOOP_LINEAR);
+
+	if (res == false) {
+		return anim; //exit early if reading the chunks in failed
+	}
+
+	for(skeletal_submotion_t const& submotion : bone_anim.submotions) {
+		float submotion_len = _add_submotion(anim, submotion);
+		if (submotion_len > animation_length) {
+			animation_length = submotion_len;
+		}
+	}
+
+	for(node_submotion_t const& submotion : node_submotions) {
+		float submotion_len = _add_submotion(anim, submotion);
+		if (submotion_len > animation_length) {
+			animation_length = submotion_len;
+		}
+	}
+
+	anim->set_length(animation_length);
+
+	return anim;
+}

--- a/extension/src/openvic-extension/utility/XSMLoader.hpp
+++ b/extension/src/openvic-extension/utility/XSMLoader.hpp
@@ -1,0 +1,176 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include <godot_cpp/classes/animation.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/packed_vector3_array.hpp>
+#include <godot_cpp/variant/packed_vector4_array.hpp>
+#include <godot_cpp/variant/quaternion.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+#include "XACUtilities.hpp"
+
+namespace OpenVic {
+	static constexpr uint32_t XSM_FORMAT_SPECIFIER = ' MSX'; /* Order reversed due to little endian */
+	static constexpr uint8_t XSM_VERSION_MAJOR = 1, XSM_VERSION_MINOR = 0;
+	
+	class XsmLoader {
+		// Pack structs of data that can be read directly
+		#pragma pack(push)
+		#pragma pack(1)
+		
+		struct xsm_header_t {
+			uint32_t format_identifier;
+			uint8_t version_major;
+			uint8_t version_minor;
+			uint8_t big_endian;
+			uint8_t pad;
+		};
+		
+		//v2 of the header adds these 2 properties at the start
+		struct xsm_metadata_v2_pack_extra_t {
+			float unused;
+			float max_acceptable_error;
+		};
+		
+		struct xsm_metadata_pack_t {
+			int32_t fps;
+			uint8_t exporter_version_major; //these 3 properties are uncertain
+			uint8_t exporter_version_minor;
+			uint16_t pad;
+		};
+		
+		struct position_key_t {
+			vec3d_t position;
+			float time;
+		};
+		
+		struct rotation_key_v2_t {
+			quat_v2_t rotation;
+			float time;
+		};
+		
+		struct rotation_key_v1_t {
+			quat_v1_t rotation;
+			float time;
+		};
+		
+		struct scale_key_t {
+			vec3d_t scale;
+			float time;
+		};
+		
+		//the quaternions come at the start of the skeletal submotion
+		struct submotion_rot_v2_pack_t {
+			quat_v2_t pose_rotation;
+			quat_v2_t bind_pose_rotation;
+			quat_v2_t pose_scale_rotation;
+			quat_v2_t bind_pose_scale_rotation;
+		};
+		
+		struct submotion_rot_v1_pack_t {
+			quat_v1_t pose_rotation;
+			quat_v1_t bind_pose_rotation;
+			quat_v1_t pose_scale_rotation;
+			quat_v1_t bind_pose_scale_rotation;
+		};
+		
+		struct skeletal_submotion_pack_t {
+			vec3d_t pose_position;
+			vec3d_t pose_scale;
+			vec3d_t bind_pose_position;
+			vec3d_t bind_pose_scale;
+			int32_t position_key_count;
+			int32_t rotation_key_count;
+			int32_t scale_key_count;
+			int32_t scale_rotation_key_count;
+			float max_error;
+		};
+		
+		struct node_submotion_pack_t {
+			vec3d_t pose_position;
+			vec3d_t pose_scale;
+			vec3d_t bind_pose_position;
+			vec3d_t bind_pose_scale;
+			int32_t position_key_count;
+			int32_t rotation_key_count;
+			int32_t scale_key_count;
+			int32_t scale_rotation_key_count;
+		};
+		
+		#pragma pack(pop)
+		
+		struct xsm_metadata_t {
+			bool has_v2_data = false;
+			xsm_metadata_v2_pack_extra_t v2_data = {};
+			xsm_metadata_pack_t packed = {};
+			godot::String source_app;
+			godot::String original_file_name;
+			godot::String export_date;
+			godot::String motion_name;
+		};
+		
+		struct rotation_key_t {
+			godot::Quaternion rotation;
+			float time;
+		};
+		
+		struct skeletal_submotion_t {
+			godot::Quaternion pose_rotation;
+			godot::Quaternion bind_pose_rotation;
+			godot::Quaternion pose_scale_rotation;
+			godot::Quaternion bind_pose_scale_rotation;
+			skeletal_submotion_pack_t packed = {};
+			godot::String node_name;
+			std::vector<position_key_t> position_keys;
+			std::vector<rotation_key_t> rotation_keys;
+			std::vector<scale_key_t> scale_keys;
+			std::vector<rotation_key_t> scale_rotation_keys;
+		};
+		
+		struct bone_animation_t {
+			int32_t submotion_count = 0;
+			std::vector<skeletal_submotion_t> submotions;
+		};
+		
+		/*
+		0xC8, v1 chunk documentation: (Let's call it node_submotion)
+			4*8x 32 bit sections = 32
+				4x quat32 = 16
+				4x vec3   = 12
+				4x keycount 04
+							32
+			string node_name
+			data...
+		
+			so this chunk is the same as a skeletal submotion v1
+			but without the fMaxError
+		*/
+		struct node_submotion_t {
+			godot::Quaternion pose_rotation;
+			godot::Quaternion bind_pose_rotation;
+			godot::Quaternion pose_scale_rotation;
+			godot::Quaternion bind_pose_scale_rotation;
+			node_submotion_pack_t packed = {};
+			godot::String node_name;
+			std::vector<position_key_t> position_keys;
+			std::vector<rotation_key_t> rotation_keys;
+			std::vector<scale_key_t> scale_keys;
+			std::vector<rotation_key_t> scale_rotation_keys;
+		};
+
+
+		private:
+			bool _read_xsm_header(godot::Ref<godot::FileAccess> const& file);
+			bool _read_xsm_metadata(godot::Ref<godot::FileAccess> const& file, xsm_metadata_t& metadata, int32_t version);
+			bool _read_rot_keys(godot::Ref<godot::FileAccess> const& file, std::vector<rotation_key_t>* keys_out, int32_t count, int32_t version);
+			bool _read_skeletal_submotion(godot::Ref<godot::FileAccess> const& file, skeletal_submotion_t& submotion, int32_t version);
+			bool _read_xsm_bone_animation(godot::Ref<godot::FileAccess> const& file, bone_animation_t& bone_animation, int32_t version);
+			bool _read_node_submotion(godot::Ref<godot::FileAccess> const& file, std::vector<node_submotion_t>* submotions);
+			template<typename T>
+			float _add_submotion(godot::Ref<godot::Animation> anim, T const& submotion);
+
+		public:
+			godot::Ref<godot::Animation> load_xsm_animation(godot::Ref<godot::FileAccess> const& file);
+	};
+}

--- a/game/project.godot
+++ b/game/project.godot
@@ -184,3 +184,4 @@ settings/ips_file_path="user://ips.cfg"
 textures/vram_compression/import_etc2_astc=true
 textures/lossless_compression/force_png=true
 textures/default_filters/use_nearest_mipmap_filter=true
+limits/global_shader_variables/buffer_size=131072

--- a/game/src/Game/GameSession/GameSession.tscn
+++ b/game/src/Game/GameSession/GameSession.tscn
@@ -48,9 +48,15 @@ _game_session_menu = NodePath("UICanvasLayer/UI/GameSessionMenu")
 
 [node name="MapView" parent="." instance=ExtResource("4_xkg5j")]
 
-[node name="ModelManager" type="Node3D" parent="." node_paths=PackedStringArray("_map_view")]
+[node name="ModelManager" type="Node3D" parent="." node_paths=PackedStringArray("_map_view", "_buildings", "_units")]
 script = ExtResource("3_qwk4j")
 _map_view = NodePath("../MapView")
+_buildings = NodePath("Buildings")
+_units = NodePath("Units")
+
+[node name="Buildings" type="Node3D" parent="ModelManager"]
+
+[node name="Units" type="Node3D" parent="ModelManager"]
 
 [node name="BillboardManager" type="MultiMeshInstance3D" parent="." node_paths=PackedStringArray("_map_view")]
 sorting_offset = 10.0

--- a/game/src/Game/GameSession/ModelManager.gd
+++ b/game/src/Game/GameSession/ModelManager.gd
@@ -2,11 +2,13 @@ class_name ModelManager
 extends Node3D
 
 @export var _map_view : MapView
+@export var _buildings : Node3D
+@export var _units : Node3D
 
 const MODEL_SCALE : float = 1.0 / 256.0
 
 func generate_units() -> void:
-	XACLoader.setup_flag_shader()
+	ModelSingleton.setup_flag_shader()
 
 	for unit : Dictionary in ModelSingleton.get_units():
 		_generate_unit(unit)
@@ -61,7 +63,7 @@ func _generate_unit(unit_dict : Dictionary) -> void:
 		model.secondary_colour = unit_dict[secondary_colour_key]
 		model.tertiary_colour = unit_dict[tertiary_colour_key]
 
-	add_child(model)
+	_units.add_child(model)
 
 func generate_buildings() -> void:
 	for building : Dictionary in ModelSingleton.get_buildings():
@@ -80,7 +82,7 @@ func _generate_building(building_dict : Dictionary) -> void:
 	model.rotate_y(PI + building_dict.get(rotation_key, 0.0))
 	model.set_position(_map_view._map_to_world_coords(building_dict[position_key]) + Vector3(0, 0.1 * MODEL_SCALE, 0))
 
-	add_child(model)
+	_buildings.add_child(model)
 
 func _generate_model(model_dict : Dictionary, culture : String = "", is_unit : bool = false) -> Node3D:
 	const file_key : StringName = &"file"
@@ -103,8 +105,7 @@ func _generate_model(model_dict : Dictionary, culture : String = "", is_unit : b
 		# Currently needs UnitModel's attach_model helper function
 		or attachments_key in model_dict
 	)
-
-	var model : Node3D = XACLoader.get_xac_model(model_dict[file_key], is_unit)
+	var model : Node3D = ModelSingleton.get_xac_model(model_dict[file_key], is_unit)
 	if not model:
 		return null
 	model.scale *= model_dict[scale_key]
@@ -113,17 +114,17 @@ func _generate_model(model_dict : Dictionary, culture : String = "", is_unit : b
 		# Animations
 		var idle_dict : Dictionary = model_dict.get(idle_key, {})
 		if idle_dict:
-			model.set_idle_anim(XSMLoader.get_xsm_animation(idle_dict[animation_file_key]))
+			model.set_idle_anim(ModelSingleton.get_xsm_animation(idle_dict[animation_file_key]))
 			model.scroll_speed_idle = idle_dict[animation_time_key]
 
 		var move_dict : Dictionary = model_dict.get(move_key, {})
 		if move_dict:
-			model.set_move_anim(XSMLoader.get_xsm_animation(move_dict[animation_file_key]))
+			model.set_move_anim(ModelSingleton.get_xsm_animation(move_dict[animation_file_key]))
 			model.scroll_speed_move = move_dict[animation_time_key]
 
 		var attack_dict : Dictionary = model_dict.get(attack_key, {})
 		if attack_dict:
-			model.set_attack_anim(XSMLoader.get_xsm_animation(attack_dict[animation_file_key]))
+			model.set_attack_anim(ModelSingleton.get_xsm_animation(attack_dict[animation_file_key]))
 			model.scroll_speed_attack = attack_dict[animation_time_key]
 
 		# Attachments

--- a/game/src/Game/Model/UnitModel.gd
+++ b/game/src/Game/Model/UnitModel.gd
@@ -101,7 +101,9 @@ const ANIMATION_LIBRARY : StringName = &"default_lib"
 		for unit : UnitModel in sub_units:
 			unit.scroll_speed_attack = speed_in
 
-func unit_init() -> void:
+func unit_init(print:bool = false) -> void:
+	#if print:
+	#	print("unit_init called!")
 	for child : Node in get_children():
 		if child is MeshInstance3D:
 			meshes.append(child)

--- a/game/src/Game/Model/XACLoader.gd
+++ b/game/src/Game/Model/XACLoader.gd
@@ -141,8 +141,9 @@ static func _load_xac_model(source_file : String, is_unit : bool) -> Node3D:
 		if mesh_chunk_name in INVALID_MESHES:
 			push_warning("Skipping unused mesh \"", mesh_chunk_name, "\" in model \"", node.name, "\"")
 			continue
-
+		#st.commit_to_arrays()
 		var mesh : ArrayMesh = null
+		#mesh.add_surface_from_arrays(
 		var verts : PackedVector3Array
 		var normals : PackedVector3Array
 		var tangents : Array[Vector4]
@@ -354,8 +355,9 @@ static func make_materials(materialDefinitionChunks : Array[MaterialDefinitionCh
 		if diffuse_name and specular_name:
 			if normal_name:
 				push_error("Normal texture present in unit colours material: ", normal_name)
-
-			var textures_index_spec : int = added_unit_textures_spec.find(specular_name)
+			var textures_index_diffuse = ModelSingleton.set_unit_material_texture(2,diffuse_name)
+			var textures_index_spec = ModelSingleton.set_unit_material_texture(3,specular_name)
+			"""var textures_index_spec : int = added_unit_textures_spec.find(specular_name)
 			if textures_index_spec < 0:
 				var unit_colours_mask_texture : ImageTexture = AssetManager.get_texture(TEXTURES_PATH % specular_name)
 				if unit_colours_mask_texture:
@@ -392,7 +394,8 @@ static func make_materials(materialDefinitionChunks : Array[MaterialDefinitionCh
 					unit_shader.set_shader_parameter(param_texture_diffuse, diffuse_textures)
 				else:
 					push_error("Failed to load diffuse texture: ", diffuse_name)
-
+			"""
+			
 			materials.push_back(MaterialDefinition.new(unit_shader, textures_index_diffuse, textures_index_spec))
 
 		# Flag (diffuse is unionjacksquare which is ignored)
@@ -414,7 +417,7 @@ static func make_materials(materialDefinitionChunks : Array[MaterialDefinitionCh
 				push_error("Specular texture present in scrolling material: ", specular_name)
 			if normal_name:
 				push_error("Normal texture present in scrolling material: ", normal_name)
-
+			#ModelSingleton. TODO
 			var scroll_textures_index_diffuse : int = added_scrolling_textures_diffuse.find(diffuse_name)
 			if scroll_textures_index_diffuse < 0:
 				var diffuse_texture : ImageTexture = AssetManager.get_texture(TEXTURES_PATH % diffuse_name)

--- a/game/src/Game/Model/unit_colours.gdshader
+++ b/game/src/Game/Model/unit_colours.gdshader
@@ -1,12 +1,14 @@
 
 shader_type spatial;
 
-render_mode cull_disabled;
+render_mode cull_disabled, depth_prepass_alpha;
 
 //hold all the textures for the units that need this shader to mix in their
 //nation colours (mostly generic infantry units)
-uniform sampler2D texture_diffuse[32] : source_color, filter_linear_mipmap, repeat_enable;
-uniform sampler2D texture_nation_colors_mask[32] : source_color, filter_linear_mipmap, repeat_enable;
+//TODO: decrease back to 32
+uniform sampler2D texture_diffuse[64] : source_color, filter_linear_mipmap, repeat_enable;
+uniform sampler2D texture_nation_colors_mask[64] : source_color, filter_linear_mipmap, repeat_enable;
+//uniform sampler2D texture_shadow[32] : source_color, filter_linear_mipmap, repeat_enable;
 
 instance uniform vec3 colour_primary : source_color;
 instance uniform vec3 colour_secondary : source_color;
@@ -14,18 +16,24 @@ instance uniform vec3 colour_tertiary : source_color;
 
 //used to access the right textures since different units (with different textures)
 //will use this same shader
-instance uniform uint tex_index_diffuse;
-instance uniform uint tex_index_specular;
+instance uniform int tex_index_diffuse;
+instance uniform int tex_index_specular;
+//instance uniform int tex_index_shadow = -1; //0 = none
 
 void fragment() {
 	vec2 base_uv = UV;
 	vec4 diffuse_tex = texture(texture_diffuse[tex_index_diffuse], base_uv);
 	vec4 nation_colours_tex = texture(texture_nation_colors_mask[tex_index_specular], base_uv);
-
+	
 	//set colours to either be white (1,1,1) or the nation colour based on the mask
 	vec3 primary_col = mix(vec3(1.0, 1.0, 1.0), colour_primary, nation_colours_tex.g);
 	vec3 secondary_col = mix(vec3(1.0, 1.0, 1.0), colour_secondary, nation_colours_tex.b);
 	vec3 tertiary_col = mix(vec3(1.0, 1.0, 1.0), colour_tertiary, nation_colours_tex.r);
-
+	
 	ALBEDO = diffuse_tex.rgb * primary_col * secondary_col * tertiary_col;
+	ALPHA = diffuse_tex.a;
+	/*if(tex_index_shadow != -1){
+		vec4 shadow_tex = texture(texture_shadow[tex_index_shadow], base_uv);
+		ALBEDO = shadow_tex.rgb;
+	}*/
 }


### PR DESCRIPTION
New PR - needs code review.


XSM animation file loading:

    Can now read 0xC8 chunk style animations (needed for zulu_walking.xsm)
    Uses a hack of deleting frame 0 from all animation tracks to work. This replicates the behaviour of the gdscript version, but obviously is not ideal.
    Cached in ModelSingleton
    Used for all animation loading

XAC file loading:

    Used for static (ie. no 'unit' script for animation) meshes only currently.
    Textures are loading, but lighting is off
    Bone weights / skinning chunks are not working and needs more work before this can fully replace the gdscript function versions.
    Cached in ModelSingleton

