### PR TITLE
Optimise godot::vformat by pooling args array

### DIFF
--- a/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXMaskedFlagTexture.cpp
@@ -129,11 +129,11 @@ Error GFXMaskedFlagTexture::set_gfx_masked_flag(GFX::MaskedFlag const* new_gfx_m
 
 	const StringName overlay_file = Utilities::std_to_godot_string(new_gfx_masked_flag->get_overlay_file());
 	const Ref<Image> new_overlay_image = asset_manager->get_image(overlay_file);
-	ERR_FAIL_NULL_V_MSG(new_overlay_image, FAILED, vformat("Failed to load flag overlay image: %s", overlay_file));
+	ERR_FAIL_NULL_V_MSG(new_overlay_image, FAILED, Utilities::format("Failed to load flag overlay image: %s", overlay_file));
 
 	const StringName mask_file = Utilities::std_to_godot_string(new_gfx_masked_flag->get_mask_file());
 	const Ref<Image> new_mask_image = asset_manager->get_image(mask_file);
-	ERR_FAIL_NULL_V_MSG(new_mask_image, FAILED, vformat("Failed to load flag mask image: %s", mask_file));
+	ERR_FAIL_NULL_V_MSG(new_mask_image, FAILED, Utilities::format("Failed to load flag mask image: %s", mask_file));
 
 	gfx_masked_flag = new_gfx_masked_flag;
 	overlay_image = new_overlay_image;
@@ -152,7 +152,7 @@ Error GFXMaskedFlagTexture::set_gfx_masked_flag_name(String const& gfx_masked_fl
 
 	GFX::MaskedFlag const* new_masked_flag = sprite->cast_to<GFX::MaskedFlag>();
 	ERR_FAIL_NULL_V_MSG(
-		new_masked_flag, FAILED, vformat(
+		new_masked_flag, FAILED, Utilities::format(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_masked_flag_name,
 			Utilities::std_to_godot_string(sprite->get_type()),
 			Utilities::std_to_godot_string(GFX::MaskedFlag::get_type_static())
@@ -207,7 +207,7 @@ Error GFXMaskedFlagTexture::set_flag_country_name_and_type(
 		game_singleton->get_definition_manager().get_country_definition_manager().get_country_definition_by_identifier(
 			Utilities::godot_to_std_string(new_flag_country_name)
 		);
-	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, vformat("Country not found: %s", new_flag_country_name));
+	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, Utilities::format("Country not found: %s", new_flag_country_name));
 
 	return set_flag_country_and_type(new_flag_country, new_flag_type);
 }
@@ -241,7 +241,7 @@ Error GFXMaskedFlagTexture::set_flag_country_name(String const& new_flag_country
 		instance_manager->get_country_instance_manager().get_country_instance_by_identifier(
 			Utilities::godot_to_std_string(new_flag_country_name)
 		);
-	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, vformat("Country not found: %s", new_flag_country_name));
+	ERR_FAIL_NULL_V_MSG(new_flag_country, FAILED, Utilities::format("Country not found: %s", new_flag_country_name));
 
 	return set_flag_country(new_flag_country);
 }

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.cpp
@@ -60,7 +60,7 @@ Error GFXPieChartTexture::_generate_pie_chart_image() {
 	ERR_FAIL_NULL_V(gfx_pie_chart, FAILED);
 	ERR_FAIL_COND_V_MSG(
 		gfx_pie_chart->get_size() <= 0, FAILED,
-		vformat("Invalid GFX::PieChart size for GFXPieChartTexture - %d", gfx_pie_chart->get_size())
+		Utilities::format("Invalid GFX::PieChart size for GFXPieChartTexture - %d", gfx_pie_chart->get_size())
 	);
 
 	const int32_t pie_chart_radius = gfx_pie_chart->get_size();
@@ -119,7 +119,7 @@ Error GFXPieChartTexture::set_slices_array(godot_pie_chart_data_t const& new_sli
 		ERR_CONTINUE_MSG(
 			!slice_dict.has(_slice_identifier_key()) || !slice_dict.has(_slice_tooltip_key()) ||
 				!slice_dict.has(_slice_colour_key()) || !slice_dict.has(_slice_weight_key()),
-			vformat("Invalid slice keys at index %d", i)
+			Utilities::format("Invalid slice keys at index %d", i)
 		);
 		const slice_t slice {
 			slice_dict[_slice_identifier_key()], slice_dict[_slice_tooltip_key()], slice_dict[_slice_colour_key()],
@@ -182,7 +182,7 @@ Error GFXPieChartTexture::set_gfx_pie_chart_name(String const& gfx_pie_chart_nam
 	ERR_FAIL_NULL_V(sprite, FAILED);
 	GFX::PieChart const* new_pie_chart = sprite->cast_to<GFX::PieChart>();
 	ERR_FAIL_NULL_V_MSG(
-		new_pie_chart, FAILED, vformat(
+		new_pie_chart, FAILED, Utilities::format(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_pie_chart_name,
 			Utilities::std_to_godot_string(sprite->get_type()),
 			Utilities::std_to_godot_string(GFX::PieChart::get_type_static())

--- a/extension/src/openvic-extension/classes/GFXSpriteTexture.cpp
+++ b/extension/src/openvic-extension/classes/GFXSpriteTexture.cpp
@@ -60,10 +60,10 @@ Error GFXSpriteTexture::set_gfx_texture_sprite(GFX::TextureSprite const* new_gfx
 
 		/* Needed for GFXButtonStateTexture, AssetManager::get_texture will re-use this image from its internal cache. */
 		const Ref<Image> image = asset_manager->get_image(texture_file);
-		ERR_FAIL_NULL_V_MSG(image, FAILED, vformat("Failed to load image: %s", texture_file));
+		ERR_FAIL_NULL_V_MSG(image, FAILED, Utilities::format("Failed to load image: %s", texture_file));
 
 		const Ref<ImageTexture> texture = asset_manager->get_texture(texture_file);
-		ERR_FAIL_NULL_V_MSG(texture, FAILED, vformat("Failed to load texture: %s", texture_file));
+		ERR_FAIL_NULL_V_MSG(texture, FAILED, Utilities::format("Failed to load texture: %s", texture_file));
 
 		button_image = image;
 		gfx_texture_sprite = new_gfx_texture_sprite;
@@ -96,7 +96,7 @@ Error GFXSpriteTexture::set_gfx_texture_sprite_name(String const& gfx_texture_sp
 	ERR_FAIL_NULL_V(sprite, FAILED);
 	GFX::TextureSprite const* new_texture_sprite = sprite->cast_to<GFX::TextureSprite>();
 	ERR_FAIL_NULL_V_MSG(
-		new_texture_sprite, FAILED, vformat(
+		new_texture_sprite, FAILED, Utilities::format(
 			"Invalid type for GFX sprite %s: %s (expected %s)", gfx_texture_sprite_name,
 			Utilities::std_to_godot_string(sprite->get_type()),
 			Utilities::std_to_godot_string(GFX::TextureSprite::get_type_static())

--- a/extension/src/openvic-extension/classes/GUILineChart.cpp
+++ b/extension/src/openvic-extension/classes/GUILineChart.cpp
@@ -78,7 +78,7 @@ Error GUILineChart::set_gfx_line_chart_name(String const& new_gfx_line_chart_nam
 
 	GFX::LineChart const* new_gfx_line_chart = sprite->cast_to<GFX::LineChart>();
 	ERR_FAIL_NULL_V_MSG(
-		new_gfx_line_chart, FAILED, vformat(
+		new_gfx_line_chart, FAILED, Utilities::format(
 			"Invalid type for GFX sprite %s: %s (expected %s)", new_gfx_line_chart_name,
 			Utilities::std_to_godot_string(sprite->get_type()),
 			Utilities::std_to_godot_string(GFX::LineChart::get_type_static())
@@ -181,7 +181,7 @@ Error GUILineChart::add_coloured_line(PackedFloat32Array const& line_values, Col
 	if (point_count <= 0) {
 		point_count = line_values.size();
 	} else {
-		ERR_FAIL_COND_V_MSG(point_count != line_values.size(), FAILED, vformat(
+		ERR_FAIL_COND_V_MSG(point_count != line_values.size(), FAILED, Utilities::format(
 			"Mismatch between number of points in GUILineChart lines: new line %d != existing lines %d",
 			line_values.size(), point_count
 		));

--- a/extension/src/openvic-extension/classes/GUINode.cpp
+++ b/extension/src/openvic-extension/classes/GUINode.cpp
@@ -131,7 +131,7 @@ static T* _cast_node(Node* node) {
 	T* result = Object::cast_to<T>(node);
 	ERR_FAIL_NULL_V_MSG(
 		result, nullptr,
-		vformat("Failed to cast node %s from type %s to %s", node->get_name(), node->get_class(), T::get_class_static())
+		Utilities::format("Failed to cast node %s from type %s to %s", node->get_name(), node->get_class(), T::get_class_static())
 	);
 	return result;
 }
@@ -157,29 +157,29 @@ Ref<Texture2D> GUINode::get_texture_from_node(Node* node) {
 	ERR_FAIL_NULL_V(node, nullptr);
 	if (TextureRect const* texture_rect = Object::cast_to<TextureRect>(node); texture_rect != nullptr) {
 		const Ref<Texture2D> texture = texture_rect->get_texture();
-		ERR_FAIL_NULL_V_MSG(texture, nullptr, vformat("Failed to get Texture2D from TextureRect %s", node->get_name()));
+		ERR_FAIL_NULL_V_MSG(texture, nullptr, Utilities::format("Failed to get Texture2D from TextureRect %s", node->get_name()));
 		return texture;
 	} else if (GUIButton const* button = Object::cast_to<GUIButton>(node); button != nullptr) {
 		static const StringName theme_name_normal = "normal";
 		const Ref<StyleBox> stylebox = button->get_theme_stylebox(theme_name_normal);
 		ERR_FAIL_NULL_V_MSG(
-			stylebox, nullptr, vformat("Failed to get StyleBox %s from GUIButton %s", theme_name_normal, node->get_name())
+			stylebox, nullptr, Utilities::format("Failed to get StyleBox %s from GUIButton %s", theme_name_normal, node->get_name())
 		);
 		const Ref<StyleBoxTexture> stylebox_texture = stylebox;
 		ERR_FAIL_NULL_V_MSG(
-			stylebox_texture, nullptr, vformat(
+			stylebox_texture, nullptr, Utilities::format(
 				"Failed to cast StyleBox %s from GUIButton %s to type StyleBoxTexture", theme_name_normal, node->get_name()
 			)
 		);
 		const Ref<Texture2D> result = stylebox_texture->get_texture();
 		ERR_FAIL_NULL_V_MSG(
 			result, nullptr,
-			vformat("Failed to get Texture2D from StyleBoxTexture %s from GUIButton %s", theme_name_normal, node->get_name())
+			Utilities::format("Failed to get Texture2D from StyleBoxTexture %s from GUIButton %s", theme_name_normal, node->get_name())
 		);
 		return result;
 	}
 	ERR_FAIL_V_MSG(
-		nullptr, vformat(
+		nullptr, Utilities::format(
 			"Failed to cast node %s from type %s to TextureRect or GUIButton", node->get_name(), node->get_class()
 		)
 	);

--- a/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
+++ b/extension/src/openvic-extension/classes/GUIOverlappingElementsBox.cpp
@@ -101,7 +101,7 @@ Error GUIOverlappingElementsBox::set_child_count(int32_t new_count) {
 		return OK;
 	} else {
 		ERR_FAIL_NULL_V_MSG(
-			gui_child_element, FAILED, vformat(
+			gui_child_element, FAILED, Utilities::format(
 				"GUIOverlappingElementsBox child element is null (child_count = %d, new_count = %d)", child_count, new_count
 			)
 		);
@@ -115,7 +115,7 @@ Error GUIOverlappingElementsBox::set_child_count(int32_t new_count) {
 				err = FAILED;
 			}
 			ERR_FAIL_NULL_V_MSG(
-				child, FAILED, vformat(
+				child, FAILED, Utilities::format(
 					"Failed to generate GUIOverlappingElementsBox child element %s (child_count = %d, new_count = %d)",
 					name, child_count, new_count
 				)
@@ -172,11 +172,11 @@ Error GUIOverlappingElementsBox::set_gui_child_element_name(
 	}
 	ERR_FAIL_COND_V_MSG(
 		gui_child_element_file.is_empty(), FAILED,
-		vformat("GUI child element file name is empty but element name is not: %s", gui_child_element_name)
+		Utilities::format("GUI child element file name is empty but element name is not: %s", gui_child_element_name)
 	);
 	ERR_FAIL_COND_V_MSG(
 		gui_child_element_name.is_empty(), FAILED,
-		vformat("GUI child element name is empty but file name is not: %s", gui_child_element_file)
+		Utilities::format("GUI child element name is empty but file name is not: %s", gui_child_element_file)
 	);
 	GUI::Element const* const new_gui_child_element = UITools::get_gui_element(gui_child_element_file, gui_child_element_name);
 	ERR_FAIL_NULL_V(new_gui_child_element, FAILED);

--- a/extension/src/openvic-extension/classes/GUIScrollbar.cpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.cpp
@@ -378,31 +378,31 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 	const auto set_texture = [&gui_scrollbar_name]<typename _Element>(
 		String const& target, _Element const* element, Ref<GFXSpriteTexture>& texture
 	) -> bool {
-		ERR_FAIL_NULL_V_MSG(element, false, vformat(
+		ERR_FAIL_NULL_V_MSG(element, false, Utilities::format(
 			"Invalid %s element for GUIScrollbar %s - null!", target, gui_scrollbar_name
 		));
 		const String element_name = Utilities::std_to_godot_string(element->get_name());
 
 		/* Get Sprite, convert to TextureSprite, use to make a GFXSpriteTexture. */
 		GFX::Sprite const* sprite = element->get_sprite();
-		ERR_FAIL_NULL_V_MSG(sprite, false, vformat(
+		ERR_FAIL_NULL_V_MSG(sprite, false, Utilities::format(
 			"Invalid %s element %s for GUIScrollbar %s - sprite is null!", target, element_name, gui_scrollbar_name
 		));
 		GFX::TextureSprite const* texture_sprite = sprite->cast_to<GFX::TextureSprite>();
-		ERR_FAIL_NULL_V_MSG(texture_sprite, false, vformat(
+		ERR_FAIL_NULL_V_MSG(texture_sprite, false, Utilities::format(
 			"Invalid %s element %s for GUIScrollbar %s - sprite type is %s with base type %s, expected base %s!", target,
 			element_name, gui_scrollbar_name, Utilities::std_to_godot_string(sprite->get_type()),
 			Utilities::std_to_godot_string(sprite->get_base_type()),
 			Utilities::std_to_godot_string(GFX::TextureSprite::get_type_static())
 		));
 		texture = GFXSpriteTexture::make_gfx_sprite_texture(texture_sprite);
-		ERR_FAIL_NULL_V_MSG(texture, false, vformat(
+		ERR_FAIL_NULL_V_MSG(texture, false, Utilities::format(
 			"Failed to make GFXSpriteTexture from %s element %s for GUIScrollbar %s!", target, element_name, gui_scrollbar_name
 		));
 		if constexpr (std::is_same_v<_Element, GUI::Button>) {
 			using enum GFXButtonStateTexture::ButtonState;
 			for (GFXButtonStateTexture::ButtonState state : { HOVER, PRESSED }) {
-				ERR_FAIL_NULL_V_MSG(texture->get_button_state_texture(state), false, vformat(
+				ERR_FAIL_NULL_V_MSG(texture->get_button_state_texture(state), false, Utilities::format(
 					"Failed to generate %s texture for %s element %s for GUIScrollbar %s!",
 					GFXButtonStateTexture::button_state_to_name(state), target, element_name, gui_scrollbar_name
 				));
@@ -602,7 +602,7 @@ void GUIScrollbar::set_range_limits_and_value_from_slider_value(SliderValue cons
 
 void GUIScrollbar::set_length_override(real_t new_length_override) {
 	ERR_FAIL_COND_MSG(
-		length_override < 0, vformat("Invalid GUIScrollbar length override: %f - cannot be negative!", length_override)
+		length_override < 0, Utilities::format("Invalid GUIScrollbar length override: %f - cannot be negative!", length_override)
 	);
 
 	length_override = new_length_override;

--- a/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
@@ -38,7 +38,7 @@ AdministrationBudget::AdministrationBudget(
 
 	if (budget_label != nullptr) {
 		budget_label->set_tooltip_string(
-			godot::vformat(
+			Utilities::format(
 				"%s\n--------------\n%s",
 				budget_label->tr("DIST_ADMINISTRATION"),
 				budget_label->tr("ADM_DESC")
@@ -61,7 +61,7 @@ fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
 ) {
 	static const godot::StringName administrative_efficiency_template = "%s\n%s%s\n--------------\n%s%s%s%s";
 	administrative_efficiency_label.set_text(
-		godot::vformat(
+		Utilities::format(
 			"%s%%",
 			Utilities::fixed_point_to_string_dp(
 				100 * country.get_administrative_efficiency_from_administrators(),
@@ -82,7 +82,7 @@ fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
 	} else {
 		static const godot::String admin_crime_template = godot::String::utf8("\n%s §Y%s%%§W %s");
 		const fixed_point_t admin_spending_crime_effect = country_defines.get_admin_spending_crimefight_percent();
-		administrative_efficiency_tooltip_args[2] = godot::vformat(
+		administrative_efficiency_tooltip_args[2] = Utilities::format(
 			admin_crime_template,
 			administrative_efficiency_label.tr("BUDGET_VIEW_CRIME_FIGHT"),
 			Utilities::fixed_point_to_string_dp(100 * admin_spending_crime_effect * scaled_value, 1),
@@ -125,7 +125,7 @@ fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
 		static const godot::String reform_template = godot::String::utf8("\n%s: %s §Y+%s%%§W");
 
 		const fixed_point_t extra_administrator_percentage = administrative_multiplier * country_defines.get_bureaucracy_percentage_increment();
-		reforms_part += godot::vformat(
+		reforms_part += Utilities::format(
 			reform_template,
 			administrative_efficiency_label.tr(
 				Utilities::std_to_godot_string(group.get_identifier())

--- a/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
@@ -77,7 +77,7 @@ void BudgetMenu::update_projected_balance() {
 	}
 
 	projected_balance_label.set_text(
-		godot::vformat(
+		Utilities::format(
 			godot::String::utf8("§%s%s§W"),
 			Utilities::get_colour_and_sign(projected_balance),
 			Utilities::cash_to_string_dp_dynamic(projected_balance)

--- a/extension/src/openvic-extension/components/budget/DiplomaticBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/DiplomaticBudget.cpp
@@ -50,7 +50,7 @@ void DiplomaticBudget::full_update(CountryInstance const& country) {
 	set_balance(diplomatic_balance);
 
 	balance_label.set_text(
-		godot::vformat(
+		Utilities::format(
 			godot::String::utf8("§%s%s§W"),
 			Utilities::get_colour_and_sign(diplomatic_balance),
 			Utilities::format_with_currency(
@@ -60,7 +60,7 @@ void DiplomaticBudget::full_update(CountryInstance const& country) {
 	);
 
 	balance_label.set_tooltip_string(
-		godot::vformat(
+		Utilities::format(
 			"%s%s%s%s", //no new lines in Victoria 2 here
 			TOOLTIP_TEXT_PART(war_subsidies_expenses, "WARSUBSIDIES_EXPENSE"),
 			TOOLTIP_TEXT_PART(war_subsidies_income, "WARSUBSIDIES_INCOME"),

--- a/extension/src/openvic-extension/components/budget/EducationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/EducationBudget.cpp
@@ -30,7 +30,7 @@ EducationBudget::EducationBudget(GUINode const& parent):
 
 	if (budget_label != nullptr) {
 		budget_label->set_tooltip_string(
-			godot::vformat(
+			Utilities::format(
 				"%s\n--------------\n%s",
 				budget_label->tr("DIST_EDUCATION"),
 				budget_label->tr("EDU_DESC")

--- a/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
@@ -30,7 +30,7 @@ MilitaryBudget::MilitaryBudget(GUINode const& parent):
 
 	if (budget_label != nullptr) {
 		budget_label->set_tooltip_string(
-			godot::vformat(
+			Utilities::format(
 				"%s\n--------------\n%s",
 				budget_label->tr("DIST_DEFENCE"),
 				budget_label->tr("DEFENCE_DESC")

--- a/extension/src/openvic-extension/components/budget/SocialBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/SocialBudget.cpp
@@ -34,7 +34,7 @@ SocialBudget::SocialBudget(GUINode const& parent):
 
 	if (budget_label != nullptr) {
 		budget_label->set_tooltip_string(
-			godot::vformat(
+			Utilities::format(
 				"%s\n--------------\n%s",
 				budget_label->tr("DIST_SOCIAL"),
 				budget_label->tr("SOCIAL_DESC2")

--- a/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
@@ -22,8 +22,8 @@ StrataTaxBudget::StrataTaxBudget(
 		parent,
 		generate_slider_tooltip_localisation_key(new_strata),
 		BALANCE,
-		godot::vformat("./country_budget/tax_%d_slider", static_cast<uint64_t>(new_strata.get_index())),
-		godot::vformat("./country_budget/tax_%d_inc", static_cast<uint64_t>(new_strata.get_index()))
+		Utilities::format("./country_budget/tax_%d_slider", static_cast<uint64_t>(new_strata.get_index())),
+		Utilities::format("./country_budget/tax_%d_inc", static_cast<uint64_t>(new_strata.get_index()))
 	),
 	BudgetIncomeComponent(generate_summary_localisation_key(new_strata), 1),
 	strata{new_strata},
@@ -36,9 +36,9 @@ StrataTaxBudget::StrataTaxBudget(
 
 	GUILabel::set_text_and_tooltip(
 		parent,
-		godot::vformat("./country_budget/tax_%d_desc", static_cast<uint64_t>(new_strata.get_index())),
+		Utilities::format("./country_budget/tax_%d_desc", static_cast<uint64_t>(new_strata.get_index())),
 		generate_slider_tooltip_localisation_key(new_strata),
-		godot::vformat(
+		Utilities::format(
 			"TAX_%s_DESC",
 			(godot::String::utf8(
 				strata.get_identifier().data(),
@@ -83,7 +83,7 @@ godot::StringName StrataTaxBudget::generate_slider_tooltip_localisation_key(Stra
 }
 
 godot::StringName StrataTaxBudget::generate_summary_localisation_key(Strata const& strata) {
-	return godot::vformat(
+	return Utilities::format(
 		"TAXES_%s",
 		(godot::StringName(
 			strata.get_identifier().data(),
@@ -114,7 +114,7 @@ void StrataTaxBudget::update_slider_tooltip(
 	const fixed_point_t tax_efficiency_from_tech = country.get_modifier_effect_value(*modifier_effect_cache.get_tax_eff());
 	const godot::String tax_efficiency_from_tech_text = slider.tr(tax_efficiency_from_tech_localisation_key).replace(
 		Utilities::get_short_value_placeholder(),
-		godot::vformat(
+		Utilities::format(
 			"%s%%",
 			Utilities::float_to_string_dp(
 				tax_efficiency_from_tech.to_float(), //tax_efficiency_from_tech is already * 100
@@ -129,7 +129,7 @@ void StrataTaxBudget::update_slider_tooltip(
 		Utilities::float_to_string_dp(100 * effective_tax_rate, 2)
 	);
 
-	const godot::String tooltip = godot::vformat(
+	const godot::String tooltip = Utilities::format(
 		godot::String::utf8("%s: §Y%s§W\n%s\n%s\n%s"),
 		localised_strata_tax,
 		Utilities::percentage_to_string_dp(scaled_value, 1),

--- a/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.cpp
@@ -89,7 +89,7 @@ void SliderBudgetComponent::update_slider_tooltip(
 	);
 	const godot::String localised = slider.tr(slider_tooltip_localisation_key);
 	if (localised.contains(Utilities::get_short_value_placeholder())) {
-		tooltip = godot::vformat(
+		tooltip = Utilities::format(
 			"%s%%",
 			localised.replace(
 				Utilities::get_short_value_placeholder(),
@@ -97,7 +97,7 @@ void SliderBudgetComponent::update_slider_tooltip(
 			)
 		);
 	} else {
-		tooltip = godot::vformat(
+		tooltip = Utilities::format(
 			"%s%s%%",
 			localised,
 			percentage_text

--- a/extension/src/openvic-extension/singletons/AssetManager.cpp
+++ b/extension/src/openvic-extension/singletons/AssetManager.cpp
@@ -44,12 +44,12 @@ Ref<Image> AssetManager::_load_image(StringName const& path, bool flip_y) {
 	const String lookedup_path = Utilities::std_to_godot_string(
 		game_singleton->get_dataloader().lookup_image_file(Utilities::godot_to_std_string(path)).string()
 	);
-	ERR_FAIL_COND_V_MSG(lookedup_path.is_empty(), nullptr, vformat("Failed to look up image: %s", path));
+	ERR_FAIL_COND_V_MSG(lookedup_path.is_empty(), nullptr, Utilities::format("Failed to look up image: %s", path));
 
 	const Ref<Image> image = Utilities::load_godot_image(lookedup_path);
 	ERR_FAIL_COND_V_MSG(
 		image.is_null() || image->is_empty(), nullptr,
-		vformat("Failed to load image: %s (looked up: %s)", path, lookedup_path)
+		Utilities::format("Failed to load image: %s (looked up: %s)", path, lookedup_path)
 	);
 	if (image->detect_alpha() != Image::ALPHA_NONE) {
 		image->fix_alpha_edges();
@@ -82,7 +82,7 @@ Ref<Image> AssetManager::get_image(StringName const& path, BitField<LoadFlags> l
 		/* Mark both image and texture as failures, regardless of cache flags, in case of future load/creation attempts. */
 		image_assets[path] = {};
 
-		ERR_FAIL_V_MSG(nullptr, vformat("Failed to load image: %s", path));
+		ERR_FAIL_V_MSG(nullptr, Utilities::format("Failed to load image: %s", path));
 	}
 }
 
@@ -95,7 +95,7 @@ Ref<ImageTexture> AssetManager::get_texture(StringName const& path, BitField<Loa
 
 	/* No creation attempt has yet been made, so we try now starting by finding the corresponding image. */
 	const Ref<Image> image = get_image(path, load_flags);
-	ERR_FAIL_NULL_V_MSG(image, nullptr, vformat("Failed to load image for texture: %s", path));
+	ERR_FAIL_NULL_V_MSG(image, nullptr, Utilities::format("Failed to load image for texture: %s", path));
 
 	const Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
 
@@ -109,7 +109,7 @@ Ref<ImageTexture> AssetManager::get_texture(StringName const& path, BitField<Loa
 		/* Mark texture as a failure, regardless of cache flags, in case of future creation attempts. */
 		image_assets[path].texture = Ref<ImageTexture> {};
 
-		ERR_FAIL_V_MSG(nullptr, vformat("Failed to create texture: %s", path));
+		ERR_FAIL_V_MSG(nullptr, Utilities::format("Failed to create texture: %s", path));
 	}
 }
 
@@ -139,7 +139,7 @@ Ref<StyleBoxTexture> AssetManager::make_stylebox_texture(Ref<Texture2D> const& t
 Ref<FontFile> AssetManager::get_font(StringName const& name) {
 	const font_map_t::const_iterator it = fonts.find(name);
 	if (it != fonts.end()) {
-		ERR_FAIL_NULL_V_MSG(it->second, nullptr, vformat("Failed to load font previously: %s", name));
+		ERR_FAIL_NULL_V_MSG(it->second, nullptr, Utilities::format("Failed to load font previously: %s", name));
 
 		return it->second;
 	}
@@ -153,7 +153,7 @@ Ref<FontFile> AssetManager::get_font(StringName const& name) {
 	if (image.is_null()) {
 		fonts.emplace(name, nullptr);
 
-		ERR_FAIL_V_MSG(nullptr, vformat("Failed to load font image %s for the font named %s", image_path, name));
+		ERR_FAIL_V_MSG(nullptr, Utilities::format("Failed to load font image %s for the font named %s", image_path, name));
 	}
 
 	GameSingleton* game_singleton = GameSingleton::get_singleton();
@@ -166,7 +166,7 @@ Ref<FontFile> AssetManager::get_font(StringName const& name) {
 	if (lookedup_font_path.is_empty()) {
 		fonts.emplace(name, nullptr);
 
-		ERR_FAIL_V_MSG(nullptr, vformat("Failed to look up font: %s", font_path));
+		ERR_FAIL_V_MSG(nullptr, Utilities::format("Failed to look up font: %s", font_path));
 	}
 
 	const Ref<FontFile> font = Utilities::load_godot_font(lookedup_font_path, image);
@@ -175,7 +175,7 @@ Ref<FontFile> AssetManager::get_font(StringName const& name) {
 
 		ERR_FAIL_V_MSG(
 			nullptr,
-			vformat("Failed to load font file %s (looked up: %s) for the font named %s", font_path, lookedup_font_path, name)
+			Utilities::format("Failed to load font file %s (looked up: %s) for the font named %s", font_path, lookedup_font_path, name)
 		);
 	}
 

--- a/extension/src/openvic-extension/singletons/CursorSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/CursorSingleton.cpp
@@ -59,59 +59,59 @@ TypedArray<StringName> CursorSingleton::get_cursor_names() const {
 
 TypedArray<ImageTexture> CursorSingleton::get_frames(StringName const& name, int32_t res_index) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 
 	std::vector<TypedArray<ImageTexture>> const& images = it->second.images;
-	ERR_FAIL_INDEX_V_MSG(res_index, images.size(), {}, vformat("Invalid image index for cursor \"%s\": %d", name, res_index));
+	ERR_FAIL_INDEX_V_MSG(res_index, images.size(), {}, Utilities::format("Invalid image index for cursor \"%s\": %d", name, res_index));
 
 	return images[res_index];
 }
 
 PackedVector2Array CursorSingleton::get_hotspots(StringName const& name, int32_t res_index) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 
 	std::vector<PackedVector2Array> const& hotspots = it->second.hotspots;
-	ERR_FAIL_INDEX_V_MSG(res_index, hotspots.size(), {}, vformat("Invalid hotspot index for cursor \"%s\": %d", name, res_index));
+	ERR_FAIL_INDEX_V_MSG(res_index, hotspots.size(), {}, Utilities::format("Invalid hotspot index for cursor \"%s\": %d", name, res_index));
 
 	return hotspots[res_index];
 }
 
 int32_t CursorSingleton::get_animation_length(StringName const& name) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 	
 	return it->second.animation_length;
 }
 
 PackedVector2Array CursorSingleton::get_resolutions(StringName const& name) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 
 	return it->second.resolutions;
 }
 
 PackedFloat32Array CursorSingleton::get_display_rates(StringName const& name) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 
 	return it->second.display_rates;
 }
 
 PackedInt32Array CursorSingleton::get_sequence(StringName const& name) const {
 	const cursor_map_t::const_iterator it = cursors.find(name);
-	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_V_MSG(it == cursors.end(), {}, Utilities::format("Cursor \"%s\" not found", name));
 
 	return it->second.sequence;
 }
 
 void CursorSingleton::generate_resolution(StringName const& name, int32_t base_res_index, Vector2 target_res) {
 	cursor_map_t::iterator it = cursors.find(name);
-	ERR_FAIL_COND_MSG(it == cursors.end(), vformat("Cursor \"%s\" not found", name));
+	ERR_FAIL_COND_MSG(it == cursors.end(), Utilities::format("Cursor \"%s\" not found", name));
 	cursor_asset_t& cursor = it.value();
 
 	ERR_FAIL_INDEX_MSG(
-		base_res_index, cursor.images.size(), vformat("Invalid image index for cursor \"%s\": %d", name, base_res_index)
+		base_res_index, cursor.images.size(), Utilities::format("Invalid image index for cursor \"%s\": %d", name, base_res_index)
 	);
 
 	TypedArray<ImageTexture> const& images = cursor.images[base_res_index];
@@ -438,7 +438,7 @@ bool CursorSingleton::_load_cursor_ani(StringName const& name, String const& pat
 
 	const Error err = FileAccess::get_open_error();
 	ERR_FAIL_COND_V_MSG(
-		err != OK || file.is_null(), false, vformat("Failed to open ani file: \"%s\"", path)
+		err != OK || file.is_null(), false, Utilities::format("Failed to open ani file: \"%s\"", path)
 	);
 
 	//read the RIFF container
@@ -580,7 +580,7 @@ bool CursorSingleton::_load_cursor_cur(StringName const& name, String const& pat
 	const Ref<FileAccess> file = FileAccess::open(path, FileAccess::ModeFlags::READ);
 	const Error err = FileAccess::get_open_error();
 	ERR_FAIL_COND_V_MSG(
-		err != OK || file.is_null(), false, vformat("Failed to open cur file: \"%s\"", path)
+		err != OK || file.is_null(), false, Utilities::format("Failed to open cur file: \"%s\"", path)
 	);
 
 	image_hotspot_pair_asset_t pair = _load_pair(file);

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -135,7 +135,7 @@ Error GameSingleton::setup_game(int32_t bookmark_index) {
 	Bookmark const* bookmark =
 		game_manager.get_definition_manager().get_history_manager().get_bookmark_manager().get_bookmark_by_index(bookmark_index
 		);
-	ERR_FAIL_NULL_V_MSG(bookmark, FAILED, vformat("Failed to get bookmark with index: %d", bookmark_index));
+	ERR_FAIL_NULL_V_MSG(bookmark, FAILED, Utilities::format("Failed to get bookmark with index: %d", bookmark_index));
 	bool ret = game_manager.setup_instance(bookmark);
 
 	// TODO - remove this temporary crime assignment
@@ -230,18 +230,18 @@ int32_t GameSingleton::get_flag_sheet_index(int32_t country_index, StringName co
 	ERR_FAIL_COND_V_MSG(
 		country_index < 0 ||
 			country_index >= get_definition_manager().get_country_definition_manager().get_country_definition_count(),
-		-1, vformat("Invalid country index: %d", country_index)
+		-1, Utilities::format("Invalid country index: %d", country_index)
 	);
 
 	const typename decltype(flag_type_index_map)::const_iterator it = flag_type_index_map.find(flag_type);
-	ERR_FAIL_COND_V_MSG(it == flag_type_index_map.end(), -1, vformat("Invalid flag type %s", flag_type));
+	ERR_FAIL_COND_V_MSG(it == flag_type_index_map.end(), -1, Utilities::format("Invalid flag type %s", flag_type));
 
 	return flag_type_index_map.size() * country_index + it->second;
 }
 
 Rect2i GameSingleton::get_flag_sheet_rect(int32_t flag_index) const {
 	ERR_FAIL_COND_V_MSG(
-		flag_index < 0 || flag_index >= flag_sheet_count, {}, vformat("Invalid flag sheet index: %d", flag_index)
+		flag_index < 0 || flag_index >= flag_sheet_count, {}, Utilities::format("Invalid flag sheet index: %d", flag_index)
 	);
 
 	return { Vector2i { flag_index % flag_sheet_dims.x, flag_index / flag_sheet_dims.x } * flag_dims, flag_dims };
@@ -370,7 +370,7 @@ int32_t GameSingleton::get_current_mapmode_index() const {
 
 Error GameSingleton::set_mapmode(int32_t index) {
 	Mapmode const* new_mapmode = get_definition_manager().get_mapmode_manager().get_mapmode_by_index(index);
-	ERR_FAIL_NULL_V_MSG(new_mapmode, FAILED, vformat("Failed to find mapmode with index: %d", index));
+	ERR_FAIL_NULL_V_MSG(new_mapmode, FAILED, Utilities::format("Failed to find mapmode with index: %d", index));
 	mapmode = new_mapmode;
 	const Error err = _update_colour_image();
 	emit_signal(_signal_mapmode_changed(), mapmode->get_index());
@@ -457,14 +457,14 @@ Error GameSingleton::_load_terrain_variants() {
 	ERR_FAIL_NULL_V(asset_manager, FAILED);
 	// Load the terrain texture sheet and prepare to slice it up
 	Ref<Image> terrain_sheet = asset_manager->get_image(terrain_texturesheet_path, AssetManager::LOAD_FLAG_NONE);
-	ERR_FAIL_NULL_V_MSG(terrain_sheet, FAILED, vformat("Failed to load terrain texture sheet: %s", terrain_texturesheet_path));
+	ERR_FAIL_NULL_V_MSG(terrain_sheet, FAILED, Utilities::format("Failed to load terrain texture sheet: %s", terrain_texturesheet_path));
 
 	static constexpr int32_t SHEET_DIMS = 8, SHEET_SIZE = SHEET_DIMS * SHEET_DIMS;
 
 	const int32_t sheet_width = terrain_sheet->get_width(), sheet_height = terrain_sheet->get_height();
 	ERR_FAIL_COND_V_MSG(
 		sheet_width < 1 || sheet_width % SHEET_DIMS != 0 || sheet_width != sheet_height, FAILED,
-		vformat(
+		Utilities::format(
 			"Invalid terrain texture sheet dims: %dx%d (must be square with dims positive multiples of %d)", sheet_width,
 			sheet_height, SHEET_DIMS
 		)
@@ -488,7 +488,7 @@ Error GameSingleton::_load_terrain_variants() {
 
 		ERR_FAIL_COND_V_MSG(
 			terrain_image.is_null() || terrain_image->is_empty(), FAILED,
-			vformat("Failed to extract terrain texture slice %s from %s", slice, terrain_texturesheet_path)
+			Utilities::format("Failed to extract terrain texture slice %s from %s", slice, terrain_texturesheet_path)
 		);
 
 		terrain_images[idx + 1] = terrain_image;

--- a/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
+++ b/extension/src/openvic-extension/singletons/LoadLocalisation.cpp
@@ -34,7 +34,7 @@ Error LoadLocalisation::_load_file(String const& file_path, Ref<Translation> con
 	const Ref<FileAccess> file = FileAccess::open(file_path, FileAccess::ModeFlags::READ);
 	Error err = FileAccess::get_open_error();
 	ERR_FAIL_COND_V_MSG(
-		err != OK || file.is_null(), err == OK ? FAILED : err, vformat("Failed to open localisation file: %s", file_path)
+		err != OK || file.is_null(), err == OK ? FAILED : err, Utilities::format("Failed to open localisation file: %s", file_path)
 	);
 	int line_number = 0;
 	while (!file->eof_reached()) {
@@ -81,7 +81,7 @@ Error LoadLocalisation::load_file(String const& file_path, String const& locale)
  */
 Error LoadLocalisation::load_locale_dir(String const& dir_path, String const& locale) const {
 	ERR_FAIL_COND_V_MSG(
-		!DirAccess::dir_exists_absolute(dir_path), FAILED, vformat("Locale directory does not exist: %s", dir_path)
+		!DirAccess::dir_exists_absolute(dir_path), FAILED, Utilities::format("Locale directory does not exist: %s", dir_path)
 	);
 
 	/* This will add the locale to the list of loaded locales even if it has no
@@ -92,7 +92,7 @@ Error LoadLocalisation::load_locale_dir(String const& dir_path, String const& lo
 	 */
 	const Ref<Translation> translation = _get_translation(locale);
 	const PackedStringArray files = DirAccess::get_files_at(dir_path);
-	ERR_FAIL_COND_V_MSG(files.size() < 1, FAILED, vformat("Locale directory does not contain any files: %s", dir_path));
+	ERR_FAIL_COND_V_MSG(files.size() < 1, FAILED, Utilities::format("Locale directory does not contain any files: %s", dir_path));
 	Error err = OK;
 	for (String const& file_name : files) {
 		if (file_name.get_extension().to_lower() == "csv") {
@@ -109,11 +109,11 @@ Error LoadLocalisation::load_locale_dir(String const& dir_path, String const& lo
  */
 Error LoadLocalisation::load_localisation_dir(String const& dir_path) const {
 	ERR_FAIL_COND_V_MSG(
-		!DirAccess::dir_exists_absolute(dir_path), FAILED, vformat("Localisation directory does not exist: %s", dir_path)
+		!DirAccess::dir_exists_absolute(dir_path), FAILED, Utilities::format("Localisation directory does not exist: %s", dir_path)
 	);
 	const PackedStringArray dirs = DirAccess::get_directories_at(dir_path);
 	ERR_FAIL_COND_V_MSG(
-		dirs.size() < 1, FAILED, vformat("Localisation directory does not contain any sub-directories: %s", dir_path)
+		dirs.size() < 1, FAILED, Utilities::format("Localisation directory does not contain any sub-directories: %s", dir_path)
 	);
 	TranslationServer* server = TranslationServer::get_singleton();
 	ERR_FAIL_NULL_V(server, FAILED);
@@ -133,7 +133,7 @@ bool LoadLocalisation::add_message(std::string_view key, Dataloader::locale_t lo
 	if (translation.is_null()) {
 		translation = _singleton->_get_translation(Dataloader::locale_names[locale]);
 		ERR_FAIL_NULL_V_MSG(
-			translation, false, vformat("Failed to get translation object: %s", Dataloader::locale_names[locale])
+			translation, false, Utilities::format("Failed to get translation object: %s", Dataloader::locale_names[locale])
 		);
 	}
 	const StringName godot_key = Utilities::std_to_godot_string(key);

--- a/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MapItemSingleton.cpp
@@ -273,7 +273,7 @@ Vector2 MapItemSingleton::get_unit_position_by_province_index(int32_t province_i
 
 	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
 		.get_province_definition_by_index(province_index);
-	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get unit position - invalid province index: %d", province_index));
+	ERR_FAIL_NULL_V_MSG(province, {}, Utilities::format("Cannot get unit position - invalid province index: %d", province_index));
 
 	return game_singleton->normalise_map_position(province->get_unit_position());
 }
@@ -283,8 +283,8 @@ Vector2 MapItemSingleton::get_port_position_by_province_index(int32_t province_i
 
 	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
 		.get_province_definition_by_index(province_index);
-	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get port position - invalid province index: %d", province_index));
-	ERR_FAIL_COND_V_MSG(!province->has_port(), {},vformat("Cannot get port position, province has no port, index: %d", province_index) ); 
+	ERR_FAIL_NULL_V_MSG(province, {}, Utilities::format("Cannot get port position - invalid province index: %d", province_index));
+	ERR_FAIL_COND_V_MSG(!province->has_port(), {},Utilities::format("Cannot get port position, province has no port, index: %d", province_index) ); 
 
 	BuildingType const* port_building_type = game_singleton->get_definition_manager().get_economy_manager().get_building_type_manager().get_port_building_type();
 	fvec2_t const* port_position = province->get_building_position(port_building_type);
@@ -303,7 +303,7 @@ int32_t MapItemSingleton::get_clicked_port_province_index(Vector2 click_position
 
 	ProvinceDefinition const* province = game_singleton->get_definition_manager().get_map_definition()
 		.get_province_definition_by_index(initial_province_index);
-	ERR_FAIL_NULL_V_MSG(province, {}, vformat("Cannot get port position - invalid province index: %d", initial_province_index));
+	ERR_FAIL_NULL_V_MSG(province, {}, Utilities::format("Cannot get port position - invalid province index: %d", initial_province_index));
 
 	BuildingType const* port_building_type = game_singleton->get_definition_manager().get_economy_manager().get_building_type_manager().get_port_building_type();
 	

--- a/extension/src/openvic-extension/singletons/MenuSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.cpp
@@ -630,7 +630,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 		static const String terrain_type_template_string = "%s" + get_tooltip_separator() + "%s" +
 			GUILabel::get_colour_marker() + "Y%s" + GUILabel::get_colour_marker() + "!%s";
 
-		ret[province_info_terrain_type_tooltip_key] = vformat(
+		ret[province_info_terrain_type_tooltip_key] = Utilities::format(
 			terrain_type_template_string,
 			tr(terrain_type_localisation_key).replace(terrain_type_replace_key, tr(terrain_type_string)),
 			tr(movement_cost_localisation_key),
@@ -649,7 +649,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 
 		static const StringName controller_localisation_key = "PV_CONTROLLER";
 		static const String controller_template_string = "%s %s";
-		ret[province_info_controller_tooltip_key] = vformat(
+		ret[province_info_controller_tooltip_key] = Utilities::format(
 			controller_template_string, tr(controller_localisation_key), _get_country_name(*controller)
 		);
 	}
@@ -708,7 +708,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 				switch (owner_job->get_effect_type()) {
 				case OUTPUT:
 					output_multiplier += effect_value;
-					output_string += vformat(
+					output_string += Utilities::format(
 						employee_effect_template_string,
 						tr(owners_localisation_key),
 						tr(Utilities::std_to_godot_string(owner_pop_type.get_identifier())),
@@ -719,7 +719,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 					break;
 				case THROUGHPUT:
 					throughput_multiplier += effect_value;
-					throughput_string += vformat(
+					throughput_string += Utilities::format(
 						employee_effect_template_string,
 						tr(owners_localisation_key),
 						tr(Utilities::std_to_godot_string(owner_pop_type.get_identifier())),
@@ -744,7 +744,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 			static const String amount_of_employees_by_pop_type_template_string = "\n  -" + GUILabel::get_colour_marker() +
 				"Y%s" + GUILabel::get_colour_marker() + "!:%d";
 
-			amount_of_employees_by_pop_type += vformat(
+			amount_of_employees_by_pop_type += Utilities::format(
 				amount_of_employees_by_pop_type_template_string,
 				tr(Utilities::std_to_godot_string(pop_type.get_identifier())),
 				employees_of_type
@@ -766,7 +766,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 				switch (job.get_effect_type()) {
 					case OUTPUT:
 						output_from_workers += effect_value;
-						output_string += vformat(
+						output_string += Utilities::format(
 							employee_effect_template_string,
 							tr(workers_localisation_key),
 							tr(Utilities::std_to_godot_string(pop_type.get_identifier())),
@@ -777,7 +777,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 						break;
 					case THROUGHPUT:
 						throughput_from_workers += effect_value;
-						throughput_string += vformat(
+						throughput_string += Utilities::format(
 							employee_effect_template_string,
 							tr(workers_localisation_key),
 							tr(Utilities::std_to_godot_string(pop_type.get_identifier())),
@@ -851,7 +851,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 			static const String size_modifier_template_string = "%s: %s\n";
 
 			if (size_from_terrain != fixed_point_t::_0) {
-				size_string = vformat(
+				size_string = Utilities::format(
 					size_modifier_template_string,
 					tr(Utilities::std_to_godot_string(province->get_terrain_type()->get_identifier())),
 					_make_modifier_effect_value_coloured(
@@ -863,7 +863,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 			if (size_from_province != fixed_point_t::_0) {
 				static const StringName rgo_size_localisation_key = "RGO_SIZE";
 
-				size_string += vformat(
+				size_string += Utilities::format(
 					size_modifier_template_string,
 					tr(rgo_size_localisation_key),
 					_make_modifier_effect_value_coloured(
@@ -918,7 +918,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 
 				static const StringName rgo_output_tech_localisation_key = "RGO_OUTPUT_TECH";
 
-				output_string += vformat(
+				output_string += Utilities::format(
 					tech_modifier_template_string,
 					tr(rgo_output_tech_localisation_key),
 					_make_modifier_effect_value_coloured(
@@ -932,7 +932,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 
 				static const StringName rgo_throughput_tech_localisation_key = "RGO_THROUGHPUT_TECH";
 
-				throughput_string += vformat(
+				throughput_string += Utilities::format(
 					tech_modifier_template_string,
 					tr(rgo_throughput_tech_localisation_key),
 					_make_modifier_effect_value_coloured(
@@ -963,7 +963,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 		const fixed_point_t base_output = production_type.get_base_output_quantity();
 		const fixed_point_t max_output = base_output * throughput_efficiency * output_efficiency;
 
-		ret[province_info_rgo_production_tooltip_key] = vformat(
+		ret[province_info_rgo_production_tooltip_key] = Utilities::format(
 			rgo_production_template_string,
 			tr(rgo_production_localisation_key).replace(
 				rgo_good_replace_key, tr(Utilities::std_to_godot_string(rgo_good.get_identifier()))
@@ -994,7 +994,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 		static const String rgo_employment_template_string = "%s" + get_tooltip_separator() + "%s%s\n%s%d\n%s\n%s" +
 			GUILabel::get_colour_marker() + "G%d";
 
-		ret[province_info_rgo_employment_tooltip_key] = vformat(
+		ret[province_info_rgo_employment_tooltip_key] = Utilities::format(
 			rgo_employment_template_string,
 			tr(employment_localisation_key).replace(Utilities::get_long_value_placeholder(), {}),
 			tr(employee_count_localisation_key).replace(
@@ -1023,7 +1023,7 @@ Dictionary MenuSingleton::get_province_info_from_index(int32_t index) const {
 		HasGetIdentifierAndGetColour auto const* key, String const& identifier, float weight, float total_weight
 	) -> String {
 		static const String format_key = "%d%% %s";
-		return vformat(
+		return Utilities::format(
 			format_key,
 			static_cast<int32_t>(100.0f * weight / total_weight),
 			tr(identifier)
@@ -1088,7 +1088,7 @@ String MenuSingleton::get_province_building_identifier(int32_t building_index) c
 		.get_economy_manager().get_building_type_manager().get_province_building_types();
 	ERR_FAIL_COND_V_MSG(
 		building_index < 0 || building_index >= province_building_types.size(), {},
-		vformat("Invalid province building index: %d", building_index)
+		Utilities::format("Invalid province building index: %d", building_index)
 	);
 	return Utilities::std_to_godot_string(province_building_types[building_index]->get_identifier());
 }
@@ -1175,7 +1175,7 @@ Dictionary MenuSingleton::get_topbar_info() const {
 			static const String state_power_template_string =
 				"\n%s: " + GUILabel::get_colour_marker() + "Y%s" + GUILabel::get_colour_marker() + "!";
 
-			industrial_power_tooltip += vformat(
+			industrial_power_tooltip += Utilities::format(
 				state_power_template_string,
 				state_name,
 				Utilities::fixed_point_to_string_dp(power, 3)
@@ -1200,7 +1200,7 @@ Dictionary MenuSingleton::get_topbar_info() const {
 			static const String investment_power_template_string = "\n" + GUILabel::get_flag_marker() + "%s %s: " +
 				GUILabel::get_colour_marker() + "Y%s" + GUILabel::get_colour_marker() + "!";
 
-			industrial_power_tooltip += vformat(
+			industrial_power_tooltip += Utilities::format(
 				investment_power_template_string,
 				country_identifier,
 				country_name,
@@ -1633,9 +1633,9 @@ PackedStringArray MenuSingleton::get_search_result_rows(int32_t start, int32_t c
 
 	ERR_FAIL_INDEX_V_MSG(
 		start, search_panel.result_indices.size(), {},
-		vformat("Invalid start for search panel result rows: %d", start)
+		Utilities::format("Invalid start for search panel result rows: %d", start)
 	);
-	ERR_FAIL_COND_V_MSG(count <= 0, {}, vformat("Invalid count for search panel result rows: %d", count));
+	ERR_FAIL_COND_V_MSG(count <= 0, {}, Utilities::format("Invalid count for search panel result rows: %d", count));
 
 	if (start + count > search_panel.result_indices.size()) {
 		UtilityFunctions::push_warning(

--- a/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
+++ b/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
@@ -390,7 +390,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 	static const String war_exhaustion_template_string = "%s/%s";
 	const String war_exhaustion_string = Utilities::fixed_point_to_string_dp(country->get_war_exhaustion(), 2);
 	const String max_war_exhaustion_string = Utilities::fixed_point_to_string_dp(country->get_war_exhaustion_max(), 2);
-	ret[military_info_war_exhaustion_key] = vformat(
+	ret[military_info_war_exhaustion_key] = Utilities::format(
 		war_exhaustion_template_string, war_exhaustion_string, max_war_exhaustion_string
 	);
 
@@ -399,7 +399,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 	static const String current_effects_localisation_key = "WEX_EFFECTS";
 	static const String war_exhaustion_tooltip_template_string = "%s%s\n\n%s%s" + get_tooltip_separator() + "%s%s";
 
-	ret[military_info_war_exhaustion_tooltip_key] = vformat(
+	ret[military_info_war_exhaustion_tooltip_key] = Utilities::format(
 		war_exhaustion_tooltip_template_string,
 		tr(war_exhaution_localisation_key).replace(
 			Utilities::get_long_value_placeholder(),

--- a/extension/src/openvic-extension/singletons/ModelSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/ModelSingleton.cpp
@@ -45,7 +45,7 @@ GFX::Actor const* ModelSingleton::get_actor(std::string_view name, bool error_on
 		game_singleton->get_definition_manager().get_ui_manager().get_cast_object_by_identifier<GFX::Actor>(name);
 
 	if (error_on_fail) {
-		ERR_FAIL_NULL_V_MSG(actor, nullptr, vformat("Failed to find actor \"%s\"", Utilities::std_to_godot_string(name)));
+		ERR_FAIL_NULL_V_MSG(actor, nullptr, Utilities::format("Failed to find actor \"%s\"", Utilities::std_to_godot_string(name)));
 	}
 
 	return actor;
@@ -58,7 +58,7 @@ GFX::Actor const* ModelSingleton::get_cultural_actor(
 	ERR_FAIL_NULL_V(game_singleton, nullptr);
 
 	ERR_FAIL_COND_V_MSG(
-		culture.empty() || name.empty(), nullptr, vformat(
+		culture.empty() || name.empty(), nullptr, Utilities::format(
 			"Failed to find actor \"%s\" for culture \"%s\" - neither can be empty",
 			Utilities::std_to_godot_string(name), Utilities::std_to_godot_string(culture)
 		)
@@ -87,7 +87,7 @@ GFX::Actor const* ModelSingleton::get_cultural_actor(
 	}
 
 	ERR_FAIL_NULL_V_MSG(
-		actor, nullptr, vformat(
+		actor, nullptr, Utilities::format(
 			"Failed to find actor \"%s\" for culture \"%s\"", Utilities::std_to_godot_string(name),
 			Utilities::std_to_godot_string(culture)
 		)
@@ -160,7 +160,7 @@ Dictionary ModelSingleton::get_model_dict(GFX::Actor const& actor) {
 				GFX::Actor const* attachment_actor = get_actor(attachment.get_actor_name());
 
 				ERR_CONTINUE_MSG(
-					attachment_actor == nullptr, vformat(
+					attachment_actor == nullptr, Utilities::format(
 						"Failed to find \"%s\" attachment actor for actor \"%s\"",
 						Utilities::std_to_godot_string(attachment.get_actor_name()),
 						Utilities::std_to_godot_string(actor.get_name())
@@ -224,14 +224,14 @@ bool ModelSingleton::add_unit_dict(
 
 	/* Last unit to enter the province is shown on top. */
 	_UnitInstanceGroup const& unit = *units.back();
-	ERR_FAIL_COND_V_MSG(unit.empty(), false, vformat("Empty unit \"%s\"", Utilities::std_to_godot_string(unit.get_name())));
+	ERR_FAIL_COND_V_MSG(unit.empty(), false, Utilities::format("Empty unit \"%s\"", Utilities::std_to_godot_string(unit.get_name())));
 
 	CountryDefinition const* country = unit.get_country()->get_country_definition();
 
 	GraphicalCultureType const& graphical_culture_type = country->get_graphical_culture();
 	UnitType const* display_unit_type = unit.get_display_unit_type();
 	ERR_FAIL_NULL_V_MSG(
-		display_unit_type, false, vformat(
+		display_unit_type, false, Utilities::format(
 			"Failed to get display unit type for unit \"%s\"", Utilities::std_to_godot_string(unit.get_name())
 		)
 	);
@@ -269,7 +269,7 @@ bool ModelSingleton::add_unit_dict(
 	);
 
 	ERR_FAIL_NULL_V_MSG(
-		actor, false, vformat(
+		actor, false, Utilities::format(
 			"Failed to find \"%s\" actor of graphical culture type \"%s\" for unit \"%s\"",
 			Utilities::std_to_godot_string(display_unit_type->get_sprite()),
 			Utilities::std_to_godot_string(graphical_culture_type.get_identifier()),
@@ -290,7 +290,7 @@ bool ModelSingleton::add_unit_dict(
 			dict[mount_model_key] = get_model_dict(*mount_actor);
 			dict[mount_attach_node_key] = Utilities::std_to_godot_string(mount_attach_node_name);
 		} else {
-			UtilityFunctions::push_error(vformat(
+			UtilityFunctions::push_error(Utilities::format(
 				"Failed to find \"%s\" mount actor of graphical culture type \"%s\" for unit \"%s\"",
 				Utilities::std_to_godot_string(mount_actor_name),
 				Utilities::std_to_godot_string(graphical_culture_type.get_identifier()),
@@ -435,7 +435,7 @@ bool ModelSingleton::add_building_dict(
 
 	GFX::Actor const* actor = get_actor(actor_name);
 	ERR_FAIL_NULL_V_MSG(
-		actor, false, vformat(
+		actor, false, Utilities::format(
 			"Failed to find \"%s\" actor for building \"%s\" in province \"%s\"",
 			Utilities::std_to_godot_string(actor_name), Utilities::std_to_godot_string(building.get_identifier()),
 			Utilities::std_to_godot_string(province.get_identifier())

--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -73,9 +73,9 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_province_list_rows(int
 
 	ERR_FAIL_INDEX_V_MSG(
 		start, population_menu.visible_province_list_entries, {},
-		vformat("Invalid start for population menu province list rows: %d", start)
+		Utilities::format("Invalid start for population menu province list rows: %d", start)
 	);
-	ERR_FAIL_COND_V_MSG(count <= 0, {}, vformat("Invalid count for population menu province list rows: %d", count));
+	ERR_FAIL_COND_V_MSG(count <= 0, {}, Utilities::format("Invalid count for population menu province list rows: %d", count));
 
 	static const StringName type_key = "type";
 	static const StringName index_key = "index";
@@ -315,7 +315,7 @@ Error MenuSingleton::population_menu_select_province(int32_t province_index) {
 
 	ERR_FAIL_COND_V_MSG(
 		entry_visitor.index >= population_menu.province_list_entries.size(), FAILED,
-		vformat("Cannot select province index %d - not found in population menu province list!", province_index)
+		Utilities::format("Cannot select province index %d - not found in population menu province list!", province_index)
 	);
 
 	return ERR(entry_visitor.ret);
@@ -327,7 +327,7 @@ Error MenuSingleton::population_menu_toggle_expanded(int32_t toggle_index, bool 
 	population_menu_t::state_entry_t* state_entry =
 		std::get_if<population_menu_t::state_entry_t>(&population_menu.province_list_entries[toggle_index]);
 
-	ERR_FAIL_NULL_V_MSG(state_entry, FAILED, vformat("Cannot toggle expansion of a non-state entry! (%d)", toggle_index));
+	ERR_FAIL_NULL_V_MSG(state_entry, FAILED, Utilities::format("Cannot toggle expansion of a non-state entry! (%d)", toggle_index));
 
 	int32_t provinces = 0;
 
@@ -593,7 +593,7 @@ Error MenuSingleton::population_menu_select_sort_key(PopSortKey sort_key) {
 	/* sort_key must be cast here to avoid causing clang to segfault during compilation. */
 	ERR_FAIL_INDEX_V_MSG(
 		static_cast<int32_t>(sort_key), static_cast<int32_t>(MAX_SORT_KEY), FAILED,
-		vformat("Invalid population menu sort key: %d (must be under %d)", sort_key, MAX_SORT_KEY)
+		Utilities::format("Invalid population menu sort key: %d (must be under %d)", sort_key, MAX_SORT_KEY)
 	);
 
 	if (sort_key == population_menu.sort_key) {
@@ -634,7 +634,7 @@ GFXPieChartTexture::godot_pie_chart_data_t MenuSingleton::generate_population_me
 			} else {
 				key_ptr = &key_ref_or_ptr;
 			}
-			String tooltip = vformat(
+			String tooltip = Utilities::format(
 				pie_chart_tooltip_format_key,
 				tr(Utilities::std_to_godot_string(key_ptr->get_identifier()) + identifier_suffix),
 				Utilities::float_to_string_dp(100.0f * static_cast<float>(weight) / total_weight, 1)
@@ -660,9 +660,9 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_rows(int32_t start
 		return {};
 	}
 	ERR_FAIL_INDEX_V_MSG(
-		start, population_menu.filtered_pops.size(), {}, vformat("Invalid start for population menu pop rows: %d", start)
+		start, population_menu.filtered_pops.size(), {}, Utilities::format("Invalid start for population menu pop rows: %d", start)
 	);
-	ERR_FAIL_COND_V_MSG(count <= 0, {}, vformat("Invalid count for population menu pop rows: %d", count));
+	ERR_FAIL_COND_V_MSG(count <= 0, {}, Utilities::format("Invalid count for population menu pop rows: %d", count));
 
 	if (start + count > population_menu.filtered_pops.size()) {
 		count = population_menu.filtered_pops.size() - start;
@@ -814,7 +814,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_filter_info() cons
 
 Error MenuSingleton::population_menu_toggle_pop_filter(int32_t index) {
 	ERR_FAIL_COND_V_MSG(
-		index < 0 || index >= population_menu.pop_filters.size(), FAILED, vformat("Invalid pop filter index: %d", index)
+		index < 0 || index >= population_menu.pop_filters.size(), FAILED, Utilities::format("Invalid pop filter index: %d", index)
 	);
 
 	population_menu_t::pop_filter_t& filter = mutable_iterator(population_menu.pop_filters).begin()[index].second;
@@ -889,7 +889,7 @@ TypedArray<Array> MenuSingleton::get_population_menu_distribution_info() const {
 	) -> String {
 		static const String format_key =
 			GUILabel::get_colour_marker() + String { "Y%s" } + GUILabel::get_colour_marker() + "!: %s%%";
-		return  vformat(
+		return  Utilities::format(
 			format_key,
 			tr(identifier),
 			Utilities::float_to_string_dp(100.0f * weight / total_weight, 2)

--- a/extension/src/openvic-extension/singletons/SoundSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/SoundSingleton.cpp
@@ -81,7 +81,7 @@ Ref<AudioStreamMP3> SoundSingleton::get_song(String const& path) {
 
 	const Ref<AudioStreamMP3> song = AudioStreamMP3::load_from_file(path);
 
-	ERR_FAIL_NULL_V_MSG(song, nullptr, vformat("Failed to load music file: %s", path));
+	ERR_FAIL_NULL_V_MSG(song, nullptr, Utilities::format("Failed to load music file: %s", path));
 	tracks.emplace(std::move(name), song);
 
 	return song;
@@ -91,7 +91,7 @@ Ref<AudioStreamMP3> SoundSingleton::get_song(String const& path) {
 // playing the whole time. Solution: load it first and separately
 bool SoundSingleton::load_title_theme() {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V_MSG(game_singleton, false, vformat("Error retrieving GameSingleton"));
+	ERR_FAIL_NULL_V_MSG(game_singleton, false, Utilities::format("Error retrieving GameSingleton"));
 
 	static constexpr std::string_view music_directory = "music";
 	bool ret = false;
@@ -110,7 +110,7 @@ bool SoundSingleton::load_title_theme() {
 		String file_stem = to_define_file_name(file, music_folder);
 
 		if (file_stem == title_theme_name.data()) {
-			ERR_BREAK_MSG(!get_song(file).is_valid(), vformat("Failed to load title theme song at path %s.", std_to_godot_string(file_name.string())));
+			ERR_BREAK_MSG(!get_song(file).is_valid(), Utilities::format("Failed to load title theme song at path %s.", std_to_godot_string(file_name.string())));
 
 			String name = to_define_file_name(file, music_folder);
 			title_theme = name;
@@ -128,7 +128,7 @@ bool SoundSingleton::load_title_theme() {
 
 bool SoundSingleton::load_music() {
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V_MSG(game_singleton, false, vformat("Error retrieving GameSingleton"));
+	ERR_FAIL_NULL_V_MSG(game_singleton, false, Utilities::format("Error retrieving GameSingleton"));
 
 	static constexpr std::string_view music_directory = "music";
 	bool ret = true;
@@ -149,7 +149,7 @@ bool SoundSingleton::load_music() {
 		}
 
 		if (!get_song(file).is_valid()) {
-			ERR_PRINT(vformat("Failed to load song at path %s.", std_to_godot_string(file_name.string())));
+			ERR_PRINT(Utilities::format("Failed to load song at path %s.", std_to_godot_string(file_name.string())));
 			ret = false;
 			continue; // don't try to append a null pointer to the list
 		}
@@ -171,7 +171,7 @@ Ref<AudioStreamWAV> SoundSingleton::get_sound(String const& path) {
 	const Ref<AudioStreamWAV> sound = AudioStreamWAV::load_from_file(path);
 
 	ERR_FAIL_NULL_V_MSG(
-		sound, nullptr, vformat("Failed to load sound file %s", path) // named %s, path
+		sound, nullptr, Utilities::format("Failed to load sound file %s", path) // named %s, path
 	);
 
 	sfx.emplace(std::move(name), sound);
@@ -182,7 +182,7 @@ Ref<AudioStreamWAV> SoundSingleton::get_sound(String const& path) {
 Ref<AudioStreamWAV> SoundSingleton::get_sound_stream(String const& path) {
 	sfx_define_map_t::iterator it = sfx_define.find(path);
 	ERR_FAIL_COND_V_MSG(
-		it == sfx_define.end(), nullptr, vformat("Attempted to retrieve sound stream at invalid index %s.", path)
+		it == sfx_define.end(), nullptr, Utilities::format("Attempted to retrieve sound stream at invalid index %s.", path)
 	);
 
 	return it.value().audioStream;
@@ -203,7 +203,7 @@ bool SoundSingleton::load_sounds() {
 	bool ret = true;
 
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
-	ERR_FAIL_NULL_V_MSG(game_singleton, false, vformat("Error retrieving GameSingleton"));
+	ERR_FAIL_NULL_V_MSG(game_singleton, false, Utilities::format("Error retrieving GameSingleton"));
 
 	SoundEffectManager const& sound_manager = game_singleton->get_definition_manager().get_sound_effect_manager();
 
@@ -218,13 +218,13 @@ bool SoundSingleton::load_sounds() {
 		// UI_Cavalry_Selected.wav doesn't exist (paradox mistake, UI_Cavalry_Select.wav does), just keep going
 		// the define its associated with also isn't used in game
 		if (full_path.empty()) {
-			WARN_PRINT(vformat("The sound define %s points to non-existent file.", std_to_godot_string(sound_inst.get_identifier())));
+			WARN_PRINT(Utilities::format("The sound define %s points to non-existent file.", std_to_godot_string(sound_inst.get_identifier())));
 			continue;
 		}
 
 		Ref<AudioStreamWAV> stream = get_sound(std_to_godot_string(full_path.string()));
 		if (stream.is_null()) {
-			ERR_PRINT(vformat("Failed to load sound %s at path %s.", std_to_godot_string(sound_inst.get_identifier()), std_to_godot_string(full_path.string())));
+			ERR_PRINT(Utilities::format("Failed to load sound %s at path %s.", std_to_godot_string(sound_inst.get_identifier()), std_to_godot_string(full_path.string())));
 			ret = false;
 			continue; // don't try to append a null pointer to the list
 		}

--- a/extension/src/openvic-extension/singletons/TradeMenu.cpp
+++ b/extension/src/openvic-extension/singletons/TradeMenu.cpp
@@ -218,7 +218,7 @@ Dictionary MenuSingleton::get_trade_menu_tables_info() const {
 
 			static const String top_producer_template_string = "\n" + GUILabel::get_flag_marker() + "%s %s: %s";
 
-			tooltip += vformat(
+			tooltip += Utilities::format(
 				top_producer_template_string,
 				Utilities::std_to_godot_string(country->get_identifier()),
 				_get_country_name(*country),

--- a/extension/src/openvic-extension/utility/UITools.cpp
+++ b/extension/src/openvic-extension/utility/UITools.cpp
@@ -56,7 +56,7 @@ GFX::Sprite const* UITools::get_gfx_sprite(String const& gfx_sprite) {
 	GFX::Sprite const* sprite = game_singleton->get_definition_manager().get_ui_manager().get_sprite_by_identifier(
 		Utilities::godot_to_std_string(gfx_sprite)
 	);
-	ERR_FAIL_NULL_V_MSG(sprite, nullptr, vformat("GFX sprite not found: %s", gfx_sprite));
+	ERR_FAIL_NULL_V_MSG(sprite, nullptr, Utilities::format("GFX sprite not found: %s", gfx_sprite));
 	return sprite;
 }
 
@@ -66,9 +66,9 @@ GUI::Element const* UITools::get_gui_element(String const& gui_scene, String con
 	GUI::Scene const* scene = game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(
 		Utilities::godot_to_std_string(gui_scene)
 	);
-	ERR_FAIL_NULL_V_MSG(scene, nullptr, vformat("Failed to find GUI scene %s", gui_scene));
+	ERR_FAIL_NULL_V_MSG(scene, nullptr, Utilities::format("Failed to find GUI scene %s", gui_scene));
 	GUI::Element const* element = scene->get_scene_element_by_identifier(Utilities::godot_to_std_string(gui_element));
-	ERR_FAIL_NULL_V_MSG(element, nullptr, vformat("Failed to find GUI element %s in GUI scene %s", gui_element, gui_scene));
+	ERR_FAIL_NULL_V_MSG(element, nullptr, Utilities::format("Failed to find GUI element %s in GUI scene %s", gui_element, gui_scene));
 	return element;
 }
 
@@ -78,9 +78,9 @@ GUI::Position const* UITools::get_gui_position(String const& gui_scene, String c
 	GUI::Scene const* scene = game_singleton->get_definition_manager().get_ui_manager().get_scene_by_identifier(
 		Utilities::godot_to_std_string(gui_scene)
 	);
-	ERR_FAIL_NULL_V_MSG(scene, nullptr, vformat("Failed to find GUI scene %s", gui_scene));
+	ERR_FAIL_NULL_V_MSG(scene, nullptr, Utilities::format("Failed to find GUI scene %s", gui_scene));
 	GUI::Position const* position = scene->get_scene_position_by_identifier(Utilities::godot_to_std_string(gui_position));
-	ERR_FAIL_NULL_V_MSG(position, nullptr, vformat("Failed to find GUI position %s in GUI scene %s", gui_position, gui_scene));
+	ERR_FAIL_NULL_V_MSG(position, nullptr, Utilities::format("Failed to find GUI position %s in GUI scene %s", gui_position, gui_scene));
 	return position;
 }
 
@@ -152,17 +152,17 @@ static Error try_create_shortcut_action_for_button(
 
 	ERR_FAIL_COND_V_MSG(
 		event_array.is_empty(), ERR_INVALID_PARAMETER,
-		vformat("Unknown shortcut key '%s' for GUI button %s", shortcut_key_name, gui_button->get_name())
+		Utilities::format("Unknown shortcut key '%s' for GUI button %s", shortcut_key_name, gui_button->get_name())
 	);
 
 	InputMap* const im = InputMap::get_singleton();
 	String action_name;
 	if (shortcut_hotkey_name.is_empty()) {
 		action_name = //
-			vformat("button_%s_hotkey", gui_button->get_name().to_lower().replace("button", "").replace("hotkey", ""))
+			Utilities::format("button_%s_hotkey", gui_button->get_name().to_lower().replace("button", "").replace("hotkey", ""))
 				.replace("__", "_");
 	} else {
-		action_name = vformat("button_%s_hotkey", shortcut_hotkey_name);
+		action_name = Utilities::format("button_%s_hotkey", shortcut_hotkey_name);
 	}
 	Ref<InputEventAction> action_event;
 	action_event.instantiate();
@@ -182,7 +182,7 @@ static Error try_create_shortcut_action_for_button(
 		}
 
 		if (should_warn) {
-			WARN_PRINT(vformat("'%s' already found in InputMap with different values, reusing hotkey", action_name));
+			WARN_PRINT(Utilities::format("'%s' already found in InputMap with different values, reusing hotkey", action_name));
 		}
 	} else {
 		im->add_action(action_name);
@@ -271,7 +271,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			GUIIcon* gui_icon = nullptr;
 			ret &= new_control(gui_icon, icon, args.name);
 			ERR_FAIL_NULL_V_MSG(
-				gui_icon, false, vformat("Failed to create GUIIcon for GUI icon %s", icon_name)
+				gui_icon, false, Utilities::format("Failed to create GUIIcon for GUI icon %s", icon_name)
 			);
 
 			gui_icon->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
@@ -289,7 +289,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			GUIMaskedFlag* gui_masked_flag = nullptr;
 			ret &= new_control(gui_masked_flag, icon, args.name);
 			ERR_FAIL_NULL_V_MSG(
-				gui_masked_flag, false, vformat("Failed to create GUIMaskedFlag for GUI icon %s", icon_name)
+				gui_masked_flag, false, Utilities::format("Failed to create GUIMaskedFlag for GUI icon %s", icon_name)
 			);
 
 			if (gui_masked_flag->set_gfx_masked_flag(masked_flag) != OK) {
@@ -302,7 +302,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			GUIProgressBar* gui_progress_bar = nullptr;
 			ret &= new_control(gui_progress_bar, icon, args.name);
 			ERR_FAIL_NULL_V_MSG(
-				gui_progress_bar, false, vformat("Failed to create GUIProgressBar for GUI icon %s", icon_name)
+				gui_progress_bar, false, Utilities::format("Failed to create GUIProgressBar for GUI icon %s", icon_name)
 			);
 
 			if (gui_progress_bar->set_gfx_progress_bar(progress_bar) != OK) {
@@ -315,7 +315,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			GUIPieChart* gui_pie_chart = nullptr;
 			ret &= new_control(gui_pie_chart, icon, args.name);
 			ERR_FAIL_NULL_V_MSG(
-				gui_pie_chart, false, vformat("Failed to create GUIPieChart for GUI icon %s", icon_name)
+				gui_pie_chart, false, Utilities::format("Failed to create GUIPieChart for GUI icon %s", icon_name)
 			);
 
 			if (gui_pie_chart->set_gfx_pie_chart(pie_chart) == OK) {
@@ -334,7 +334,7 @@ static bool generate_icon(generate_gui_args_t&& args) {
 			GUILineChart* gui_line_chart = nullptr;
 			ret &= new_control(gui_line_chart, icon, args.name);
 			ERR_FAIL_NULL_V_MSG(
-				gui_line_chart, false, vformat("Failed to create GUILineChart for GUI icon %s", icon_name)
+				gui_line_chart, false, Utilities::format("Failed to create GUILineChart for GUI icon %s", icon_name)
 			);
 
 			if (gui_line_chart->set_gfx_line_chart(line_chart) != OK) {
@@ -377,7 +377,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 	const String shortcut_key_name = Utilities::std_to_godot_string(button.get_shortcut());
 	SoundEffect const* clicksound = button.get_clicksound();
 
-	ERR_FAIL_NULL_V_MSG(button.get_sprite(), false, vformat("Null sprite for GUI button %s", button_name));
+	ERR_FAIL_NULL_V_MSG(button.get_sprite(), false, Utilities::format("Null sprite for GUI button %s", button_name));
 
 	GUIButton* gui_button = nullptr;
 	bool ret = true;
@@ -385,7 +385,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 	if (GFX::IconTextureSprite const* texture_sprite = button.get_sprite()->cast_to<GFX::IconTextureSprite>()) {
 		GUIIconButton* gui_icon_button = nullptr;
 		ret &= new_control(gui_icon_button, button, args.name);
-		ERR_FAIL_NULL_V_MSG(gui_icon_button, false, vformat("Failed to create GUIIconButton for GUI button %s", button_name));
+		ERR_FAIL_NULL_V_MSG(gui_icon_button, false, Utilities::format("Failed to create GUIIconButton for GUI button %s", button_name));
 
 		if (gui_icon_button->set_gfx_texture_sprite(texture_sprite) != OK) {
 			UtilityFunctions::push_error("Error setting up GUIIconButton for GUI button ", button_name);
@@ -397,7 +397,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 		GUIMaskedFlagButton* gui_masked_flag_button = nullptr;
 		ret &= new_control(gui_masked_flag_button, button, args.name);
 		ERR_FAIL_NULL_V_MSG(
-			gui_masked_flag_button, false, vformat("Failed to create GUIMaskedFlagButton for GUI button %s", button_name)
+			gui_masked_flag_button, false, Utilities::format("Failed to create GUIMaskedFlagButton for GUI button %s", button_name)
 		);
 
 		if (gui_masked_flag_button->set_gfx_masked_flag(masked_flag) != OK) {
@@ -408,7 +408,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 		gui_button = gui_masked_flag_button;
 	} else {
 		ERR_FAIL_V_MSG(
-			false, vformat(
+			false, Utilities::format(
 				"Invalid sprite type %s for GUI button %s", Utilities::std_to_godot_string(button.get_sprite()->get_type()),
 				button_name
 			)
@@ -424,7 +424,7 @@ static bool generate_button(generate_gui_args_t&& args) {
 	}
 
 	if (try_create_shortcut_action_for_button(gui_button, shortcut_key_name) != OK) {
-		WARN_PRINT(vformat("Failed to create shortcut for GUI button '%s'", button_name));
+		WARN_PRINT(Utilities::format("Failed to create shortcut for GUI button '%s'", button_name));
 	}
 
 	gui_button->set_shortcut_feedback(false);
@@ -471,12 +471,12 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 	const String checkbox_name = Utilities::std_to_godot_string(checkbox.get_name());
 	const String shortcut_key_name = Utilities::std_to_godot_string(checkbox.get_shortcut());
 
-	ERR_FAIL_NULL_V_MSG(checkbox.get_sprite(), false, vformat("Null sprite for GUI checkbox %s", checkbox_name));
+	ERR_FAIL_NULL_V_MSG(checkbox.get_sprite(), false, Utilities::format("Null sprite for GUI checkbox %s", checkbox_name));
 
 	GFX::IconTextureSprite const* texture_sprite = checkbox.get_sprite()->cast_to<GFX::IconTextureSprite>();
 
 	ERR_FAIL_NULL_V_MSG(
-		texture_sprite, false, vformat(
+		texture_sprite, false, Utilities::format(
 			"Invalid sprite type %s for GUI checkbox %s", Utilities::std_to_godot_string(checkbox.get_sprite()->get_type()),
 			checkbox_name
 		)
@@ -485,7 +485,7 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 	GUIIconButton* gui_icon_button = nullptr;
 	bool ret = new_control(gui_icon_button, checkbox, args.name);
 	ERR_FAIL_NULL_V_MSG(
-		gui_icon_button, false, vformat("Failed to create GUIIconButton for GUI checkbox %s", checkbox_name)
+		gui_icon_button, false, Utilities::format("Failed to create GUIIconButton for GUI checkbox %s", checkbox_name)
 	);
 
 	gui_icon_button->set_toggle_mode(true);
@@ -502,7 +502,7 @@ static bool generate_checkbox(generate_gui_args_t&& args) {
 	}
 
 	if (try_create_shortcut_action_for_button(gui_icon_button, shortcut_key_name) != OK) {
-		WARN_PRINT(vformat("Failed to create shortcut hotkey for GUI checkbox '%s'", checkbox_name));
+		WARN_PRINT(Utilities::format("Failed to create shortcut hotkey for GUI checkbox '%s'", checkbox_name));
 	}
 
 	gui_icon_button->set_shortcut_feedback(false);
@@ -519,7 +519,7 @@ static bool generate_text(generate_gui_args_t&& args) {
 
 	GUILabel* gui_label = nullptr;
 	bool ret = new_control(gui_label, text, args.name);
-	ERR_FAIL_NULL_V_MSG(gui_label, false, vformat("Failed to create GUILabel for GUI text %s", text_name));
+	ERR_FAIL_NULL_V_MSG(gui_label, false, Utilities::format("Failed to create GUILabel for GUI text %s", text_name));
 
 	gui_label->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 
@@ -545,7 +545,7 @@ static bool generate_overlapping_elements(generate_gui_args_t&& args) {
 	bool ret = new_control(box, overlapping_elements, args.name);
 	ERR_FAIL_NULL_V_MSG(
 		box, false,
-		vformat("Failed to create GUIOverlappingElementsBox for GUI overlapping elements %s", overlapping_elements_name)
+		Utilities::format("Failed to create GUIOverlappingElementsBox for GUI overlapping elements %s", overlapping_elements_name)
 	);
 	box->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 
@@ -567,7 +567,7 @@ static bool generate_listbox(generate_gui_args_t&& args) {
 
 	GUIListBox* gui_listbox = nullptr;
 	bool ret = new_control(gui_listbox, listbox, args.name);
-	ERR_FAIL_NULL_V_MSG(gui_listbox, false, vformat("Failed to create GUIListBox for GUI listbox %s", listbox_name));
+	ERR_FAIL_NULL_V_MSG(gui_listbox, false, Utilities::format("Failed to create GUIListBox for GUI listbox %s", listbox_name));
 
 	if (gui_listbox->set_gui_listbox(&listbox) != OK) {
 		UtilityFunctions::push_error("Error initializing GUIListBox for GUI listbox ", listbox_name);
@@ -588,7 +588,7 @@ static bool generate_texteditbox(generate_gui_args_t&& args) {
 	LineEdit* godot_line_edit = nullptr;
 	bool ret = new_control(godot_line_edit, text_edit_box, args.name);
 	ERR_FAIL_NULL_V_MSG(
-		godot_line_edit, false, vformat("Failed to create LineEdit for GUI text edit box %s", text_edit_box_name)
+		godot_line_edit, false, Utilities::format("Failed to create LineEdit for GUI text edit box %s", text_edit_box_name)
 	);
 
 	godot_line_edit->set_context_menu_enabled(false);
@@ -665,7 +665,7 @@ static bool generate_scrollbar(generate_gui_args_t&& args) {
 
 	GUIScrollbar* gui_scrollbar = nullptr;
 	bool ret = new_control(gui_scrollbar, scrollbar, args.name);
-	ERR_FAIL_NULL_V_MSG(gui_scrollbar, false, vformat("Failed to create GUIScrollbar for GUI scrollbar %s", scrollbar_name));
+	ERR_FAIL_NULL_V_MSG(gui_scrollbar, false, Utilities::format("Failed to create GUIScrollbar for GUI scrollbar %s", scrollbar_name));
 
 	if (gui_scrollbar->set_gui_scrollbar(&scrollbar) != OK) {
 		UtilityFunctions::push_error("Error initializing GUIScrollbar for GUI scrollbar ", scrollbar_name);
@@ -689,7 +689,7 @@ static bool generate_window(generate_gui_args_t&& args) {
 
 	Panel* godot_panel = nullptr;
 	bool ret = new_control(godot_panel, window, args.name);
-	ERR_FAIL_NULL_V_MSG(godot_panel, false, vformat("Failed to create Panel for GUI window %s", window_name));
+	ERR_FAIL_NULL_V_MSG(godot_panel, false, Utilities::format("Failed to create Panel for GUI window %s", window_name));
 
 	if (window.get_fullscreen()) {
 		godot_panel->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
@@ -742,7 +742,7 @@ static bool generate_element(GUI::Element const* element, String const& name, As
 	const decltype(type_map)::const_iterator it = type_map.find(element->get_type());
 	ERR_FAIL_COND_V_MSG(
 		it == type_map.end(), false,
-		vformat("Invalid GUI element type: %s", Utilities::std_to_godot_string(element->get_type()))
+		Utilities::format("Invalid GUI element type: %s", Utilities::std_to_godot_string(element->get_type()))
 	);
 	return it->second({ *element, name, asset_manager, result });
 }

--- a/extension/src/openvic-extension/utility/Utilities.cpp
+++ b/extension/src/openvic-extension/utility/Utilities.cpp
@@ -127,7 +127,7 @@ String Utilities::fixed_point_to_string_dp(fixed_point_t val, int32_t decimal_pl
 }
 
 String Utilities::percentage_to_string_dp(fixed_point_t val, int32_t decimal_places) {
-	return godot::vformat(
+	return Utilities::format(
 		"%s%%",
 		Utilities::float_to_string_dp(
 			(100 * val).to_float(),
@@ -151,14 +151,14 @@ String Utilities::cash_to_string_dp_dynamic(fixed_point_t val) {
 
 String Utilities::format_with_currency(godot::String const& text) {
 	static const String currency_format = String::utf8("%s¤");
-	return godot::vformat(currency_format, text);
+	return Utilities::format(currency_format, text);
 }
 
 String Utilities::date_to_string(Date date) {
 	static const String date_template_string = String { "%d" } + Date::SEPARATOR_CHARACTER + "%d" +
 		Date::SEPARATOR_CHARACTER + "%d";
 
-	return vformat(date_template_string, date.get_year(), date.get_month(), date.get_day());
+	return Utilities::format(date_template_string, date.get_year(), date.get_month(), date.get_day());
 }
 
 /* Date formatted like one of these, with the month localised if possible:
@@ -188,13 +188,13 @@ Ref<Resource> Utilities::load_resource(String const& path, String const& type_hi
 
 static Ref<Image> load_dds_image(String const& path) {
 	gli::texture2d texture { gli::load_dds(Utilities::godot_to_std_string(path)) };
-	ERR_FAIL_COND_V_MSG(texture.empty(), nullptr, vformat("Failed to load DDS file: %s", path));
+	ERR_FAIL_COND_V_MSG(texture.empty(), nullptr, Utilities::format("Failed to load DDS file: %s", path));
 
 	static constexpr gli::format expected_format = gli::FORMAT_BGRA8_UNORM_PACK8;
 	const bool needs_bgr_to_rgb = texture.format() == expected_format;
 	if (!needs_bgr_to_rgb) {
 		texture = gli::convert(texture, expected_format);
-		ERR_FAIL_COND_V_MSG(texture.empty(), nullptr, vformat("Failed to convert DDS file: %s", path));
+		ERR_FAIL_COND_V_MSG(texture.empty(), nullptr, Utilities::format("Failed to convert DDS file: %s", path));
 	}
 
 	const gli::texture2d::extent_type extent { texture.extent() };
@@ -203,7 +203,7 @@ static Ref<Image> load_dds_image(String const& path) {
 	/* Only fail if there aren't enough bytes, everything seems to work fine if there are extra bytes and we ignore them */
 	ERR_FAIL_COND_V_MSG(
 		size > texture.size(), nullptr,
-		vformat("Texture size %d mismatched with dims-based size %d for %s", static_cast<int64_t>(texture.size()), size, path)
+		Utilities::format("Texture size %d mismatched with dims-based size %d for %s", static_cast<int64_t>(texture.size()), size, path)
 	);
 
 	PackedByteArray pixels;
@@ -233,7 +233,7 @@ Ref<FontFile> Utilities::load_godot_font(String const& fnt_path, Ref<Image> cons
 	ERR_FAIL_NULL_V(image, nullptr);
 	Ref<FontFile> font;
 	font.instantiate();
-	ERR_FAIL_COND_V_MSG(font->load_bitmap_font(fnt_path) != OK, nullptr, vformat("Failed to load font: %s", fnt_path));
+	ERR_FAIL_COND_V_MSG(font->load_bitmap_font(fnt_path) != OK, nullptr, Utilities::format("Failed to load font: %s", fnt_path));
 	font->set_texture_image(0, { font->get_fixed_size(), 0 }, 0, image);
 	return font;
 }
@@ -251,4 +251,11 @@ Ref<ImageTexture> Utilities::make_solid_colour_texture(Color const& colour, int3
 	const Ref<ImageTexture> result = ImageTexture::create_from_image(image);
 	ERR_FAIL_NULL_V(result, nullptr);
 	return result;
+}
+
+namespace OpenVic::Utilities {
+	thread_local memory::vector<godot::Array> _formatting_array_pool_1;
+	thread_local memory::vector<godot::Array> _formatting_array_pool_2;
+	thread_local memory::vector<godot::Array> _formatting_array_pool_3;
+	thread_local memory::vector<godot::Array> _formatting_array_pool_4;
 }


### PR DESCRIPTION
the godot engine has a cpp implementation that emulates the godot script features. One commonly used feature is string formatting. In godot script you can just use `%`. In godot-cpp you use `godot::vformat(template, ...)`.

The issue is this is implemented as follows:
```cpp
template <typename... VarArgs>
String vformat(const String &p_text, const VarArgs... p_args) {
    Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
    Array args_array;
    args_array.resize(sizeof...(p_args));
    for (uint32_t i = 0; i < sizeof...(p_args); i++) {
        args_array[i] = args[i];
    }

    return p_text % args_array;
}
```

So it creates a new array each invocation.
The array is always discarded afterwards, resulting in redundant allocations and deallocations.

Instead we should clear and reuse the array. To support multithreading, the reusable array must be thread local.
Since nesting could occur, we use a vector of reusable arrays.

Note that clearing the array would free the memory and resizing the array would reallocate memory. So resize is called once to set the array to the desired size and clear is avoided. Instead the array is filled with empty values. This is done to prevent references being kept alive by simply being in the pooled array.
