### PR TITLE
Use province index instead of province number in population_menu

### DIFF
--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -6,6 +6,7 @@
 
 #include <openvic-simulation/DefinitionManager.hpp>
 #include <openvic-simulation/InstanceManager.hpp>
+#include <openvic-simulation/map/ProvinceDefinition.hpp>
 #include <openvic-simulation/pop/Culture.hpp>
 #include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
 #include <openvic-simulation/types/IndexedFlatMap.hpp>
@@ -259,13 +260,14 @@ Error MenuSingleton::population_menu_select_province_list_entry(int32_t select_i
 }
 
 Error MenuSingleton::population_menu_select_province(int32_t province_number) {
+	const ProvinceDefinition::index_t province_index = ProvinceDefinition::get_index_from_province_number(province_number);
 	GameSingleton const* game_singleton = GameSingleton::get_singleton();
 	ERR_FAIL_NULL_V(game_singleton, FAILED);
 	InstanceManager const* instance_manager = game_singleton->get_instance_manager();
 	ERR_FAIL_NULL_V(instance_manager, FAILED);
 
 	ERR_FAIL_COND_V(
-		province_number <= 0 || province_number > instance_manager->get_map_instance().get_province_instance_by_definition().get_count(),
+		!instance_manager->get_map_instance().get_province_instance_by_definition().contains_index(province_index),
 		FAILED
 	);
 
@@ -273,7 +275,7 @@ Error MenuSingleton::population_menu_select_province(int32_t province_number) {
 
 		MenuSingleton& menu_singleton;
 
-		const int32_t _province_number = 0;
+		const ProvinceDefinition::index_t _province_index = 0;
 
 		int32_t index = 0;
 
@@ -297,7 +299,7 @@ Error MenuSingleton::population_menu_select_province(int32_t province_number) {
 		}
 
 		bool operator()(population_menu_t::province_entry_t& province_entry) {
-			if (province_entry.province.get_province_definition().get_province_number() == _province_number) {
+			if (province_entry.province.get_province_definition().get_index() == _province_index) {
 
 				if (state_entry_to_expand >= 0) {
 					ret &= menu_singleton.population_menu_toggle_expanded(state_entry_to_expand, false) == OK;
@@ -310,7 +312,7 @@ Error MenuSingleton::population_menu_select_province(int32_t province_number) {
 			return true;
 		}
 
-	} entry_visitor { *this, province_number };
+	} entry_visitor { *this, province_index };
 
 	while (entry_visitor.index < population_menu.province_list_entries.size()
 		&& std::visit(entry_visitor, population_menu.province_list_entries[entry_visitor.index])) {


### PR DESCRIPTION
The population menu should not be validating province number by value.
It should merely check whether the province number corresponds with a valid province.