### PR TITLE
Update .editorconfig formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,15 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+indent_size = 4
 indent_style = tab
 insert_final_newline = true
-
-[*.{cpp,hpp,c,h,mm}]
+max_line_length = 120
 trim_trailing_whitespace = true
-indent_size = 4
+
+[{*.py,SConstruct,SCsub}]
+indent_style = space
+
+[{*.{yml,yaml},.clang{-format,-tidy,d}}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Refine project .editorconfig:
- Set default indent_size=4, max_line_length=120, and trim_trailing_whitespace
- Add per-file overrides (spaces for Python, SConstruct/SCsub; 2-space indentation for YAML and clang-format/tidy files)
- Ensure file ends with newline.