### PR TITLE
Reactive budget menu

### DIFF
--- a/extension/doc_classes/MenuSingleton.xml
+++ b/extension/doc_classes/MenuSingleton.xml
@@ -186,6 +186,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="link_budget_menu_to_cpp">
+			<return type="void" />
+			<param index="0" name="godot_budget_menu" type="GUINode" />
+			<description>
+			</description>
+		</method>
 		<method name="population_menu_deselect_all_pop_filters">
 			<return type="int" enum="Error" />
 			<description>

--- a/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
@@ -1,0 +1,35 @@
+#include "AdministrationBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+AdministrationBudget::AdministrationBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/exp_1_slider",
+		"./country_budget/exp_val_1"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * country.get_projected_administration_spending_unscaled_by_slider();
+}
+SliderValue const& AdministrationBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_administration_spending_slider_value();
+}
+void AdministrationBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_administration_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/AdministrationBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/AdministrationBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct AdministrationBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		AdministrationBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/ArmyStockpileBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/ArmyStockpileBudget.cpp
@@ -1,0 +1,34 @@
+#include "ArmyStockpileBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+ArmyStockpileBudget::ArmyStockpileBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/land_stockpile_slider"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t ArmyStockpileBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * 1; //TODO connect with sim once sim has this
+}
+SliderValue const& ArmyStockpileBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_army_spending_slider_value();
+}
+void ArmyStockpileBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_national_stockpile_army_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/ArmyStockpileBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/ArmyStockpileBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct ArmyStockpileBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		ArmyStockpileBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/BudgetComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/BudgetComponent.cpp
@@ -1,0 +1,16 @@
+#include "BudgetComponent.hpp"
+
+using namespace OpenVic;
+
+fixed_point_t BudgetComponent::get_balance() const {
+	return balance;
+}
+
+void BudgetComponent::set_balance(const fixed_point_t new_balance) {
+	if (balance == new_balance) {;
+		return;
+	}
+
+	balance = new_balance;
+	balance_changed();
+}

--- a/extension/src/openvic-extension/components/budget/BudgetComponent.hpp
+++ b/extension/src/openvic-extension/components/budget/BudgetComponent.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
+#include <openvic-simulation/types/Signal.hpp>
+
+namespace OpenVic {
+	struct CountryInstance;
+
+	struct BudgetComponent {
+	private:
+		fixed_point_t balance = 0;
+
+	protected:
+		void set_balance(const fixed_point_t balance);
+
+	public:
+		signal_property<BudgetComponent> balance_changed;
+		fixed_point_t get_balance() const;
+		virtual void full_update(CountryInstance const& country) = 0;
+	};
+}

--- a/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
@@ -1,0 +1,177 @@
+#include "BudgetMenu.hpp"
+
+#include <godot_cpp/core/error_macros.hpp>
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUINode.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+BudgetMenu::BudgetMenu(GUINode const& parent, utility::forwardable_span<const Strata> strata_keys)
+	: administrative_efficiency_label{parent.get_gui_label_from_nodepath("./country_budget/admin_efficiency")},
+	gold_income_label{parent.get_gui_label_from_nodepath("./country_budget/gold_inc")},
+	projected_balance_label{parent.get_gui_label_from_nodepath("./country_budget/balance")},
+	projected_expenses_label{parent.get_gui_label_from_nodepath("./country_budget/total_exp")},
+	projected_income_label{parent.get_gui_label_from_nodepath("./country_budget/total_inc")},
+	administration_budget{parent},
+	education_budget{parent},
+	military_budget{parent},
+	national_stockpile_budget{parent},
+	social_budget{parent},
+	tariff_budget{parent}
+	{
+		ERR_FAIL_NULL(administrative_efficiency_label);
+		ERR_FAIL_NULL(gold_income_label);
+		ERR_FAIL_NULL(projected_balance_label);
+		ERR_FAIL_NULL(projected_expenses_label);
+		ERR_FAIL_NULL(projected_income_label);
+		tax_budgets.reserve(strata_keys.size());
+		connections.reserve(6 + strata_keys.size());
+		connections.push_back(administration_budget.balance_changed.connect(&BudgetMenu::update_projected_expenses_and_balance, this));
+		connections.push_back(education_budget.balance_changed.connect(&BudgetMenu::update_projected_expenses_and_balance, this));
+		connections.push_back(military_budget.balance_changed.connect(&BudgetMenu::update_projected_expenses_and_balance, this));
+		connections.push_back(national_stockpile_budget.balance_changed.connect(&BudgetMenu::update_projected_expenses_and_balance, this));
+		connections.push_back(social_budget.balance_changed.connect(&BudgetMenu::update_projected_expenses_and_balance, this));
+		connections.push_back(tariff_budget.balance_changed.connect(&BudgetMenu::update_all_projections, this));
+		for (Strata const& strata : strata_keys) {
+			StrataTaxBudget& strata_tax_budget = tax_budgets.emplace_back(parent, strata);
+			connections.push_back(strata_tax_budget.balance_changed.connect(&BudgetMenu::update_projected_income_and_balance, this));
+		}
+	}
+
+void BudgetMenu::update_projected_balance() {
+	ERR_FAIL_NULL(projected_balance_label);
+	CountryInstance const* const country_ptr = PlayerSingleton::get_singleton()->get_player_country();
+	ERR_FAIL_NULL(country_ptr);
+	CountryInstance const& country = *country_ptr;
+	fixed_point_t projected_balance = country.get_gold_income()
+		+ administration_budget.get_balance()
+		+ education_budget.get_balance()
+		+ military_budget.get_balance()
+		+ national_stockpile_budget.get_balance()
+		+ social_budget.get_balance()
+		+ tariff_budget.get_balance();
+
+	for (StrataTaxBudget const& strata_tax_budget : tax_budgets) {
+		projected_balance += strata_tax_budget.get_balance();
+	}
+
+	projected_balance_label->set_text(
+		godot::vformat(
+			godot::String::utf8("§%s%s"),
+			projected_balance > 0
+				? "G+"
+				: projected_balance < 0
+					? "R"
+					: "Y+",
+			Utilities::cash_to_string_dp_dynamic(projected_balance)
+		)
+	);
+}
+
+void BudgetMenu::update_projected_expenses() {
+	ERR_FAIL_NULL(projected_expenses_label);
+	fixed_point_t projected_expenses =  administration_budget.get_balance()
+		+ education_budget.get_balance()
+		+ military_budget.get_balance()
+		+ national_stockpile_budget.get_balance()
+		+ social_budget.get_balance();
+		//TODO: + import subsidies?
+		//TODO: + factory subsidies
+		//TODO: + interest
+		//TODO: + diplomatic costs
+
+	const fixed_point_t tariff_balance = tariff_budget.get_balance();
+	if (tariff_balance < fixed_point_t::_0) {
+		projected_expenses += tariff_balance;
+	}
+
+	projected_expenses_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(-projected_expenses)
+	);
+}
+
+void BudgetMenu::update_projected_expenses_and_balance() {
+	update_projected_expenses();
+	update_projected_balance();
+}
+
+void BudgetMenu::update_projected_income() {
+	ERR_FAIL_NULL(projected_income_label);
+	CountryInstance const* const country_ptr = PlayerSingleton::get_singleton()->get_player_country();
+	ERR_FAIL_NULL(country_ptr);
+	CountryInstance const& country = *country_ptr;
+	fixed_point_t projected_income = country.get_gold_income();
+	for (StrataTaxBudget const& strata_tax_budget : tax_budgets) {
+		projected_income += strata_tax_budget.get_balance();
+	}
+	//TODO: + stockpile sales
+	//TODO: + diplomatic income
+
+	const fixed_point_t tariff_balance = tariff_budget.get_balance();
+	if (tariff_balance > fixed_point_t::_0) {
+		projected_income += tariff_balance;
+	}
+
+	projected_income_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(projected_income)
+	);
+}
+
+void BudgetMenu::update_projected_income_and_balance() {
+	update_projected_income();
+	update_projected_balance();
+}
+
+void BudgetMenu::update_all_projections() {
+	update_projected_balance();
+	update_projected_expenses();
+	update_projected_income();
+}
+
+#define DO_FOR_ALL_COMPONENTS(F) \
+	administration_budget.F; \
+	education_budget.F; \
+	military_budget.F; \
+	national_stockpile_budget.F; \
+	social_budget.F; \
+	tariff_budget.F; \
+	for (StrataTaxBudget& strata_tax_budget : tax_budgets) { \
+		strata_tax_budget.F; \
+	}
+
+void BudgetMenu::update() {
+	ERR_FAIL_NULL(administrative_efficiency_label);
+	ERR_FAIL_NULL(gold_income_label);
+	CountryInstance const* const country_ptr = PlayerSingleton::get_singleton()->get_player_country();
+	ERR_FAIL_NULL(country_ptr);
+	CountryInstance const& country = *country_ptr;
+
+	//this will trigger a lot of signals we should ignore
+	for (connection& c : connections) {
+		c.block();
+	};
+	DO_FOR_ALL_COMPONENTS(full_update(country))
+	for (connection& c : connections) {
+		c.unblock();
+	};
+	update_all_projections();
+
+	administrative_efficiency_label->set_text(
+		godot::vformat(
+			"%s%%",
+			Utilities::fixed_point_to_string_dp(
+				100 * country.get_administrative_efficiency(),
+				1
+			)
+		)
+	);
+	const fixed_point_t gold_income = country.get_gold_income();
+	gold_income_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(gold_income)
+	);
+}
+
+#undef DO_FOR_ALL_COMPONENTS

--- a/extension/src/openvic-extension/components/budget/BudgetMenu.hpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <vector>
+
+#include <godot_cpp/classes/object.hpp>
+
+#include <openvic-simulation/types/Signal.hpp>
+#include <openvic-simulation/utility/ForwardableSpan.hpp>
+
+#include "openvic-extension/components/budget/AdministrationBudget.hpp"
+#include "openvic-extension/components/budget/EducationBudget.hpp"
+#include "openvic-extension/components/budget/MilitaryBudget.hpp"
+#include "openvic-extension/components/budget/NationalStockpileBudget.hpp"
+#include "openvic-extension/components/budget/SocialBudget.hpp"
+#include "openvic-extension/components/budget/StrataTaxBudget.hpp"
+#include "openvic-extension/components/budget/TariffBudget.hpp"
+
+namespace OpenVic {
+	struct CountryInstance;
+	struct GUINode;
+	struct GUILabel;
+
+	struct BudgetMenu {
+	private:
+		std::vector<connection> connections;
+		GUILabel* administrative_efficiency_label { nullptr };
+		GUILabel* gold_income_label { nullptr };
+		GUILabel* projected_balance_label { nullptr };
+		GUILabel* projected_expenses_label { nullptr };
+		GUILabel* projected_income_label { nullptr };
+		AdministrationBudget administration_budget;
+		EducationBudget education_budget;
+		MilitaryBudget military_budget;
+		NationalStockpileBudget national_stockpile_budget;
+		SocialBudget social_budget;
+		TariffBudget tariff_budget;
+		std::vector<StrataTaxBudget> tax_budgets;
+
+		void update_projected_balance();
+		void update_projected_expenses();
+		void update_projected_expenses_and_balance();
+		void update_projected_income();
+		void update_projected_income_and_balance();
+		void update_all_projections();
+	public:
+		BudgetMenu(GUINode const& parent, utility::forwardable_span<const Strata> strata_keys);
+		void update();
+	};
+}

--- a/extension/src/openvic-extension/components/budget/ConstructionStockpileBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/ConstructionStockpileBudget.cpp
@@ -1,0 +1,34 @@
+#include "ConstructionStockpileBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+ConstructionStockpileBudget::ConstructionStockpileBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/projects_stockpile_slider"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t ConstructionStockpileBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * 3; //TODO connect with sim once sim has this
+}
+SliderValue const& ConstructionStockpileBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_construction_spending_slider_value();
+}
+void ConstructionStockpileBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_national_stockpile_construction_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/ConstructionStockpileBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/ConstructionStockpileBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct ConstructionStockpileBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		ConstructionStockpileBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/EducationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/EducationBudget.cpp
@@ -1,0 +1,35 @@
+#include "EducationBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+EducationBudget::EducationBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/exp_0_slider",
+		"./country_budget/exp_val_0"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t EducationBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * country.get_projected_education_spending_unscaled_by_slider();
+}
+SliderValue const& EducationBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_education_spending_slider_value();
+}
+void EducationBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_education_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/EducationBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/EducationBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct EducationBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		EducationBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
@@ -1,0 +1,35 @@
+#include "MilitaryBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+MilitaryBudget::MilitaryBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/exp_3_slider",
+		"./country_budget/exp_val_3"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t MilitaryBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * country.get_projected_military_spending_unscaled_by_slider();
+}
+SliderValue const& MilitaryBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_military_spending_slider_value();
+}
+void MilitaryBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_military_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/MilitaryBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/MilitaryBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct MilitaryBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		MilitaryBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/NationalStockpileBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/NationalStockpileBudget.cpp
@@ -1,0 +1,74 @@
+#include "NationalStockpileBudget.hpp"
+
+#include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/variant/callable_method_pointer.hpp>
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
+
+#include "openvic-extension/classes/GUILabel.hpp"
+#include "openvic-extension/classes/GUINode.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+NationalStockpileBudget::NationalStockpileBudget(GUINode const& parent):
+	military_costs_label{parent.get_gui_label_from_nodepath("./country_budget/mil_cost_val")},
+	todays_actual_stockpile_spending_label{parent.get_gui_label_from_nodepath("./country_budget/nat_stock_val")},
+	overseas_costs_label{parent.get_gui_label_from_nodepath("./country_budget/overseas_cost_val")},
+	value_label{parent.get_gui_label_from_nodepath("./country_budget/nat_stock_est")},
+	army_stockpile_budget{parent},
+	navy_stockpile_budget{parent},
+	construction_stockpile_budget{parent}
+{
+	ERR_FAIL_NULL(military_costs_label);
+	ERR_FAIL_NULL(todays_actual_stockpile_spending_label);
+	ERR_FAIL_NULL(overseas_costs_label);
+	ERR_FAIL_NULL(value_label);
+	connections[0] = army_stockpile_budget.balance_changed.connect(&NationalStockpileBudget::on_slider_value_changed, this);
+	connections[1] = navy_stockpile_budget.balance_changed.connect(&NationalStockpileBudget::on_slider_value_changed, this);
+	connections[2] = construction_stockpile_budget.balance_changed.connect(&NationalStockpileBudget::on_slider_value_changed, this);
+}
+
+void NationalStockpileBudget::on_slider_value_changed() {
+	CountryInstance const* const country_ptr = PlayerSingleton::get_singleton()->get_player_country();
+	ERR_FAIL_NULL(country_ptr);
+	update_labels(*country_ptr);
+}
+
+void NationalStockpileBudget::full_update(CountryInstance const& country) {\
+	for (connection& c : connections) {
+		c.block();
+	};
+	army_stockpile_budget.full_update(country);
+	navy_stockpile_budget.full_update(country);
+	construction_stockpile_budget.full_update(country);
+	for (connection& c : connections) {
+		c.unblock();
+	};
+
+	update_labels(country);
+}
+
+void NationalStockpileBudget::update_labels(CountryInstance const& country) {
+	ERR_FAIL_NULL(value_label);
+	const fixed_point_t military_balance = army_stockpile_budget.get_balance()
+		+ navy_stockpile_budget.get_balance();
+	const fixed_point_t balance = military_balance
+		+ construction_stockpile_budget.get_balance();
+
+	military_costs_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(-military_balance)
+	);
+	todays_actual_stockpile_spending_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(2) //TODO
+	);
+	overseas_costs_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(3) //TODO
+	);
+	value_label->set_text(
+		Utilities::cash_to_string_dp_dynamic(-balance)
+	);
+
+	set_balance(balance);
+}

--- a/extension/src/openvic-extension/components/budget/NationalStockpileBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/NationalStockpileBudget.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "openvic-extension/components/budget/BudgetComponent.hpp"
+#include "openvic-extension/components/budget/ArmyStockpileBudget.hpp"
+#include "openvic-extension/components/budget/ConstructionStockpileBudget.hpp"
+#include "openvic-extension/components/budget/NavyStockpileBudget.hpp"
+
+namespace OpenVic {
+	struct GUILabel;
+	struct GUINode;
+	struct GUIScrollbar;
+
+	struct NationalStockpileBudget : public BudgetComponent {
+	private:
+		connection connections[3];
+		GUILabel* military_costs_label { nullptr };
+		GUILabel* todays_actual_stockpile_spending_label { nullptr };
+		GUILabel* overseas_costs_label { nullptr };
+		GUILabel* value_label { nullptr };
+		ArmyStockpileBudget army_stockpile_budget;
+		NavyStockpileBudget navy_stockpile_budget;
+		ConstructionStockpileBudget construction_stockpile_budget;
+		void on_slider_value_changed();
+		void update_labels(CountryInstance const& country);
+
+	public:
+		NationalStockpileBudget(GUINode const& parent);
+		void full_update(CountryInstance const& country);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/NavyStockpileBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/NavyStockpileBudget.cpp
@@ -1,0 +1,34 @@
+#include "NavyStockpileBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+NavyStockpileBudget::NavyStockpileBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/naval_stockpile_slider"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t NavyStockpileBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * 2; //TODO connect with sim once sim has this
+}
+SliderValue const& NavyStockpileBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_navy_spending_slider_value();
+}
+void NavyStockpileBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_national_stockpile_navy_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/NavyStockpileBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/NavyStockpileBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct NavyStockpileBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		NavyStockpileBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/SliderBudgetComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/SliderBudgetComponent.cpp
@@ -1,0 +1,84 @@
+#include "SliderBudgetComponent.hpp"
+
+#include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/variant/callable_method_pointer.hpp>
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUILabel.hpp"
+#include "openvic-extension/classes/GUINode.hpp"
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/components/budget/BudgetComponent.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+SliderBudgetComponent::SliderBudgetComponent(
+	GUINode const& parent,
+	const BudgetType new_budget_type,
+	godot::NodePath const& slider_path,
+	godot::NodePath const& budget_label_path,
+	godot::NodePath const& percent_label_path
+):
+	budget_type{new_budget_type},
+	budget_label{
+		budget_label_path.is_empty()
+		? nullptr
+		: parent.get_gui_label_from_nodepath(budget_label_path)
+	},
+	percent_label{
+		percent_label_path.is_empty()
+		? nullptr
+		: parent.get_gui_label_from_nodepath(percent_label_path)
+	},
+	slider{*parent.get_gui_scrollbar_from_nodepath(slider_path)}
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(0, 1, 100);
+	slider.set_block_signals(false);
+	slider.value_changed.connect(&SliderBudgetComponent::_on_slider_value_changed, this);
+}
+
+void SliderBudgetComponent::_on_slider_value_changed() {
+	const fixed_point_t scaled_value = slider.get_value_scaled_fp();
+	on_slider_value_changed(scaled_value);
+	CountryInstance const* const country_ptr = PlayerSingleton::get_singleton()->get_player_country();
+	ERR_FAIL_NULL(country_ptr);
+	update_labels(*country_ptr, scaled_value);
+}
+
+void SliderBudgetComponent::full_update(CountryInstance const& country) {
+	SliderValue const& slider_value = get_slider_value(country);
+
+	slider.set_block_signals(true);
+	slider.set_range_limits_and_value_from_slider_value(slider_value);
+	slider.set_block_signals(false);
+	update_labels(country, slider_value.get_value());
+}
+
+void SliderBudgetComponent::update_labels(CountryInstance const& country, const fixed_point_t scaled_value) {
+	const fixed_point_t budget = calculate_budget_and_update_custom(country, scaled_value);
+	if (budget_label != nullptr) {
+		budget_label->set_text(
+			Utilities::cash_to_string_dp_dynamic(budget)
+		);
+	};
+
+	if (percent_label != nullptr) {
+		percent_label->set_text(
+			godot::vformat(
+				"%s%%",
+				Utilities::float_to_string_dp(
+					(100 * scaled_value).to_float(),
+					1
+				)
+			)
+		);
+	}
+
+	const fixed_point_t balance = budget_type == EXPENSES
+		? -budget 
+		: budget;
+	set_balance(balance);
+}

--- a/extension/src/openvic-extension/components/budget/SliderBudgetComponent.hpp
+++ b/extension/src/openvic-extension/components/budget/SliderBudgetComponent.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <godot_cpp/variant/node_path.hpp>
+
+#include "openvic-extension/components/budget/BudgetComponent.hpp"
+
+namespace OpenVic {
+	struct CountryInstance;
+	struct GUILabel;
+	struct GUINode;
+	struct GUIScrollbar;
+	struct SliderValue;
+
+	enum BudgetType {
+		BALANCE,
+		EXPENSES
+	};
+
+	struct SliderBudgetComponent : public BudgetComponent {
+	private:
+		//multiplies balance by -1 for balance_label
+		const BudgetType budget_type;
+		GUILabel* const budget_label;
+		GUILabel* const percent_label;
+		void _on_slider_value_changed();
+		void update_labels(CountryInstance const& country, const fixed_point_t scaled_value);
+	protected:
+		GUIScrollbar& slider;
+		virtual fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		) = 0;
+		virtual SliderValue const& get_slider_value(CountryInstance const& country) const = 0;
+		virtual void on_slider_value_changed(const fixed_point_t scaled_value) = 0;
+
+	public:
+		SliderBudgetComponent(
+			GUINode const& parent,
+			const BudgetType new_budget_type,
+			godot::NodePath const& slider_path,
+			godot::NodePath const& budget_label_path = {},
+			godot::NodePath const& percent_label_path = {}
+		);
+		void full_update(CountryInstance const& country);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/SocialBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/SocialBudget.cpp
@@ -1,0 +1,48 @@
+#include "SocialBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
+
+#include "openvic-extension/classes/GUILabel.hpp"
+#include "openvic-extension/classes/GUINode.hpp"
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+SocialBudget::SocialBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		EXPENSES,
+		"./country_budget/exp_2_slider",
+		"./country_budget/exp_val_2"
+	),
+	pensions_label{*parent.get_gui_label_from_nodepath("./country_budget/exp_val_2")}, //TODO figure out how to get their path
+	unemployment_subsidies_label{*parent.get_gui_label_from_nodepath("./country_budget/exp_val_2")}
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t SocialBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	const fixed_point_t pensions = scaled_value * country.get_projected_pensions_spending_unscaled_by_slider();
+	pensions_label.set_text(
+		Utilities::cash_to_string_dp_dynamic(pensions)
+	);
+	const fixed_point_t unemployment_subsidies = scaled_value * country.get_projected_unemployment_subsidies_spending_unscaled_by_slider();
+	unemployment_subsidies_label.set_text(
+		Utilities::cash_to_string_dp_dynamic(unemployment_subsidies)
+	);
+	return pensions + unemployment_subsidies;
+}
+SliderValue const& SocialBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_social_spending_slider_value();
+}
+void SocialBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_social_spending_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/SocialBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/SocialBudget.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct SocialBudget : public SliderBudgetComponent {
+	private:
+		GUILabel& pensions_label;
+		GUILabel& unemployment_subsidies_label;
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		SocialBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
@@ -1,0 +1,40 @@
+#include "StrataTaxBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+StrataTaxBudget::StrataTaxBudget(GUINode const& parent, Strata const& new_strata):
+	SliderBudgetComponent(
+		parent,
+		BALANCE,
+		godot::vformat("./country_budget/tax_%s_slider", static_cast<uint64_t>(new_strata.get_index())),
+		godot::vformat("./country_budget/tax_%s_inc", static_cast<uint64_t>(new_strata.get_index()))
+	),
+	strata{new_strata}
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(100);
+	slider.set_scale(fixed_point_t::_0, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t StrataTaxBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * country.get_strata_taxable_income(strata);
+}
+SliderValue const& StrataTaxBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_tax_rate_slider_value_by_strata()[strata];
+}
+void StrataTaxBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_strata_tax_rate_slider_value(
+		strata,
+		scaled_value
+	);
+}

--- a/extension/src/openvic-extension/components/budget/StrataTaxBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/StrataTaxBudget.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <openvic-simulation/pop/PopType.hpp>
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct StrataTaxBudget : public SliderBudgetComponent {
+	private:
+		Strata const& strata;
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		StrataTaxBudget(GUINode const& parent, Strata const& new_strata);
+		StrataTaxBudget(StrataTaxBudget&&) = default;
+	};
+}

--- a/extension/src/openvic-extension/components/budget/TariffBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/TariffBudget.cpp
@@ -1,0 +1,37 @@
+#include "TariffBudget.hpp"
+
+#include <openvic-simulation/country/CountryInstance.hpp>
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
+
+#include "openvic-extension/classes/GUIScrollbar.hpp"
+#include "openvic-extension/singletons/PlayerSingleton.hpp"
+
+using namespace OpenVic;
+
+TariffBudget::TariffBudget(GUINode const& parent):
+	SliderBudgetComponent(
+		parent,
+		BALANCE,
+		"./country_budget/tariff_slider",
+		"./country_budget/tariff_val",
+		"./country_budget/tariffs_percent"
+	)
+{
+	slider.set_block_signals(true);
+	slider.set_step_count(200);
+	slider.set_scale(fixed_point_t::minus_one, 1, 100);
+	slider.set_block_signals(false);
+}
+
+fixed_point_t TariffBudget::calculate_budget_and_update_custom(
+	CountryInstance const& country,
+	const fixed_point_t scaled_value
+) {
+	return scaled_value * country.get_yesterdays_import_value();
+}
+SliderValue const& TariffBudget::get_slider_value(CountryInstance const& country) const {
+	return country.get_tariff_rate_slider_value();
+}
+void TariffBudget::on_slider_value_changed(const fixed_point_t scaled_value) {
+	PlayerSingleton::get_singleton()->set_tariff_rate_slider_value(scaled_value);
+}

--- a/extension/src/openvic-extension/components/budget/TariffBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/TariffBudget.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "openvic-extension/components/budget/SliderBudgetComponent.hpp"
+
+namespace OpenVic {
+	struct TariffBudget : public SliderBudgetComponent {
+	private:
+		fixed_point_t calculate_budget_and_update_custom(
+			CountryInstance const& country,
+			const fixed_point_t scaled_value
+		);
+		SliderValue const& get_slider_value(CountryInstance const& country) const;
+		void on_slider_value_changed(const fixed_point_t scaled_value);
+
+	public:
+		TariffBudget(GUINode const& parent);
+	};
+}

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -80,6 +80,7 @@ GameSingleton* GameSingleton::get_singleton() {
 void GameSingleton::_on_gamestate_updated() {
 	_update_colour_image();
 	emit_signal(_signal_gamestate_updated());
+	gamestate_updated();
 }
 
 /* REQUIREMENTS:

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -36,16 +36,12 @@ namespace OpenVic {
 		godot::Error _load_terrain_variants();
 		godot::Error _load_flag_sheet();
 
-	public:
-		/* Generate the province_colour_texture from the current mapmode. */
-		godot::Error _update_colour_image();
-		void _on_gamestate_updated();
-
 	protected:
 		static void _bind_methods();
 
 	public:
 		static GameSingleton* get_singleton();
+		signal_property<GameSingleton> gamestate_updated;
 
 		GameSingleton();
 		~GameSingleton();
@@ -129,5 +125,8 @@ namespace OpenVic {
 		bool is_parchment_mapmode_allowed() const;
 
 		godot::Error update_clock();
+		/* Generate the province_colour_texture from the current mapmode. */
+		godot::Error _update_colour_image();
+		void _on_gamestate_updated();
 	};
 }

--- a/extension/src/openvic-extension/singletons/MenuSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <variant>
 
 #include <godot_cpp/classes/control.hpp>
@@ -13,6 +14,7 @@
 #include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
 
 #include "openvic-extension/classes/GFXPieChartTexture.hpp"
+#include "openvic-extension/components/budget/BudgetMenu.hpp"
 
 namespace OpenVic {
 	struct CountryInstance;
@@ -117,6 +119,7 @@ namespace OpenVic {
 		};
 
 	private:
+		std::unique_ptr<BudgetMenu> budget_menu { nullptr };
 		population_menu_t population_menu;
 		search_panel_t search_panel;
 
@@ -280,6 +283,9 @@ namespace OpenVic {
 		godot::Dictionary make_unit_group_dict(UnitInstanceGroupBranched<Branch> const& unit_group);
 		godot::Dictionary make_in_progress_unit_dict() const;
 		godot::Dictionary get_military_menu_info();
+
+		/* BUDGET MENU */
+		void link_budget_menu_to_cpp(GUINode const* const godot_budget_menu);
 
 		/* Find/Search Panel */
 		// TODO - update on country government type change and state creation/destruction

--- a/extension/src/openvic-extension/singletons/PlayerSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/PlayerSingleton.cpp
@@ -211,6 +211,37 @@ void PlayerSingleton::expand_selected_province_building(int32_t building_index) 
 }
 
 // Budget
+#define SET_SLIDER_GAME_ACTION(value_name, game_action_name) \
+void PlayerSingleton::set_##value_name##_slider_value(fixed_point_t const value) const { \
+	if (player_country == nullptr) { \
+		return; \
+	} \
+	GameSingleton::get_singleton()->get_instance_manager()->queue_game_action( \
+		game_action_type_t::GAME_ACTION_SET_##game_action_name, \
+		std::pair<uint64_t, fixed_point_t> { player_country->get_index(), value } \
+	); \
+}
+
+SET_SLIDER_GAME_ACTION(administration_spending, ADMINISTRATION_SPENDING)
+SET_SLIDER_GAME_ACTION(education_spending, EDUCATION_SPENDING)
+SET_SLIDER_GAME_ACTION(military_spending, MILITARY_SPENDING)
+SET_SLIDER_GAME_ACTION(social_spending, SOCIAL_SPENDING)
+SET_SLIDER_GAME_ACTION(national_stockpile_army_spending, ARMY_SPENDING)
+SET_SLIDER_GAME_ACTION(national_stockpile_navy_spending, NAVY_SPENDING)
+SET_SLIDER_GAME_ACTION(national_stockpile_construction_spending, CONSTRUCTION_SPENDING)
+SET_SLIDER_GAME_ACTION(tariff_rate, TARIFF_RATE)
+
+#undef SET_SLIDER_GAME_ACTION
+
+void PlayerSingleton::set_strata_tax_rate_slider_value(Strata const& strata, fixed_point_t const value) const {
+	if (player_country == nullptr) {
+		return;
+	}
+	GameSingleton::get_singleton()->get_instance_manager()->queue_game_action(
+		game_action_type_t::GAME_ACTION_SET_STRATA_TAX,
+		std::tuple<uint64_t, uint64_t, fixed_point_t> { player_country->get_index(), strata.get_index(), value }
+	);
+}
 
 // Technology
 

--- a/extension/src/openvic-extension/singletons/PlayerSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/PlayerSingleton.hpp
@@ -2,6 +2,8 @@
 
 #include <godot_cpp/classes/object.hpp>
 
+#include <openvic-simulation/pop/PopType.hpp>
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
 #include <openvic-simulation/utility/Getters.hpp>
 
 namespace OpenVic {
@@ -48,6 +50,15 @@ namespace OpenVic {
 		void expand_selected_province_building(int32_t building_index) const;
 
 		// Budget
+		void set_administration_spending_slider_value(fixed_point_t const value) const;
+		void set_education_spending_slider_value(fixed_point_t const value) const;
+		void set_military_spending_slider_value(fixed_point_t const value) const;
+		void set_social_spending_slider_value(fixed_point_t const value) const;
+		void set_national_stockpile_army_spending_slider_value(fixed_point_t const value) const;
+		void set_national_stockpile_navy_spending_slider_value(fixed_point_t const value) const;
+		void set_national_stockpile_construction_spending_slider_value(fixed_point_t const value) const;
+		void set_strata_tax_rate_slider_value(Strata const& strata, fixed_point_t const value) const;
+		void set_tariff_rate_slider_value(fixed_point_t const value) const;
 
 		// Technology
 

--- a/extension/src/openvic-extension/utility/Utilities.cpp
+++ b/extension/src/openvic-extension/utility/Utilities.cpp
@@ -106,6 +106,15 @@ String Utilities::float_to_string_dp_dynamic(float val) {
 	return float_to_string_dp(val, abs_val < 2.0f ? 3 : abs_val < 10.0f ? 2 : 1);
 }
 
+String Utilities::cash_to_string_dp_dynamic(fixed_point_t val) {
+	return godot::vformat(
+		String::utf8("%s¤"),
+		Utilities::float_to_string_dp_dynamic(
+			val.to_float()
+		)
+	);
+}
+
 String Utilities::date_to_string(Date date) {
 	static const String date_template_string = String { "%d" } + Date::SEPARATOR_CHARACTER + "%d" +
 		Date::SEPARATOR_CHARACTER + "%d";

--- a/extension/src/openvic-extension/utility/Utilities.hpp
+++ b/extension/src/openvic-extension/utility/Utilities.hpp
@@ -38,6 +38,7 @@ namespace OpenVic::Utilities {
 
 	// 3dp if abs(val) < 2 else 2dp if abs(val) < 10 else 1dp
 	godot::String float_to_string_dp_dynamic(float val);
+	godot::String cash_to_string_dp_dynamic(fixed_point_t val);
 
 	constexpr real_t to_real_t(std::floating_point auto val) {
 		return static_cast<real_t>(val);

--- a/game/src/UI/Session/BudgetMenu.gd
+++ b/game/src/UI/Session/BudgetMenu.gd
@@ -3,13 +3,6 @@ extends GUINode
 var _active : bool = false
 var _incVal : int = 0 # incremental value to see the UI update, replace later by real values
 
-# income
-var _lower_class_label : GUILabel
-var _middle_class_label : GUILabel
-var _upper_class_label : GUILabel
-var _gold_label : GUILabel
-var _total_inc_label : GUILabel
-
 # debt
 var _national_bank_label : GUILabel
 var _total_funds_label : GUILabel
@@ -17,35 +10,21 @@ var _debt_val_label : GUILabel
 var _interest_val_label : GUILabel
 
 # costs
-var _nat_stock_val_label : GUILabel
-var _nat_stock_exp_label : GUILabel
-var _mil_cost_val_label : GUILabel
 var _overseas_cost_val_label : GUILabel
 var _ind_sub_val_label : GUILabel
-var _admin_efficiency_label : GUILabel
-var _education_exp_label : GUILabel
-var _administration_exp_label : GUILabel
-var _social_exp_label : GUILabel
-var _military_exp_label : GUILabel
-var _total_exp_label : GUILabel
 
 # others
-var _tariffs_percent_label : GUILabel
-var _tariff_val_label : GUILabel
 var _diplomatic_balance_label : GUILabel
-var _balance_label : GUILabel
 
 var _lower_class_chart : GUIPieChart
 var _middle_class_chart : GUIPieChart
 var _upper_class_chart : GUIPieChart
 var _debt_chart : GUIPieChart
 
-const _screen : NationManagement.Screen = NationManagement.Screen.BUDGET
+const SCREEN := NationManagement.Screen.BUDGET
 
 # TODO - testing function, should be replaced with calls to SIM which trigger UI updates through gamestate_updated
-func _on_tax_slider_changed(slider : GUIScrollbar, label : GUILabel, tooltip : StringName, value : int) -> void:
-	label.text = "%s¤" % GUINode.float_to_string_dp(value, 3 if abs(value) < 1000 else 1)
-	slider.set_tooltip_string("%s: §Y%s%%" % [tr(tooltip), GUINode.float_to_string_dp(value, 1)])
+#	slider.set_tooltip_string("%s: §Y%s%%" % [tr(tooltip), GUINode.float_to_string_dp(value, 1)])
 
 func _ready() -> void:
 	GameSingleton.gamestate_updated.connect(_update_info)
@@ -53,111 +32,24 @@ func _ready() -> void:
 	Events.NationManagementScreens.update_active_nation_management_screen.connect(_on_update_active_nation_management_screen)
 
 	add_gui_element("country_budget", "country_budget")
+	MenuSingleton.link_budget_menu_to_cpp(self)
 
 	set_click_mask_from_nodepaths([^"./country_budget/main_bg"])
 
 	var close_button : GUIIconButton = get_gui_icon_button_from_nodepath(^"./country_budget/close_button")
 	if close_button:
-		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(_screen))
+		close_button.pressed.connect(Events.NationManagementScreens.close_nation_management_screen.bind(SCREEN))
 
 	# labels
-	# income
-	_lower_class_label = get_gui_label_from_nodepath(^"./country_budget/tax_0_inc")
-	_middle_class_label = get_gui_label_from_nodepath(^"./country_budget/tax_1_inc")
-	_upper_class_label = get_gui_label_from_nodepath(^"./country_budget/tax_2_inc")
-	_gold_label = get_gui_label_from_nodepath(^"./country_budget/gold_inc")
-	_total_inc_label = get_gui_label_from_nodepath(^"./country_budget/total_inc")
 	# debt
 	_national_bank_label = get_gui_label_from_nodepath(^"./country_budget/national_bank_val")
 	_total_funds_label = get_gui_label_from_nodepath(^"./country_budget/total_funds_val")
 	_debt_val_label = get_gui_label_from_nodepath(^"./country_budget/debt_val")
 	_interest_val_label = get_gui_label_from_nodepath(^"./country_budget/interest_val")
 	# costs
-	_nat_stock_val_label = get_gui_label_from_nodepath(^"./country_budget/nat_stock_val")
-	_nat_stock_exp_label = get_gui_label_from_nodepath(^"./country_budget/nat_stock_est")
-	_mil_cost_val_label = get_gui_label_from_nodepath(^"./country_budget/mil_cost_val")
-	_overseas_cost_val_label = get_gui_label_from_nodepath(^"./country_budget/overseas_cost_val")
 	_ind_sub_val_label = get_gui_label_from_nodepath(^"./country_budget/ind_sub_val")
-	_admin_efficiency_label = get_gui_label_from_nodepath(^"./country_budget/admin_efficiency")
-	_education_exp_label = get_gui_label_from_nodepath(^"./country_budget/exp_val_0")
-	_administration_exp_label = get_gui_label_from_nodepath(^"./country_budget/exp_val_1")
-	_social_exp_label = get_gui_label_from_nodepath(^"./country_budget/exp_val_2")
-	_military_exp_label = get_gui_label_from_nodepath(^"./country_budget/exp_val_3")
-	_total_exp_label = get_gui_label_from_nodepath(^"./country_budget/total_exp")
 	# others
-	_tariffs_percent_label = get_gui_label_from_nodepath(^"./country_budget/tariffs_percent")
-	_tariff_val_label = get_gui_label_from_nodepath(^"./country_budget/tariff_val")
 	_diplomatic_balance_label = get_gui_label_from_nodepath(^"./country_budget/diplomatic_balance")
-	_balance_label = get_gui_label_from_nodepath(^"./country_budget/balance")
-
-	# sliders
-	# income
-	var _lower_class_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/tax_0_slider")
-	if _lower_class_slider and _lower_class_label:
-		_lower_class_slider.value_changed.connect(
-			func (value : int) -> void:
-				_on_tax_slider_changed(_lower_class_slider, _lower_class_label, &"BUDGET_TAX_POOR", value)
-		)
-		_lower_class_slider.emit_value_changed()
-	var _middle_class_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/tax_1_slider")
-	if _middle_class_slider and _middle_class_label:
-		_middle_class_slider.value_changed.connect(
-			func (value : int) -> void:
-				_on_tax_slider_changed(_middle_class_slider, _middle_class_label, &"BUDGET_TAX_MIDDLE", value)
-		)
-		_middle_class_slider.emit_value_changed()
-	var _upper_class_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/tax_2_slider")
-	if _upper_class_slider and _upper_class_label:
-		_upper_class_slider.value_changed.connect(
-			func (value : int) -> void:
-				_on_tax_slider_changed(_upper_class_slider, _upper_class_label, &"BUDGET_TAX_RICH", value)
-		)
-		_upper_class_slider.emit_value_changed()
-
-	# costs
-	var _land_stockpile_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/land_stockpile_slider")
-	if _land_stockpile_slider and _mil_cost_val_label:
-		_land_stockpile_slider.value_changed.connect(func(value : int) -> void: _mil_cost_val_label.text = "%s¤" % GUINode.float_to_string_dp(value, 2))
-		_land_stockpile_slider.emit_value_changed()
-	var _naval_stockpile_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/naval_stockpile_slider")
-	if _naval_stockpile_slider and _overseas_cost_val_label:
-		_naval_stockpile_slider.value_changed.connect(func(value : int) -> void: _overseas_cost_val_label.text = "%s¤" % GUINode.float_to_string_dp(value, 1))
-		_naval_stockpile_slider.emit_value_changed()
-	var _projects_stockpile_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/projects_stockpile_slider")
-	if _projects_stockpile_slider:
-		if _nat_stock_val_label:
-			_projects_stockpile_slider.value_changed.connect(func(value : int) -> void: _nat_stock_val_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		if _nat_stock_exp_label:
-			_projects_stockpile_slider.value_changed.connect(func(value : int) -> void: _nat_stock_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		_projects_stockpile_slider.emit_value_changed()
-	var _exp_0_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/exp_0_slider")
-	if _exp_0_slider and _education_exp_label:
-		_exp_0_slider.value_changed.connect(func(value : int) -> void: _education_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		_exp_0_slider.emit_value_changed()
-	var _exp_1_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/exp_1_slider")
-	if _exp_1_slider:
-		if _administration_exp_label:
-			_exp_1_slider.value_changed.connect(func(value : int) -> void: _administration_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		if _admin_efficiency_label:
-			_exp_1_slider.value_changed.connect(func(value : int) -> void: _admin_efficiency_label.text = "%s%%" % GUINode.float_to_string_dp(value, 1))
-		_exp_1_slider.emit_value_changed()
-	var _exp_2_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/exp_2_slider")
-	if _exp_2_slider and _social_exp_label:
-		_exp_2_slider.value_changed.connect(func(value : int) -> void: _social_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		_exp_2_slider.emit_value_changed()
-	var _exp_3_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/exp_3_slider")
-	if _exp_3_slider and _military_exp_label:
-		_exp_3_slider.value_changed.connect(func(value : int) -> void: _military_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		_exp_3_slider.emit_value_changed()
-
-	# others
-	var _tariff_slider : GUIScrollbar = get_gui_scrollbar_from_nodepath(^"./country_budget/tariff_slider")
-	if _tariff_slider:
-		if _tariff_val_label:
-			_tariff_slider.value_changed.connect(func(value : int) -> void: _tariff_val_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(value))
-		if _tariffs_percent_label:
-			_tariff_slider.value_changed.connect(func(value : int) -> void: _tariffs_percent_label.text = "%s%%" % GUINode.float_to_string_dp(value, 1))
-		_tariff_slider.emit_value_changed()
 
 	# debt buttons
 	var _tab_takenloans_button : GUIIconButton = get_gui_icon_button_from_nodepath(^"./country_budget/tab_takenloans")
@@ -195,7 +87,7 @@ func _notification(what : int) -> void:
 			_update_info()
 
 func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
-	_active = active_screen == _screen
+	_active = active_screen == SCREEN
 	_update_info()
 
 func _update_info() -> void:
@@ -203,12 +95,6 @@ func _update_info() -> void:
 	_incVal += 1
 
 	if _active:
-		if _gold_label:
-			_gold_label.text = "%s¤" % GUINode.float_to_string_dp(_incVal - (_incVal % 7), 1)
-
-		if _total_inc_label:
-			_total_inc_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(_incVal)
-
 		if _national_bank_label:
 			_national_bank_label.text = "%s¤" % GUINode.float_to_string_suffixed(_incVal * 2)
 
@@ -228,15 +114,7 @@ func _update_info() -> void:
 			# TODO - check colours and +/- when non-zero
 			_diplomatic_balance_label.text = "§Y%s¤" % GUINode.float_to_string_dp(_incVal * 8, 1)
 
-		if _total_exp_label:
-			_total_exp_label.text = "%s¤" % GUINode.float_to_string_dp_dynamic(_incVal + 1)
-
-		if _balance_label:
-			var balance : float = _incVal * 2.5
-			_balance_label.text = "§%s%s¤" % ["G+" if balance > 0.0 else "R" if balance < 0.0 else "Y+", GUINode.float_to_string_dp_dynamic(balance)]
-
 		# TODO - set strata tax and debt charts
-		# TODO - update sliders to reflect changes in limits
 		# TODO - update loans taken/given list and enable/disable take/give loan buttons
 
 		show()


### PR DESCRIPTION
- Supersedes #497 
- Depends on #509
- Depends on #514  

Splits up the budget menu into components.
Each component manages it's own slider and label.
When the balance of a component changes, it emits a c++ signal so the budget menu can update.

This PR moves a lot of UI code from godot to c++.

![{9231A9EB-E551-4E6D-9A58-16B70EF7E60B}](https://github.com/user-attachments/assets/07ae18e9-4495-4b58-bb83-5da6069b93ca)
