### PR TITLE
Add AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,81 @@
+# OpenVic Game authors
+
+This file does not strictly reflect copyright ownership for the game
+source code. For this, refer to the Git history to know which contributor
+wrote which part of the codebase.
+
+GitHub usernames are indicated in parentheses, or as sole entry when no other
+name is available.
+
+Consultants and Artist have not necessarily contributed code but have contributed in other
+ways to development of the game.
+
+## Senior Developers
+
+    Hop311
+    George L. Albany (Spartan322)
+    BrickPi
+
+## Developers
+
+    General WVPM (wvpm)
+    Nemrav
+    zaaarf
+    Arturo
+    BetterBite
+    FarmingtonS9
+    Orwellian-225
+
+## Contributors
+
+    joethepro36
+    ZincLadder (ClarkeCode)
+    FakeByte
+    random person (unique-usernames-are-annoying)
+    Gone2Daly
+    Frédéric Van Aken
+    DiarmaidMckeagney
+    fxrmi (Fxrmillan)
+    Wolfgang Aigner
+    Rerum02
+    YouriRombouts
+    Ben1152000
+    IsaiahWitzke
+    JunkJen
+    markomitos
+    Typhion
+    Jarturog
+    TheRedKing247
+    KaiserOfNone
+    ce-lp
+    nuruvilu
+    devdude
+
+## Consultants
+
+    Spudgun
+    Catylist
+    motionsense
+    Mr_StuG
+    Manters
+    wyrm
+    Nurse_Reno
+    Dempsey
+    kiwi
+    Zombie_Freak115
+    Valerus9
+
+## Artists
+
+    Catylist
+    JunkJen
+    Amelia
+    Bon Marché
+    qazdr6
+    Rataz
+    lex_smn_cs
+    Patrick
+    Starls
+    The Second Appearance
+    The Skeleton Appears
+    Tupinamba

--- a/SConstruct
+++ b/SConstruct
@@ -46,6 +46,20 @@ Default(
         env.Run(env.license_builder), name_prefix="game"
     )
 )
+Default(
+    env.CommandNoCache(
+        "extension/src/gen/author_info.gen.hpp",
+        "#AUTHORS.md",
+        env.Run(env.author_builder), name_prefix="game",
+        sections = {
+            "Senior Developers": "AUTHORS_SENIOR_DEVELOPERS",
+            "Developers": "AUTHORS_DEVELOPERS",
+            "Contributors": "AUTHORS_CONTRIBUTORS",
+            "Consultants": "AUTHORS_CONSULTANTS",
+            "Artists": "AUTHORS_ARTISTS"
+        }
+    )
+)
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++


### PR DESCRIPTION
- Depends on #501 

Add compile-time author info generator

Reference for generated data is
```cpp
namespace OpenVic {
	static constexpr std::array<std::string_view> GAME_AUTHORS_SENIOR_DEVELOPERS;
	static constexpr std::array<std::string_view> GAME_AUTHORS_DEVELOPERS;
	static constexpr std::array<std::string_view> GAME_AUTHORS_CONTRIBUTORS;
	static constexpr std::array<std::string_view> GAME_AUTHORS_CONSULTANTS;
	static constexpr std::array<std::string_view> GAME_AUTHORS_ARTISTS;
}
```

Note: This is not an exhaustive list of correct information, especially for consultants and artists, if any information should be corrected or changed I would recommend contacting me, I have left any non-usernames out aside from mine even if it is identified with the email or Github account to minimize overstepping the desired boundaries. If anyone would like their proper (full or partial) name included, you can put it here. 