### PR TITLE
Unlink BudgetMenu instances before one is invalidated

### DIFF
--- a/extension/doc_classes/MenuSingleton.xml
+++ b/extension/doc_classes/MenuSingleton.xml
@@ -255,6 +255,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="unlink_budget_menu_from_cpp">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="update_search_results">
 			<return type="void" />
 			<param index="0" name="text" type="String" />

--- a/extension/src/openvic-extension/singletons/MenuSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.hpp
@@ -287,6 +287,7 @@ namespace OpenVic {
 
 		/* BUDGET MENU */
 		void link_budget_menu_to_cpp(GUINode const* const godot_budget_menu);
+		void unlink_budget_menu_from_cpp();
 
 		/* Find/Search Panel */
 		// TODO - update on country government type change and state creation/destruction

--- a/game/src/UI/Session/BudgetMenu.gd
+++ b/game/src/UI/Session/BudgetMenu.gd
@@ -78,6 +78,11 @@ func _notification(what : int) -> void:
 	match what:
 		NOTIFICATION_TRANSLATION_CHANGED:
 			_update_info()
+		NOTIFICATION_PREDELETE:
+			# If the C++ BudgetMenu isn't freed before the destruction of this GUINode, then its update method, triggered by
+			# gamestate updates, could be called after all the child UI nodes they refer to have been freed,
+			# meaning the C++ BudgetMenu would be dereferencing invalid pointers.
+			MenuSingleton.unlink_budget_menu_from_cpp()
 
 func _on_update_active_nation_management_screen(active_screen : NationManagement.Screen) -> void:
 	_active = active_screen == SCREEN


### PR DESCRIPTION
Without this change the program often crashes after entering a game, resigning it and entering a new game