### PR TITLE
Actual stockpile spending UI

### DIFF
--- a/extension/src/openvic-extension/components/budget/NationalStockpileBudget.cpp
+++ b/extension/src/openvic-extension/components/budget/NationalStockpileBudget.cpp
@@ -4,11 +4,13 @@
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 
 #include <openvic-simulation/country/CountryInstance.hpp>
+#include <openvic-simulation/economy/GoodInstance.hpp>
 #include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
 
 #include "openvic-extension/classes/GUILabel.hpp"
 #include "openvic-extension/classes/GUINode.hpp"
 #include "openvic-extension/singletons/PlayerSingleton.hpp"
+#include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;
 
@@ -65,11 +67,45 @@ void NationalStockpileBudget::update_labels(CountryInstance& country) {
 	military_costs_label.set_text(
 		Utilities::cash_to_string_dp_dynamic(-military_balance)
 	);
+	const fixed_point_t actual_stockpile_spending = country.get_actual_national_stockpile_spending();
 	todays_actual_stockpile_spending_label.set_text(
-		Utilities::cash_to_string_dp_dynamic(2) //TODO
+		Utilities::cash_to_string_dp_dynamic(actual_stockpile_spending)
 	);
+
+	godot::String todays_actual_stockpile_spending_tooltip = todays_actual_stockpile_spending_label.tr("STOCKPILE_COST_ACTUAL");
+	if (actual_stockpile_spending > 0) {
+		todays_actual_stockpile_spending_tooltip += "\n"; //This is for a whiteline, not just a linebreak. Just like Victoria 2.
+
+		memory::vector<std::pair<GoodInstance const*, CountryInstance::good_data_t const*>> bought_goods {};
+		for (auto const& [good_instance, good_data] : country.get_goods_data()) {
+			if (good_data.money_traded_yesterday < 0) {
+				bought_goods.push_back({&good_instance, &good_data});
+			}
+		}
+
+		std::ranges::sort(
+			bought_goods, 
+			[](auto const& lhs, auto const& rhs) {
+				return lhs.second->money_traded_yesterday < rhs.second->money_traded_yesterday;
+			}
+		);
+
+		for (auto const& [good_instance_ptr, good_data_ptr] : bought_goods) {
+			GoodInstance const& good_instance = *good_instance_ptr;
+			CountryInstance::good_data_t const& good_data = *good_data_ptr;
+			todays_actual_stockpile_spending_tooltip += Utilities::format(
+				godot::String::utf8("\n %s: §R%s§! (%s)"),
+				todays_actual_stockpile_spending_label.tr(Utilities::std_to_godot_string(good_instance.get_identifier())),
+				Utilities::cash_to_string_dp_dynamic(-good_data.money_traded_yesterday),
+				Utilities::float_to_string_dp_dynamic(good_data.quantity_traded_yesterday)
+			);
+		}
+	}
+
+	todays_actual_stockpile_spending_label.set_tooltip_string(todays_actual_stockpile_spending_tooltip);
+
 	overseas_costs_label.set_text(
-		Utilities::cash_to_string_dp_dynamic(3) //TODO
+		Utilities::cash_to_string_dp_dynamic(0) //TODO
 	);
 	expenses_label.set_text(
 		Utilities::cash_to_string_dp_dynamic(-balance)


### PR DESCRIPTION
Sets the text and tooltip for the actual spending label.
<img width="228" height="291" alt="{FB283352-392F-4170-ADAD-09146B088425}" src="https://github.com/user-attachments/assets/8a3d6920-c0ca-4152-b8ed-2cd3f866eed4" />
