### PR TITLE
Replace useless StringName construction with String

### DIFF
--- a/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
@@ -86,7 +86,7 @@ void BudgetMenu::update_projected_balance() {
 }
 
 void BudgetMenu::update_projected_expenses() {
-	static const godot::StringName projected_expenses_template = "%s\n--------------\n%s\n%s\n%s\n%s\n%s\n%s%s";
+	static const godot::String projected_expenses_template = "%s\n--------------\n%s\n%s\n%s\n%s\n%s\n%s%s";
 	const fixed_point_t projected_expenses =  administration_budget.get_expenses()
 		+ diplomatic_budget.get_expenses()
 		+ education_budget.get_expenses()
@@ -227,7 +227,7 @@ void BudgetMenu::update() {
 	);
 }
 
-godot::StringName BudgetMenu::generate_projected_income_template(const size_t tax_budgets_size) {
+godot::String BudgetMenu::generate_projected_income_template(const size_t tax_budgets_size) {
 	static const std::string_view projected_income_template_start = "%s\n--------------";
 	static const std::string_view projected_income_template_dynamic_part = "\n%s";
 
@@ -242,10 +242,7 @@ godot::StringName BudgetMenu::generate_projected_income_template(const size_t ta
 		projected_income_template.append(projected_income_template_dynamic_part);
 	}
 	projected_income_template += "\n%s\n%s\n%s%s";
-	return godot::StringName(
-		projected_income_template.data(),
-		false
-	);
+	return projected_income_template.data();
 }
 
 #undef DO_FOR_ALL_COMPONENTS

--- a/extension/src/openvic-extension/components/budget/BudgetMenu.hpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.hpp
@@ -21,9 +21,9 @@ namespace OpenVic {
 
 	struct BudgetMenu {
 	private:
-		static godot::StringName generate_projected_income_template(const size_t tax_budgets_size);
+		static godot::String generate_projected_income_template(const size_t tax_budgets_size);
 
-		const godot::StringName projected_income_template;
+		godot::String projected_income_template;
 		godot::Array projected_income_args;
 		godot::Array projected_expenses_args;
 		memory::vector<connection> connections;

--- a/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
@@ -40,10 +40,7 @@ StrataTaxBudget::StrataTaxBudget(
 		generate_slider_tooltip_localisation_key(new_strata),
 		Utilities::format(
 			"TAX_%s_DESC",
-			(godot::String::utf8(
-				strata.get_identifier().data(),
-				strata.get_identifier().length()
-			)).to_upper()
+			Utilities::std_to_godot_string(strata.get_identifier()).to_upper()
 		)
 	);
 }
@@ -73,23 +70,11 @@ void StrataTaxBudget::on_slider_value_changed(const fixed_point_t scaled_value) 
 }
 
 godot::StringName StrataTaxBudget::generate_slider_tooltip_localisation_key(Strata const& strata) {
-	const godot::StringName prefix = "BUDGET_TAX_";
-	godot::StringName localisation_key;
-	const godot::StringName strata_identifier = (godot::StringName(
-		strata.get_identifier().data(),
-		strata.get_identifier().length()
-	)).to_upper();
-	return prefix + strata_identifier;
+	return "BUDGET_TAX_" + Utilities::std_to_godot_string(strata.get_identifier()).to_upper();
 }
 
 godot::StringName StrataTaxBudget::generate_summary_localisation_key(Strata const& strata) {
-	return Utilities::format(
-		"TAXES_%s",
-		(godot::StringName(
-			strata.get_identifier().data(),
-			strata.get_identifier().length()
-		)).to_upper()
-	);
+	return "TAXES_" + Utilities::std_to_godot_string(strata.get_identifier()).to_upper();
 }
 
 void StrataTaxBudget::update_slider_tooltip(


### PR DESCRIPTION
This fixes the errors of unreferenced static string for strata names, eliminating the only errors in running OpenVic currently, neither StringNames nor Strings have a constructor that takes a length, when length was being called on StringNames it was just setting the static bool to true (unless it was empty) because of the implicit conversion of size_t to bool. StringName construction here also didn't make any sense anyway, it costed useless performance for no gain because it was then construction a StringName from a String that was was made from a StringName, and in other cases the construction of a StringName was completely useless because it was never consumed as a StringName.