### PR TITLE
Bugfix: divide by zero in GUIScrollbar::set_gui_scrollbar

### DIFF
--- a/extension/src/openvic-extension/classes/GUIScrollbar.cpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.cpp
@@ -1,5 +1,6 @@
 #include "GUIScrollbar.hpp"
 
+#include <cassert>
 #include <cstdint>
 
 #include <godot_cpp/classes/global_constants.hpp>
@@ -433,10 +434,13 @@ Error GUIScrollbar::set_gui_scrollbar(GUI::Scrollbar const* new_gui_scrollbar) {
 	_calculate_rects();
 
 	auto adjust_for_min_and_step_size = [
-		min_value = gui_scrollbar->get_min_value().truncate<int32_t>(),
-		step_size = gui_scrollbar->get_step_size().truncate<int32_t>()
+		min_value = gui_scrollbar->get_min_value(),
+		step_size = gui_scrollbar->get_step_size()
 	](const int32_t val)->int32_t {
-		return (val - min_value) / step_size;
+		assert(step_size != 0);
+		return (
+			(val - min_value) / step_size
+		).truncate<int32_t>();
 	};
 
 	const bool was_blocking_signals = is_blocking_signals();


### PR DESCRIPTION
The code does `(val - min_value) / step_size`.
If step_size is truncated to int, this can become 0, causing a runtime divide by zero crash.

To remedy this, the math is performed using fixed_point_t and the result is truncated to an int32.
Also I added an assert to help if this occurs again.