### PR TITLE
UI for budget cuts

### DIFF
--- a/extension/src/openvic-extension/components/budget/AdministrationBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/AdministrationBudget.hpp
@@ -13,6 +13,8 @@ namespace OpenVic {
 		CountryDefines const& country_defines;
 		godot::Array administrative_efficiency_tooltip_args;
 		GUILabel& administrative_efficiency_label;
+
+		bool was_budget_cut(CountryInstance const& country) const override;
 		fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/EducationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/EducationBudget.cpp
@@ -5,6 +5,7 @@
 #include "openvic-extension/classes/GUILabel.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 #include "openvic-extension/singletons/PlayerSingleton.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;
 
@@ -27,26 +28,38 @@ EducationBudget::EducationBudget(GUINode const& parent):
 		parent, "./country_budget/education_desc",
 		"EDUCATION","EDU_DESC"
 	);
-
-	if (budget_label != nullptr) {
-		budget_label->set_tooltip_string(
-			Utilities::format(
-				"%s\n--------------\n%s",
-				budget_label->tr("DIST_EDUCATION"),
-				budget_label->tr("EDU_DESC")
-			)
-		);
-	}
 }
 
 fixed_point_t EducationBudget::get_expenses() const {
 	return std::max(fixed_point_t::_0, -get_balance());
 }
 
+bool EducationBudget::was_budget_cut(CountryInstance const& country) const {
+	return country.get_was_education_budget_cut_yesterday();
+}
+
 fixed_point_t EducationBudget::calculate_budget_and_update_custom(
 	CountryInstance& country,
 	const fixed_point_t scaled_value
 ) {
+	if (budget_label != nullptr) {
+		budget_label->set_tooltip_string(
+			Utilities::format(
+				"%s\n--------------\n%s%s",
+				budget_label->tr("DIST_EDUCATION"),
+				was_budget_cut(country)
+					? budget_label->tr("EXPENSE_NO_AFFORD").replace(
+						Utilities::get_short_value_placeholder(),
+						Utilities::float_to_string_dp_dynamic(
+							country.get_actual_education_spending().load()
+						)
+					) + "\n"
+					: "",
+				budget_label->tr("EDU_DESC")
+			)
+		);
+	}
+
 	return scaled_value * country.get_projected_education_spending_unscaled_by_slider_untracked();
 }
 

--- a/extension/src/openvic-extension/components/budget/EducationBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/EducationBudget.hpp
@@ -6,6 +6,7 @@
 namespace OpenVic {
 	struct EducationBudget : public SliderBudgetComponent, public BudgetExpenseComponent {
 	private:
+		bool was_budget_cut(CountryInstance const& country) const override;
 		fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/MilitaryBudget.cpp
@@ -5,6 +5,7 @@
 #include "openvic-extension/classes/GUILabel.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 #include "openvic-extension/singletons/PlayerSingleton.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;
 
@@ -27,26 +28,38 @@ MilitaryBudget::MilitaryBudget(GUINode const& parent):
 		parent, "./country_budget/mil_spend_desc",
 		"MILITARY_SPENDING","DEFENCE_DESC"
 	);
-
-	if (budget_label != nullptr) {
-		budget_label->set_tooltip_string(
-			Utilities::format(
-				"%s\n--------------\n%s",
-				budget_label->tr("DIST_DEFENCE"),
-				budget_label->tr("DEFENCE_DESC")
-			)
-		);
-	}
 }
 
 fixed_point_t MilitaryBudget::get_expenses() const {
 	return std::max(fixed_point_t::_0, -get_balance());
 }
 
+bool MilitaryBudget::was_budget_cut(CountryInstance const& country) const {
+	return country.get_was_military_budget_cut_yesterday();
+}
+
 fixed_point_t MilitaryBudget::calculate_budget_and_update_custom(
 	CountryInstance& country,
 	const fixed_point_t scaled_value
 ) {
+	if (budget_label != nullptr) {
+		budget_label->set_tooltip_string(
+			Utilities::format(
+				"%s\n--------------\n%s%s",
+				budget_label->tr("DIST_DEFENCE"),
+				was_budget_cut(country)
+					? budget_label->tr("EXPENSE_NO_AFFORD").replace(
+						Utilities::get_short_value_placeholder(),
+						Utilities::float_to_string_dp_dynamic(
+							country.get_actual_military_spending().load()
+						)
+					) + "\n"
+					: "",
+				budget_label->tr("DEFENCE_DESC")
+			)
+		);
+	}
+
 	return scaled_value * country.get_projected_military_spending_unscaled_by_slider_untracked();
 }
 

--- a/extension/src/openvic-extension/components/budget/MilitaryBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/MilitaryBudget.hpp
@@ -6,6 +6,7 @@
 namespace OpenVic {
 	struct MilitaryBudget : public SliderBudgetComponent, public BudgetExpenseComponent {
 	private:
+		bool was_budget_cut(CountryInstance const& country) const override;
 		fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/SocialBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/SocialBudget.cpp
@@ -7,6 +7,7 @@
 #include "openvic-extension/classes/GUINode.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 #include "openvic-extension/singletons/PlayerSingleton.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;
 
@@ -31,26 +32,39 @@ SocialBudget::SocialBudget(GUINode const& parent):
 		parent, "./country_budget/soc_stand_desc",
 		"SOCIAL_SPENDING","SOCIAL_DESC2"
 	);
-
-	if (budget_label != nullptr) {
-		budget_label->set_tooltip_string(
-			Utilities::format(
-				"%s\n--------------\n%s",
-				budget_label->tr("DIST_SOCIAL"),
-				budget_label->tr("SOCIAL_DESC2")
-			)
-		);
-	}
 }
 
 fixed_point_t SocialBudget::get_expenses() const {
 	return std::max(fixed_point_t::_0, -get_balance());
 }
 
+bool SocialBudget::was_budget_cut(CountryInstance const& country) const {
+	return country.get_was_social_budget_cut_yesterday();
+}
+
 fixed_point_t SocialBudget::calculate_budget_and_update_custom(
 	CountryInstance& country,
 	const fixed_point_t scaled_value
 ) {
+	if (budget_label != nullptr) {
+		budget_label->set_tooltip_string(
+			Utilities::format(
+				"%s\n--------------\n%s%s",
+				budget_label->tr("DIST_SOCIAL"),
+				was_budget_cut(country)
+					? budget_label->tr("EXPENSE_NO_AFFORD").replace(
+						Utilities::get_short_value_placeholder(),
+						Utilities::float_to_string_dp_dynamic(
+							country.get_actual_pensions_spending().load()
+							+ country.get_actual_unemployment_subsidies_spending().load()
+						)
+					) + "\n"
+					: "",
+				budget_label->tr("SOCIAL_DESC2")
+			)
+		);
+	}
+
 	const fixed_point_t pensions = scaled_value * country.get_projected_pensions_spending_unscaled_by_slider_untracked();
 	pensions_label.set_text(
 		Utilities::cash_to_string_dp_dynamic(pensions)

--- a/extension/src/openvic-extension/components/budget/SocialBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/SocialBudget.hpp
@@ -8,6 +8,8 @@ namespace OpenVic {
 	private:
 		GUILabel& pensions_label;
 		GUILabel& unemployment_subsidies_label;
+
+		bool was_budget_cut(CountryInstance const& country) const override;
 		fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/TariffBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/TariffBudget.cpp
@@ -54,6 +54,10 @@ fixed_point_t TariffBudget::get_income() const {
 	return std::max(fixed_point_t::_0, get_balance());
 }
 
+bool TariffBudget::was_budget_cut(CountryInstance const& country) const {
+	return country.get_was_import_subsidies_budget_cut_yesterday();
+}
+
 fixed_point_t TariffBudget::calculate_budget_and_update_custom(
 	CountryInstance& country,
 	const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/TariffBudget.hpp
+++ b/extension/src/openvic-extension/components/budget/TariffBudget.hpp
@@ -16,6 +16,7 @@ namespace OpenVic {
 	private:
 		godot::Array slider_tooltip_args;
 
+		bool was_budget_cut(CountryInstance const& country) const override;
 		fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value

--- a/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.cpp
@@ -8,6 +8,7 @@
 #include "openvic-extension/classes/GUINode.hpp"
 #include "openvic-extension/classes/GUIScrollbar.hpp"
 #include "openvic-extension/singletons/PlayerSingleton.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;
 
@@ -59,8 +60,11 @@ void SliderBudgetComponent::full_update(CountryInstance& country) {
 void SliderBudgetComponent::update_labels(CountryInstance& country, const fixed_point_t scaled_value) {
 	const fixed_point_t budget = calculate_budget_and_update_custom(country, scaled_value);
 	if (budget_label != nullptr) {
+		const godot::String budget_text = Utilities::cash_to_string_dp_dynamic(budget);
 		budget_label->set_text(
-			Utilities::cash_to_string_dp_dynamic(budget)
+			was_budget_cut(country)
+				? Utilities::format(godot::String::utf8("§R%s§W"), budget_text)
+				: budget_text
 		);
 	};
 

--- a/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.hpp
+++ b/extension/src/openvic-extension/components/budget/abstract/SliderBudgetComponent.hpp
@@ -38,6 +38,9 @@ namespace OpenVic {
 			godot::NodePath const& percent_label_path = {}
 		);
 
+		virtual bool was_budget_cut(CountryInstance const& country) const {
+			return false;
+		}
 		virtual fixed_point_t calculate_budget_and_update_custom(
 			CountryInstance& country,
 			const fixed_point_t scaled_value


### PR DESCRIPTION
When a budget was cut (see [CountryInstance::country_tick_before_map](https://github.com/OpenVicProject/OpenVic-Simulation/blob/master/src/openvic-simulation/country/CountryInstance.cpp#L1862)) the budget label turns red and the tooltip (if any) displays the actual spending.
<img width="392" height="209" alt="{97B65598-C6DC-4723-B36C-E272C531D24A}" src="https://github.com/user-attachments/assets/731c0e86-1756-424f-9c69-0bf264f60737" />

Should be compatible with #545 
