### PR TITLE
Limit .gitignore of build directory to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ bin/*
 compile_commands.json
 
 # Out-of-source build directory
-build/
+/build/
 
 # ccls
 .ccls-cache


### PR DESCRIPTION
- Waiting on OpenVicProject/OpenVic-Simulation#765 

VSCode uses .gitignore to hide directories, without this change this includes `scripts/build`, making it impossible to open or search the directory inside VSCode.