### PR TITLE
Refactor scrollbar

### DIFF
--- a/extension/doc_classes/GUIScrollbar.xml
+++ b/extension/doc_classes/GUIScrollbar.xml
@@ -19,7 +19,6 @@
 		</method>
 		<method name="decrement_value">
 			<return type="void" />
-			<param index="0" name="signal" type="bool" default="true" />
 			<description>
 			</description>
 		</method>
@@ -38,28 +37,8 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_max_value" qualifiers="const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_min_value" qualifiers="const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="get_orientation" qualifiers="const">
 			<return type="int" enum="Orientation" />
-			<description>
-			</description>
-		</method>
-		<method name="get_range_limit_max" qualifiers="const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_range_limit_min" qualifiers="const">
-			<return type="int" />
 			<description>
 			</description>
 		</method>
@@ -80,7 +59,6 @@
 		</method>
 		<method name="increment_value">
 			<return type="void" />
-			<param index="0" name="signal" type="bool" default="true" />
 			<description>
 			</description>
 		</method>
@@ -90,7 +68,7 @@
 			</description>
 		</method>
 		<method name="reset">
-			<return type="int" enum="Error" />
+			<return type="void" />
 			<description>
 			</description>
 		</method>
@@ -107,28 +85,9 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_limits">
-			<return type="int" enum="Error" />
-			<param index="0" name="new_min_value" type="int" />
-			<param index="1" name="new_max_value" type="int" />
-			<param index="2" name="signal" type="bool" default="true" />
-			<description>
-			</description>
-		</method>
-		<method name="set_range_limits">
-			<return type="int" enum="Error" />
-			<param index="0" name="new_range_limit_min" type="int" />
-			<param index="1" name="new_range_limit_max" type="int" />
-			<param index="2" name="signal" type="bool" default="true" />
-			<description>
-			</description>
-		</method>
-		<method name="set_range_limits_and_value">
-			<return type="int" enum="Error" />
-			<param index="0" name="new_range_limit_min" type="int" />
-			<param index="1" name="new_range_limit_max" type="int" />
-			<param index="2" name="new_value" type="int" />
-			<param index="3" name="signal" type="bool" default="true" />
+		<method name="set_step_count">
+			<return type="void" />
+			<param index="0" name="new_step_count" type="int" />
 			<description>
 			</description>
 		</method>
@@ -142,14 +101,12 @@
 		<method name="set_value">
 			<return type="void" />
 			<param index="0" name="new_value" type="int" />
-			<param index="1" name="signal" type="bool" default="true" />
 			<description>
 			</description>
 		</method>
 		<method name="set_value_as_ratio">
 			<return type="void" />
 			<param index="0" name="new_ratio" type="float" />
-			<param index="1" name="signal" type="bool" default="true" />
 			<description>
 			</description>
 		</method>

--- a/extension/src/openvic-extension/classes/GUIListBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIListBox.cpp
@@ -63,7 +63,11 @@ Error GUIListBox::_calculate_max_scroll_index(bool signal) {
 
 	ERR_FAIL_NULL_V(scrollbar, FAILED);
 
-	scrollbar->set_limits(0, max_scroll_index, false);
+	const bool was_blocking_signals = scrollbar->is_blocking_signals();
+	scrollbar->set_block_signals(true);
+	scrollbar->set_step_count(max_scroll_index);
+	scrollbar->set_block_signals(was_blocking_signals);
+
 	scrollbar->set_visible(max_scroll_index > 0);
 
 	set_scroll_index(scrollbar->get_value(), signal);
@@ -209,7 +213,10 @@ void GUIListBox::set_scroll_index(int32_t new_scroll_index, bool signal) {
 	scroll_index = std::clamp(new_scroll_index, 0, max_scroll_index);
 
 	if (scrollbar != nullptr && scrollbar->get_value() != scroll_index) {
-		scrollbar->set_value(scroll_index, false);
+		const bool was_blocking_signals = scrollbar->is_blocking_signals();
+		scrollbar->set_block_signals(true);
+		scrollbar->set_value(scroll_index);
+		scrollbar->set_block_signals(was_blocking_signals);
 	}
 
 	if (signal && scroll_index != old_scroll_index) {

--- a/extension/src/openvic-extension/classes/GUIScrollbar.hpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <cstdint>
+
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/input_event.hpp>
 
 #include <openvic-simulation/interface/GUI.hpp>
+#include <openvic-simulation/types/Signal.hpp>
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
 
 #include "openvic-extension/classes/GFXSpriteTexture.hpp"
 #include "openvic-extension/classes/GUIHasTooltip.hpp"
@@ -38,14 +42,15 @@ namespace OpenVic {
 		godot::Orientation PROPERTY(orientation, godot::HORIZONTAL);
 		real_t PROPERTY(length_override, 0.0);
 
-		fixed_point_t PROPERTY(step_size, 1);
+		fixed_point_t offset = 0;
+		int32_t scale_numerator = 1;
+		int32_t scale_denominator = 1;
+		int32_t PROPERTY(step_count, 1);
 		int32_t PROPERTY(value, 0);
-		int32_t PROPERTY(min_value, 0);
-		int32_t PROPERTY(max_value, 0);
 
 		bool PROPERTY_CUSTOM_PREFIX(range_limited, is, false);
-		int32_t PROPERTY(range_limit_min, 0);
-		int32_t PROPERTY(range_limit_max, 0);
+		std::optional<int32_t> upper_range_limit;
+		std::optional<int32_t> lower_range_limit;
 
 		bool hover_slider = false, hover_track = false, hover_less = false, hover_more = false;
 		bool pressed_slider = false, pressed_track = false, pressed_less = false, pressed_more = false;
@@ -71,12 +76,13 @@ namespace OpenVic {
 		bool _update_button_change();
 
 		float _value_to_ratio(int32_t val) const;
+		int32_t _fp_to_value(const fixed_point_t val) const;
+		fixed_point_t _get_scaled_value(const int32_t val) const;
 
 		void _calculate_rects();
 
 		void _constrain_value();
-		godot::Error _constrain_range_limits();
-		godot::Error _constrain_limits();
+		void _constrain_range_limits();
 
 	protected:
 		static void _bind_methods();
@@ -85,6 +91,7 @@ namespace OpenVic {
 
 	public:
 		static godot::StringName const& signal_value_changed();
+		mutable signal_property<GUIScrollbar> value_changed;
 
 		GUIScrollbar();
 
@@ -92,40 +99,42 @@ namespace OpenVic {
 		void _gui_input(godot::Ref<godot::InputEvent> const& event) override;
 
 		void emit_value_changed();
-		godot::Error reset();
+		void reset();
 		void clear();
 
 		godot::Error set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar);
 		godot::Error set_gui_scrollbar_name(godot::String const& gui_scene, godot::String const& gui_scrollbar_name);
 		godot::String get_gui_scrollbar_name() const;
 
-		void set_value(int32_t new_value, bool signal = true);
-		void set_value_fp(fixed_point_t new_value, bool signal = true);
-		void set_value_from_slider_value(SliderValue const& slider_value, int32_t scale, bool signal = true);
-		void increment_value(bool signal = true);
-		void decrement_value(bool signal = true);
+		void set_value(int32_t new_value);
+		void set_scaled_value(fixed_point_t new_scaled_value);
+		fixed_point_t get_max_value_scaled() const;
+		void increment_value();
+		void decrement_value();
 
 		float get_value_as_ratio() const;
-		void set_value_as_ratio(float new_ratio, bool signal = true);
+		void set_value_as_ratio(float new_ratio);
 
 		fixed_point_t get_value_scaled_fp() const;
 		float get_value_scaled() const;
 
-		godot::Error set_range_limits(
-			int32_t new_range_limit_min, int32_t new_range_limit_max, bool signal = true
+		void set_step_count(const int32_t new_step_count);
+		void set_scale(
+			const fixed_point_t new_offset,
+			const int32_t new_scale_numerator,
+			const int32_t new_scale_denominator
 		);
-		godot::Error set_range_limits_and_value(
-			int32_t new_range_limit_min, int32_t new_range_limit_max, int32_t new_value, bool signal = true
+		void set_range_limits(
+			const std::optional<int32_t> new_lower_range_limit,
+			const std::optional<int32_t> new_upper_range_limit
 		);
-		godot::Error set_limits(int32_t new_min_value, int32_t new_max_value, bool signal = true);
-
-		godot::Error set_range_limits_and_value_fp(
-			fixed_point_t new_range_limit_min, fixed_point_t new_range_limit_max, fixed_point_t new_value, bool signal = true
+		void set_range_limits_fp(
+			const std::optional<fixed_point_t> new_lower_range_limit,
+			const std::optional<fixed_point_t> new_upper_range_limit
 		);
-		godot::Error set_range_limits_and_value_from_slider_value(
-			SliderValue const& slider_value, int32_t scale, bool signal = true
+		void set_range_limits_and_value_from_slider_value(
+			SliderValue const& slider_value
 		);
-		godot::Error set_step_size_and_limits_fp(fixed_point_t new_step_size, int32_t new_min_value, int32_t new_max_value);
 
 		/* Override the main dimension of gui_scollbar's size with the specified length. */
 		void set_length_override(real_t new_length_override);

--- a/extension/src/openvic-extension/singletons/TradeMenu.cpp
+++ b/extension/src/openvic-extension/singletons/TradeMenu.cpp
@@ -166,17 +166,11 @@ Dictionary MenuSingleton::get_trade_menu_trade_details_info(
 	ret[trade_detail_is_automated_key] = good_data.is_automated;
 	ret[trade_detail_is_selling_key] = good_data.is_selling;
 	if (stockpile_cutoff_slider != nullptr) {
-		int32_t index = 0;
-
-		while (index < stockpile_cutoff_slider->get_max_value() && calculate_trade_menu_stockpile_cutoff_amount_fp(
-			index * stockpile_cutoff_slider->get_step_size()
-		) < good_data.stockpile_cutoff) {
-			++index;
-		}
-
-		// TODO - use a more efficient algorithm, e.g. some kind of binary search
-
-		stockpile_cutoff_slider->set_value(index, false);
+		const int32_t index = calculate_slider_value_from_trade_menu_stockpile_cutoff(
+			good_data.stockpile_cutoff,
+			stockpile_cutoff_slider->get_max_value_scaled()
+		);
+		stockpile_cutoff_slider->set_scaled_value(index);
 	}
 	ret[trade_detail_slider_amount_key] = good_data.stockpile_cutoff.to_float();
 	ret[trade_detail_government_needs_key] = good_data.government_needs.to_float();

--- a/game/src/UI/Session/PopulationMenu.gd
+++ b/game/src/UI/Session/PopulationMenu.gd
@@ -530,10 +530,10 @@ func _update_pop_list() -> void:
 	if _pop_list_scrollbar:
 		var max_scroll_index : int = MenuSingleton.get_population_menu_pop_row_count() - _pop_list_rows.size()
 		if max_scroll_index > 0:
-			_pop_list_scrollbar.set_limits(0, max_scroll_index)
+			_pop_list_scrollbar.set_step_count(max_scroll_index)
 			_pop_list_scrollbar.show()
 		else:
-			_pop_list_scrollbar.set_limits(0, 0)
+			_pop_list_scrollbar.set_step_count(0)
 			_pop_list_scrollbar.hide()
 
 	var pop_rows = MenuSingleton.get_population_menu_pop_rows(_pop_list_scroll_index, _pop_list_rows.size())


### PR DESCRIPTION
- Supersedes #507 

The scrollbar was bugged and difficult to work with.
Having to specify a scale when adjusting range limits is redundant.
Min max values and step size also are redundant.

All we need is a scrollbar that starts at 0 and increments by 1 to a max (step_count) combined with a fixed_point_t offset and scale.
I implemented the scale using numerator/denominator as neither floats nor fixed_point_t can store 1/100 accurately.

Also setting range limits on scrollbars that are not range limited no longer results in errors if the range limit are 0 to step_count. This allows us to set from slider value.

Per @Spartan322 's suggestion `godot::Error` returns are minimised and method calls with invalid data are merely logged and ignored. Also signals are blocked instead of passing a bool to indicate whether to signal or not. Blocking signals now also blocks c++ signal.

The trade menu's stockpile slider logic is optimised and the special case of min > max from [SliderValue.hpp](https://github.com/OpenVicProject/OpenVic-Simulation/blob/master/src/openvic-simulation/types/SliderValue.hpp) is now supported in the UI.