### PR TITLE
Reset colour instead of white

### DIFF
--- a/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/AdministrationBudget.cpp
@@ -84,7 +84,7 @@ fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
 	if (scaled_value == 0) {
 		administrative_efficiency_tooltip_args[2] = "";
 	} else {
-		static const godot::String admin_crime_template = godot::String::utf8("\n%s §Y%s%%§W %s");
+		static const godot::String admin_crime_template = godot::String::utf8("\n%s §Y%s%%§! %s");
 		const fixed_point_t admin_spending_crime_effect = country_defines.get_admin_spending_crimefight_percent();
 		administrative_efficiency_tooltip_args[2] = Utilities::format(
 			admin_crime_template,
@@ -126,7 +126,7 @@ fixed_point_t AdministrationBudget::calculate_budget_and_update_custom(
 			continue;
 		}
 		
-		static const godot::String reform_template = godot::String::utf8("\n%s: %s §Y+%s%%§W");
+		static const godot::String reform_template = godot::String::utf8("\n%s: %s §Y+%s%%§!");
 
 		const fixed_point_t extra_administrator_percentage = administrative_multiplier * country_defines.get_bureaucracy_percentage_increment();
 		reforms_part += Utilities::format(

--- a/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
+++ b/extension/src/openvic-extension/components/budget/BudgetMenu.cpp
@@ -78,7 +78,7 @@ void BudgetMenu::update_projected_balance() {
 
 	projected_balance_label.set_text(
 		Utilities::format(
-			godot::String::utf8("§%s%s§W"),
+			godot::String::utf8("§%s%s§!"),
 			Utilities::get_colour_and_sign(projected_balance),
 			Utilities::cash_to_string_dp_dynamic(projected_balance)
 		)

--- a/extension/src/openvic-extension/components/budget/DiplomaticBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/DiplomaticBudget.cpp
@@ -51,7 +51,7 @@ void DiplomaticBudget::full_update(CountryInstance& country) {
 
 	balance_label.set_text(
 		Utilities::format(
-			godot::String::utf8("§%s%s§W"),
+			godot::String::utf8("§%s%s§!"),
 			Utilities::get_colour_and_sign(diplomatic_balance),
 			Utilities::format_with_currency(
 				Utilities::float_to_string_dp(diplomatic_balance, decimal_places)

--- a/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/StrataTaxBudget.cpp
@@ -115,7 +115,7 @@ void StrataTaxBudget::update_slider_tooltip(
 	);
 
 	const godot::String tooltip = Utilities::format(
-		godot::String::utf8("%s: §Y%s§W\n%s\n%s\n%s"),
+		godot::String::utf8("%s: §Y%s§!\n%s\n%s\n%s"),
 		localised_strata_tax,
 		Utilities::percentage_to_string_dp(scaled_value, 1),
 		tax_efficiency_text,

--- a/extension/src/openvic-extension/components/overview/BudgetOverview.cpp
+++ b/extension/src/openvic-extension/components/overview/BudgetOverview.cpp
@@ -53,7 +53,7 @@ void BudgetOverview::update() {
 
 	funds_label.set_text(
 		Utilities::format(
-			godot::String::utf8("§Y%s§W (§%s%s§W)"),
+			godot::String::utf8("§Y%s§! (§%s%s§!)"),
 			Utilities::cash_to_string_dp_dynamic(cash),
 			Utilities::get_colour_and_sign(last_balance),
 			Utilities::cash_to_string_dp_dynamic(last_balance)
@@ -62,12 +62,12 @@ void BudgetOverview::update() {
 	funds_label.set_tooltip_string(
 		funds_label.tr("TOPBAR_FUNDS")
 			.replace("$YESTERDAY$", Utilities::format(
-					godot::String::utf8("§%s%s§W"),
+					godot::String::utf8("§%s%s§!"),
 					Utilities::get_colour_and_sign(last_balance),
 					Utilities::cash_to_string_dp_dynamic(last_balance)
 				))
 			.replace("$CASH$", Utilities::format(
-					godot::String::utf8("§Y%s§W"),
+					godot::String::utf8("§Y%s§!"),
 					Utilities::cash_to_string_dp_dynamic(cash)
 				))
 	);
@@ -75,12 +75,12 @@ void BudgetOverview::update() {
 		history_chart.tr("TOPBAR_HISTORICAL_INCOME")
 			.replace("$DAYS$", godot::String::num_int64(balance_history.size()))
 			.replace("$MAX$", Utilities::format(
-				godot::String::utf8("§%s%s§W"),
+				godot::String::utf8("§%s%s§!"),
 				Utilities::get_colour_and_sign(maximum_balance),
 				Utilities::cash_to_string_dp_dynamic(maximum_balance)
 			))
 			.replace("$MIN$", Utilities::format(
-				godot::String::utf8("§%s%s§W"),
+				godot::String::utf8("§%s%s§!"),
 				Utilities::get_colour_and_sign(minimum_balance),
 				Utilities::cash_to_string_dp_dynamic(minimum_balance)
 			))


### PR DESCRIPTION
`§W` switches the text colour to white.
`§!` resets it.
Often yellow, red or green text is desired.

`§Ytext§!` this makes `text` yellow and then resets the text colour.
`§Ytext§W` also makes `text` yellow but sets the text colour to white afterwards.