### PR TITLE
Fix budget elements with tooltips halting mouse clicks

### DIFF
--- a/extension/src/openvic-extension/components/overview/BudgetOverview.cpp
+++ b/extension/src/openvic-extension/components/overview/BudgetOverview.cpp
@@ -13,7 +13,11 @@ using namespace OpenVic;
 BudgetOverview::BudgetOverview(GUINode const& parent):
 funds_label{*parent.get_gui_label_from_nodepath("./topbar/budget_funds")},
 history_chart{*parent.get_gui_line_chart_from_nodepath("./topbar/budget_linechart")}
-{}
+{
+	godot::Control* node = parent.get_node<godot::Control>("./topbar/topbarbutton_budget");
+	funds_label.reparent(node);
+	history_chart.reparent(node);
+}
 
 void BudgetOverview::update() {
 	GameSingleton& game_singleton = *GameSingleton::get_singleton();


### PR DESCRIPTION
This fixes the issue where the linechart and label with tooltips will prevent the budget button from being clickable.