### PR TITLE
Call end game session

### DIFF
--- a/extension/doc_classes/GameSingleton.xml
+++ b/extension/doc_classes/GameSingleton.xml
@@ -8,6 +8,11 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="end_game_session">
+			<return type="int" enum="Error" />
+			<description>
+			</description>
+		</method>
 		<method name="get_bookmark_info" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
@@ -123,6 +128,21 @@
 			<return type="Texture2DArray" />
 			<description>
 				Return a [Texture2DArray] containing all terrain textures, both the solid blue generated water texture and the loaded land terrain textures.
+			</description>
+		</method>
+		<method name="is_bookmark_loaded" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="is_game_instance_setup" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="is_game_session_active" qualifiers="const">
+			<return type="bool" />
+			<description>
 			</description>
 		</method>
 		<method name="is_parchment_mapmode_allowed" qualifiers="const">

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -43,7 +43,12 @@ void GameSingleton::_bind_methods() {
 
 	OV_BIND_METHOD(GameSingleton::get_bookmark_info);
 	OV_BIND_METHOD(GameSingleton::setup_game, { "bookmark_index" });
+	OV_BIND_METHOD(GameSingleton::is_game_instance_setup);
+	OV_BIND_METHOD(GameSingleton::is_bookmark_loaded);
+
 	OV_BIND_METHOD(GameSingleton::start_game_session);
+	OV_BIND_METHOD(GameSingleton::end_game_session);
+	OV_BIND_METHOD(GameSingleton::is_game_session_active);
 
 	OV_BIND_METHOD(GameSingleton::get_province_number_from_uv_coords, { "coords" });
 
@@ -169,8 +174,24 @@ Error GameSingleton::setup_game(int32_t bookmark_index) {
 	return ERR(ret);
 }
 
+bool GameSingleton::is_game_instance_setup() const {
+	return game_manager.is_game_instance_setup();
+}
+
+bool GameSingleton::is_bookmark_loaded() const {
+	return game_manager.is_bookmark_loaded();
+}
+
 Error GameSingleton::start_game_session() {
 	return ERR(game_manager.start_game_session());
+}
+
+Error GameSingleton::end_game_session() {
+	return ERR(game_manager.end_game_session());
+}
+
+bool GameSingleton::is_game_session_active() const {
+	return game_manager.is_game_session_active();
 }
 
 int32_t GameSingleton::get_province_number_from_uv_coords(Vector2 const& coords) const {

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -76,9 +76,16 @@ namespace OpenVic {
 
 		godot::TypedArray<godot::Dictionary> get_bookmark_info() const;
 
-		/* Post-load/restart game setup - reset the game to post-load state and load the specified bookmark. */
+		/* After initial load or resigning a previous session game setup, all mutable components of the simulation
+		   are reset and reinitialised to their initial states, then updated by the history instructions of the
+		   chosen bookmark. */
 		godot::Error setup_game(int32_t bookmark_index);
+		bool is_game_instance_setup() const;
+		bool is_bookmark_loaded() const;
+
 		godot::Error start_game_session();
+		godot::Error end_game_session();
+		bool is_game_session_active() const;
 
 		int32_t get_province_number_from_uv_coords(godot::Vector2 const& coords) const;
 

--- a/game/src/Systems/Session/GameSession.gd
+++ b/game/src/Systems/Session/GameSession.gd
@@ -16,6 +16,12 @@ func _ready() -> void:
 	# In game, the province selector uses the normal glove cursor.
 	CursorManager.set_compat_cursor(&"normal", Input.CURSOR_IBEAM)
 
+func _notification(what : int) -> void:
+	match what:
+		NOTIFICATION_PREDELETE:
+			if GameSingleton.end_game_session() != OK:
+				push_error("Failed to end game session")
+
 func _process(_delta : float) -> void:
 	GameSingleton.update_clock()
 


### PR DESCRIPTION
Calls functions added in [SIM#567](https://github.com/OpenVicProject/OpenVic-Simulation/pull/567), specifically so that we can free game session data before returning to the main menu rather than leaving potentially invalidated stuff sitting there until a new game session is started.