### PR TITLE
Reset PlayerSingleton after ending game instance

### DIFF
--- a/extension/doc_classes/PlayerSingleton.xml
+++ b/extension/doc_classes/PlayerSingleton.xml
@@ -39,6 +39,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="reset_player_singleton">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="set_auto_assign_leaders" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="value" type="bool" />

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -187,6 +187,7 @@ Error GameSingleton::start_game_session() {
 }
 
 Error GameSingleton::end_game_session() {
+	PlayerSingleton::get_singleton()->reset_player_singleton();
 	return ERR(game_manager.end_game_session());
 }
 

--- a/extension/src/openvic-extension/singletons/PlayerSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/PlayerSingleton.cpp
@@ -19,6 +19,8 @@ StringName const& PlayerSingleton::_signal_province_selected() {
 }
 
 void PlayerSingleton::_bind_methods() {
+	OV_BIND_METHOD(PlayerSingleton::reset_player_singleton);
+
 	// Player country
 	OV_BIND_METHOD(PlayerSingleton::set_player_country_by_province_number, { "province_number" });
 	OV_BIND_METHOD(PlayerSingleton::get_player_country_capital_position);
@@ -72,6 +74,14 @@ PlayerSingleton::PlayerSingleton() {
 PlayerSingleton::~PlayerSingleton() {
 	ERR_FAIL_COND(singleton != this);
 	singleton = nullptr;
+}
+
+void PlayerSingleton::reset_player_singleton() {
+	// This function is called when a game session ends, so we don't use functions like set_player_country or
+	// unset_selected_province here as they can dereference leftover pointers from the previous game session which
+	// are either already or soon to be invalid.
+	player_country = nullptr;
+	selected_province = nullptr;
 }
 
 // Player country

--- a/extension/src/openvic-extension/singletons/PlayerSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/PlayerSingleton.hpp
@@ -30,6 +30,8 @@ namespace OpenVic {
 		PlayerSingleton();
 		~PlayerSingleton();
 
+		void reset_player_singleton();
+
 		// Player country
 		[[nodiscard]] constexpr CountryInstance* get_player_country() {
 			return player_country;


### PR DESCRIPTION
Clear player country when finishing game session to prevent a dangling pointer