### PR TITLE
Add nightly releases

### DIFF
--- a/.github/actions/godot-env/action.yml
+++ b/.github/actions/godot-env/action.yml
@@ -1,0 +1,120 @@
+name: Setup Godot variables
+description: Setup Godot variables for OpenVic
+
+inputs:
+  godot-src-url:
+    description: Source URL to create Linux and Template URLs from
+    default: https://github.com/godotengine/godot
+  godot-version:
+    description: Version of Godot
+    default: "4.6"
+  godot-version-type:
+    description: Type of Version of Godot
+    default: stable
+
+outputs:
+  godot-linux-url:
+    description: The Linux Headless URL of Godot that was generated.
+    value: ${{ steps.variables.outputs.godot-linux-url }}
+  godot-template-url:
+    description: The link to the `.tpz` archive of export templates that was generated.
+    value: ${{ steps.variables.outputs.godot-template-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup variables
+      id: variables
+      shell: bash
+      env:
+        INPUTS_GODOT_URL_SRC: ${{ inputs.godot-src-url }}
+        INPUTS_GODOT_VERSION: ${{ inputs.godot-version }}
+        INPUTS_GODOT_VERSION_TYPE: ${{ inputs.godot-version-type }}
+      run: |
+        EXIT_STATUS=0
+
+        # returns $1 and $2 joined together with a single '/''
+        JOIN_PATH_RESULT=""
+        join_path() {
+            JOIN_PATH_RESULT=$1
+            if [[ $JOIN_PATH_RESULT == *"/" && $2 == "/"* ]]; then
+                JOIN_PATH_RESULT=${JOIN_PATH_RESULT%/}
+            fi
+            if [[ $JOIN_PATH_RESULT != *"/" && $2 != "/"* ]]; then
+                JOIN_PATH_RESULT="$JOIN_PATH_RESULT/"
+            fi
+            JOIN_PATH_RESULT="$JOIN_PATH_RESULT$2"
+        }
+
+        validate_url() {
+          if [[ $1 == "" ]]; then
+            echo "::error::${2:-parameter} environment variable has not been set."
+            EXIT_STATUS=1
+            false
+            return
+          elif ! curl -o /dev/null --head --silent --fail "$1"; then
+            echo "::error::curl could not find ${2:-parameter}."
+            EXIT_STATUS=1
+            false
+            return
+          fi
+        }
+
+        validate_url "$INPUTS_GODOT_URL_SRC" "inputs.godot-src-url"
+
+        echo "GODOT_URL_SRC=$INPUTS_GODOT_URL_SRC" >> "$GITHUB_ENV"
+        echo "GODOT_VERSION=$INPUTS_GODOT_VERSION" >> "$GITHUB_ENV"
+        echo "GODOT_VERSION_TYPE=$INPUTS_GODOT_VERSION_TYPE" >> "$GITHUB_ENV"
+
+        GODOT_FILE_PREFIX="Godot_v${INPUTS_GODOT_VERSION}-${INPUTS_GODOT_VERSION_TYPE}"
+        GODOT_LINUX_FILENAME="${GODOT_FILE_PREFIX}_linux.x86_64.zip"
+        GODOT_TEMPLATE_FILENAME="${GODOT_FILE_PREFIX}_export_templates.tpz"
+
+        # Checks if tuxfamily godot download url
+        if [[ $INPUTS_GODOT_URL_SRC == *"downloads.tuxfamily.org/godotengine"* ]]; then
+            if [[ $INPUTS_GODOT_URL_SRC != *"$INPUTS_GODOT_VERSION"* ]]; then
+                join_path "$INPUTS_GODOT_URL_SRC" "$INPUTS_GODOT_VERSION"
+                INPUTS_GODOT_URL_SRC="$JOIN_PATH_RESULT"
+            fi
+
+            if [[ $INPUTS_GODOT_VERSION_TYPE != "stable" ]]; then
+              join_path "$INPUTS_GODOT_URL_SRC" "$INPUTS_GODOT_VERSION_TYPE"
+              INPUTS_GODOT_URL_SRC="$JOIN_PATH_RESULT"
+            fi
+
+            join_path "$INPUTS_GODOT_URL_SRC" "$GODOT_LINUX_FILENAME"
+            GODOT_LINUX_URL="$JOIN_PATH_RESULT"
+
+            join_path "$INPUTS_GODOT_URL_SRC" "$GODOT_TEMPLATE_FILENAME"
+            GODOT_TEMPLATE_URL="$JOIN_PATH_RESULT"
+
+        # Checks if github godot download url
+        elif [[ $INPUTS_GODOT_URL_SRC == *"github.com/godotengine"* ]]; then
+          if [[ $INPUTS_GODOT_URL_SRC != *"/releases"* ]]; then
+            join_path "$INPUTS_GODOT_URL_SRC" "releases"
+            INPUTS_GODOT_URL_SRC="$JOIN_PATH_RESULT"
+          fi
+
+          if [[ $INPUTS_GODOT_URL_SRC != *"/download"* ]]; then
+            join_path "$INPUTS_GODOT_URL_SRC" "download"
+            INPUTS_GODOT_URL_SRC="$JOIN_PATH_RESULT"
+          fi
+
+          GODOT_VERSION_DIR="${INPUTS_GODOT_VERSION}-${INPUTS_GODOT_VERSION_TYPE}"
+
+          join_path "$GODOT_VERSION_DIR" "$GODOT_LINUX_FILENAME"
+          join_path "$INPUTS_GODOT_URL_SRC" "$JOIN_PATH_RESULT"
+          GODOT_LINUX_URL="$JOIN_PATH_RESULT"
+
+          join_path "$GODOT_VERSION_DIR" "$GODOT_TEMPLATE_FILENAME"
+          join_path "$INPUTS_GODOT_URL_SRC" "$JOIN_PATH_RESULT"
+          GODOT_TEMPLATE_URL="$JOIN_PATH_RESULT"
+        fi
+
+        validate_url "$GODOT_LINUX_URL" "GODOT_LINUX_URL"
+        echo "godot-linux-url=$GODOT_LINUX_URL" >> $GITHUB_OUTPUT
+
+        validate_url "$GODOT_TEMPLATE_URL" "GODOT_TEMPLATE_URL"
+        echo "godot-template-url=$GODOT_TEMPLATE_URL" >> $GITHUB_OUTPUT
+
+        exit $EXIT_STATUS

--- a/.github/actions/openvic-build/action.yml
+++ b/.github/actions/openvic-build/action.yml
@@ -1,0 +1,99 @@
+name: Build OpenVic
+description: Setup and Build OpenVic with the provided options
+
+inputs:
+  identifier:
+    description: Identifier of this build
+  target:
+    description: Target type to build for
+    required: true
+  platform:
+    description: Platform to build for
+    required: true
+  arch:
+    description: Architecture to build for
+    required: true
+  scons-flags:
+    description: Additional flags to send to SCons
+    default: ''
+  cache-base-branch:
+    description: Branch to base the cache upon
+    default: 'master'
+  disable-cache:
+    description: Whether to disable the build cache
+    default: 'false'
+  tag-name:
+    description: Name of tag
+    default: ''
+  release-name:
+    description: Name of release
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup build cache
+      uses: OpenVicProject/openvic-cache@master
+      if: ${{ inputs.disable-cache != 'true' }}
+      with:
+        cache-name: ${{ inputs.identifier }}
+        base-branch: ${{ inputs.cache-base-branch }}
+      continue-on-error: true
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.x"
+
+    - name: Set up SCons
+      shell: bash
+      run: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install scons
+        scons --version
+
+    - name: Install APT dependencies
+      if: ${{ inputs.platform == 'linux' }}
+      uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+      with:
+        packages: build-essential pkg-config libtbb-dev
+
+    - name: Install and Set g++ to version 13
+      if: ${{ inputs.platform == 'linux' }}
+      shell: sh
+      run: |
+        g++ --version
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo apt update -y
+        sudo apt install g++-13
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
+        sudo update-alternatives --set g++ /usr/bin/g++-13
+        g++ --version
+
+    - name: Setup MinGW for Windows/MinGW build
+      if: ${{ inputs.platform == 'windows' }}
+      uses: egor-tensin/setup-mingw@ef0952fadae6794e225c0c1654887408bcadbf64
+
+    - name: Compile with SCons
+      uses: OpenVicProject/openvic-build@master
+      env:
+        OPENVIC_TAG: ${{ inputs.tag-name }}
+        OPENVIC_RELEASE: ${{ inputs.release-name }}
+      with:
+        platform: ${{ inputs.platform }}
+        target: ${{ inputs.target }}
+        bin-dir: "game/bin/"
+        sconsflags: arch=${{ inputs.arch }} ${{ inputs.scons-flags }}
+
+    - name: Delete compilation files
+      if: ${{ inputs.platform == 'windows' }}
+      shell: pwsh
+      run: |
+        Remove-Item game/bin/openvic/* -Include *.exp,*.lib,*.pdb -Force
+
+    - name: Upload extension artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ github.event.repository.name }}-${{ inputs.identifier }}-extension
+        path: |
+          ${{ github.workspace }}/game/bin/openvic/*

--- a/.github/actions/openvic-export/action.yml
+++ b/.github/actions/openvic-export/action.yml
@@ -1,0 +1,70 @@
+name: Export OpenVic
+description: Setup and Export OpenVic with the provided options
+
+inputs:
+  godot-executable-url:
+    description: The Linux Headless version of Godot that you want to use to export your project.
+    required: true
+  godot-templates-url:
+    description: The link to the `.tpz` archive of export templates.
+    required: true
+  export-as-pack:
+    description: Export project files as a .pck file.
+    default: "false"
+  export-debug:
+    description: Export builds in debug mode.
+    default: "false"
+  relative-export-path:
+    description: Move exports to the provided directory relative to the root of the Git repository.
+    default: ""
+  archive-output:
+    description: Archive each export into a .zip file.
+    default: "false"
+
+outputs:
+  build-directory:
+    description: ""
+    value: ${{ steps.export_game.outputs.build_directory }}
+  archive-directory:
+    description: ""
+    value: ${{ steps.export_game.outputs.archive_directory }}
+  executable-path:
+    description: ""
+    value: ${{ steps.export_game.outputs.executable_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        path: game/bin/openvic
+        pattern: ${{ github.event.repository.name }}-*-extension
+        merge-multiple: true
+
+    - name: Export game project
+      id: export_game
+      uses: Spartan322/godot-export@385faf3b35630a777cb44b8436a09fa0c5632dea
+      with:
+        godot_executable_download_url: ${{ inputs.godot-executable-url }}
+        godot_export_templates_download_url: ${{ inputs.godot-templates-url }}
+        relative_project_path: ./game
+        export_as_pack: ${{ inputs.export-as-pack == 'true' }}
+        export_debug: ${{ inputs.export-debug == 'true' }}
+        archive_output: ${{ inputs.archive-output == 'true' }}
+        cache: true
+        relative_export_path: ${{ inputs.relative-export-path }}
+
+    - name: Move pck file
+      if: inputs.export-debug == 'true' && inputs.export-as-pack == 'true'
+      shell: sh
+      run: mv "./game/export/LinuxX11 x86_64/OpenVic.x86_64.pck" "./game/export/$(basename "$GITHUB_REPOSITORY").pck"
+
+    - name: Upload pck artifact
+      if: inputs.export-debug == 'true' && inputs.export-as-pack == 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ github.event.repository.name }}-debug-pck
+        compression-level: 9
+        path: |
+          ${{inputs.relative-export-path}}/${{ github.event.repository.name }}.pck

--- a/.github/actions/openvic-release/action.yml
+++ b/.github/actions/openvic-release/action.yml
@@ -1,0 +1,308 @@
+name: Release OpenVic
+description: Setup, Build, and Release OpenVic
+
+inputs:
+  tag-name:
+    description: "Name to assign to the tag (default: github.ref)"
+    default: ${{ github.ref }}
+  target-repo:
+    description: Repository to publish this release to
+    default: "OpenVic"
+  to-ref:
+    description: "Tag/Commit to publish this release to (default: github.ref)"
+    default: ${{ github.ref }}
+  from-ref:
+    description: Tag/Commit to source the release notes from
+    required: true
+  from-tag:
+    description: "Tag name being sourced from (default: from-ref)"
+    default: ""
+  nightly-release:
+    description: Whether the release is a nightly build
+    default: "false"
+  snapshot-release:
+    description: Whether the release is a snapshot release
+    default: "false"
+  latest:
+    description: Latest
+    default: "false"
+  prerelease:
+    description: Pre-release
+    required: true
+  src-token:
+    description: Github token for source repository
+    required: true
+  target-token:
+    description: Github token for target repository
+    default: ""
+  release-name:
+    description: Name of release
+    default: ""
+  godot-executable-url:
+    description: The Linux Headless version of Godot that you want to use to export your project.
+    required: true
+  godot-templates-url:
+    description: The link to the `.tpz` archive of export templates.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup regex variables
+      shell: bash
+      run: |
+        echo "SEMVER_REGEX=^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})(-(alpha|beta|rc)\.([1-9][0-9]*))?$" >> $GITHUB_ENV
+        echo "SEMVER_SNAPSHOT_REGEX=^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})-(snapshot|snapshot\.dev)\.([1-9][0-9]*)\+([0-9a-fA-F]{40})$" >> $GITHUB_ENV
+        echo "SEMVER_NIGHTLY_REGEX=^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})-(nightly\.([1-9]([0-9]){3})\.(([0-9]){2})\.(([0-9]){2}))\+([0-9a-fA-F]{40})$" >> $GITHUB_ENV
+        echo "SHA_REGEX=^[0-9a-fA-F]{40}$" >> $GITHUB_ENV
+
+    - name: Validate input values
+      shell: bash
+      env:
+        INPUTS_TAG_NAME: ${{ inputs.tag-name }}
+        INPUTS_TARGET_REPO: ${{ inputs.target-repo }}
+        INPUTS_TO_REF: ${{ inputs.to-ref }}
+        INPUTS_FROM_REF: ${{ inputs.from-ref }}
+        INPUTS_FROM_TAG: ${{ inputs.from-tag }}
+        INPUTS_NIGHTLY_RELEASE: ${{ inputs.nightly-release }}
+        INPUTS_SNAPSHOT_RELEASE: ${{ inputs.snapshot-release }}
+        INPUTS_LATEST: ${{ inputs.latest }}
+        INPUTS_PRERELEASE: ${{ inputs.prerelease }}
+        INPUTS_SRC_TOKEN: ${{ inputs.src-token }}
+        INPUTS_TARGET_TOKEN: ${{ inputs.target-token }}
+      run: |
+        # Can report error for every validation check
+        EXIT_STATUS=0
+
+        validate_non_empty () {
+          [[ -n ${1-} ]] && return
+          echo "::error::${2-parameter} is empty."
+          EXIT_STATUS=1
+          false
+        }
+
+        validate_semver () {
+          if validate_non_empty "$1" "${2-}"; then
+            [[ ${1-} =~ $SEMVER_REGEX ]] && return
+            [[ ${1-} =~ $SEMVER_SNAPSHOT_REGEX ]] && return
+            [[ ${1-} =~ $SEMVER_NIGHTLY_REGEX ]] && return
+          fi
+
+          if [[ -n ${2-} ]]; then
+            echo "::error::$2 is not a valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', 'snapshot.dev', and 'nightly'. A count value must follow all but 'nightly' prerelease tags, starting from 1. 'nightly' must include the date in YYYY.MM.DD format. 'snapshot', 'snapshot.dev', 'nightly' must include the full commit SHA as a build string."
+            EXIT_STATUS=1
+          fi
+          false
+        }
+
+        validate_ref () {
+          local VALUE=${1#'refs/tags/'}
+
+          if validate_non_empty "$VALUE" "${2-}"; then
+            validate_semver "$VALUE" && return
+            [[ ${VALUE:-} =~ $SHA_REGEX ]] && return
+          fi
+
+          echo "::error::${2-parameter} is not a git commit SHA or valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', 'snapshot.dev', and 'nightly'. A count value must follow all but 'nightly' prerelease tags, starting from 1. 'nightly' must include the date in YYYY.MM.DD format. 'snapshot', 'snapshot.dev', 'nightly' must include the full commit SHA as a build string."
+          EXIT_STATUS=1
+          false
+        }
+
+        if [[ $INPUTS_TAG_NAME == refs/tags/* ]]; then
+          INPUTS_TAG_NAME=${INPUTS_TAG_NAME#'refs/tags/'}
+        fi
+
+        validate_semver "$INPUTS_TAG_NAME" "inputs.tag-name"
+
+        if [[ "$GITHUB_REPOSITORY_OWNER/$INPUTS_TARGET_REPO" != $GITHUB_REPOSITORY ]]; then
+          if ! validate_non_empty "$INPUTS_TARGET_REPO" "inputs.target-repo" && [[ -z $INPUTS_TARGET_TOKEN ]]; then
+            echo "::error::inputs.target-repo is set to a different repository and the inputs.target-token is not set."
+            EXIT_STATUS=1
+          fi
+        fi
+
+        validate_ref "$INPUTS_TO_REF" "inputs.to-ref"
+
+        validate_ref "$INPUTS_FROM_REF" "inputs.from-ref"
+
+        if [[ -n $INPUTS_FROM_TAG ]]; then
+          validate_ref "$INPUTS_FROM_TAG" "inputs.from-tag"
+        fi
+
+        validate_non_empty "$INPUTS_SRC_TOKEN" "inputs.src-token"
+
+        exit $EXIT_STATUS
+
+    - name: Copy src-token to env.TARGET_TOKEN
+      if: format('{0}/{1}', github.repository_owner, inputs.target-repo) == github.repository
+      shell: bash
+      env:
+        INPUTS_SRC_TOKEN: ${{ inputs.src-token }}
+      run: echo "TARGET_TOKEN=$INPUTS_SRC_TOKEN" >> $GITHUB_ENV
+
+    - name: Copy target-token to env.TARGET_TOKEN
+      if: format('{0}/{1}', github.repository_owner, inputs.target-repo) != github.repository
+      shell: bash
+      env:
+        INPUTS_TARGET_TOKEN: ${{ inputs.target-token }}
+      run: echo "TARGET_TOKEN=$INPUTS_TARGET_TOKEN" >> $GITHUB_ENV
+
+    - name: Set TO_TAG from to-ref
+      if: inputs.tag-name == inputs.to-ref
+      shell: bash
+      env:
+        INPUTS_TO_REF: ${{ inputs.to-ref }}
+      run: echo "TO_TAG=${INPUTS_TO_REF#'refs/tags/'}" >> $GITHUB_ENV
+
+    - name: Set TO_TAG from tag-name
+      if: inputs.tag-name != inputs.to-ref
+      shell: bash
+      env:
+        INPUTS_TAG_NAME: ${{ inputs.tag-name }}
+      run: echo "TO_TAG=$INPUTS_TAG_NAME" >> $GITHUB_ENV
+
+    - name: Build Release Notes
+      if: inputs.snapshot-release == 'false' && inputs.nightly-release == 'false'
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
+      env:
+        GITHUB_TOKEN: ${{ inputs.src-token }}
+      with:
+        configuration: "${{ github.action_path }}/release-notes-configuration.json"
+        toTag: ${{ inputs.tag-name == inputs.to-ref && env.TO_TAG || inputs.to-ref }}
+        fromTag: ${{ inputs.from-ref }}
+        outputFile: release-notes.md
+
+    - name: Build Snapshot Release Notes
+      if: inputs.snapshot-release == 'true' && inputs.nightly-release == 'false'
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
+      env:
+        GITHUB_TOKEN: ${{ inputs.src-token }}
+      with:
+        configuration: "${{ github.action_path }}/snapshot-release-notes-configuration.json"
+        toTag: ${{ inputs.tag-name == inputs.to-ref && env.TO_TAG || inputs.to-ref }}
+        fromTag: ${{ inputs.from-ref }}
+        outputFile: release-notes.md
+
+    - name: Build Nightly Release Notes
+      if: inputs.nightly-release == 'true' && inputs.snapshot-release == 'false'
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
+      env:
+        GITHUB_TOKEN: ${{ inputs.src-token }}
+      with:
+        configuration: "${{ github.action_path }}/nightly-release-notes-configuration.json"
+        toTag: ${{ inputs.tag-name == inputs.to-ref && env.TO_TAG || inputs.to-ref }}
+        fromTag: ${{ inputs.from-ref }}
+        outputFile: release-notes.md
+
+    - name: Create release tag and name and set release name in release-notes.md
+      shell: bash
+      env:
+        INPUTS_RELEASE_NAME: ${{ inputs.release-name }}
+        INPUTS_FROM_TAG_OR_FROM_REF: ${{ inputs.from-tag || inputs.from-ref }}
+      run: |
+        if [[ $TO_TAG =~ $SEMVER_REGEX ]]; then
+          PRERELEASE_TYPE=${BASH_REMATCH[6]}
+          PRERELEASE_VERSION=${BASH_REMATCH[7]}
+
+          if [[ $PRERELEASE_TYPE == 'rc' ]]; then
+            PRERELEASE_NAME="Release Candidate"
+          else
+            PRERELEASE_NAME=${PRERELEASE_TYPE@u}
+          fi
+
+          PRERELEASE_VERSION_DATE=$PRERELEASE_VERSION
+        elif [[ $TO_TAG =~ $SEMVER_SNAPSHOT_REGEX ]]; then
+          PRERELEASE_TYPE=${BASH_REMATCH[5]}
+          PRERELEASE_VERSION=${BASH_REMATCH[6]}
+          PRERELEASE_HASH=${BASH_REMATCH[7]}
+
+          if [[ $PRERELEASE_TYPE == 'snapshot.dev' ]]; then
+            PRERELEASE_NAME="Dev Snapshot"
+          else
+            PRERELEASE_NAME=${PRERELEASE_TYPE@u}
+          fi
+
+          PRERELEASE_VERSION_DATE=$PRERELEASE_VERSION
+        elif [[ $TO_TAG =~ $SEMVER_NIGHTLY_REGEX ]]; then
+          PRERELEASE_TYPE=nightly
+          PRERELEASE_YEAR=${BASH_REMATCH[6]}
+          PRERELEASE_MONTH=${BASH_REMATCH[8]}
+          PRERELEASE_DAY=${BASH_REMATCH[10]}
+          PRERELEASE_HASH=${BASH_REMATCH[12]}
+          PRERELEASE_NAME=${PRERELEASE_TYPE@u}
+
+          PRERELEASE_VERSION_DATE="$PRERELEASE_YEAR.$PRERELEASE_MONTH.$PRERELEASE_DAY"
+        fi
+
+        VERSION_CORE="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+
+        RELEASE_VERSION_INFO="$(xargs <<< "$VERSION_CORE $PRERELEASE_NAME $PRERELEASE_VERSION_DATE")"
+        RELEASE_NAME="$RELEASE_VERSION_INFO"
+        FULL_RELEASE_NAME="$(basename "$GITHUB_REPOSITORY") $RELEASE_NAME"
+
+        if [[ -n $INPUTS_RELEASE_NAME ]]; then
+          RELEASE_NAME="$INPUTS_RELEASE_NAME"
+          FULL_RELEASE_NAME="$(basename "$GITHUB_REPOSITORY") $INPUTS_RELEASE_NAME ($RELEASE_VERSION_INFO)"
+        fi
+
+        echo "FULL_RELEASE_NAME=$FULL_RELEASE_NAME" >> $GITHUB_ENV
+        echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_ENV
+
+        # Keep up to date with .github/actions/openvic-release release-notes configs
+        sed -i "s/<<RELEASE_NAME_REPLACEMENT>>/$FULL_RELEASE_NAME/g" release-notes.md
+        sed -i "s/<<FROM_TAG_NAME_REPLACEMENT>>/$INPUTS_FROM_TAG_OR_FROM_REF/g" release-notes.md
+
+        if [[ $INPUTS_FROM_TAG_OR_FROM_REF =~ $SHA_REGEX ]]; then
+          RELEASE_OR_COMMIT_PATH=commit
+        else
+          RELEASE_OR_COMMIT_PATH=releases\\/tag
+        fi
+
+        sed -i "s/<<RELEASE_OR_COMMIT_PATH>>/$RELEASE_OR_COMMIT_PATH/g" release-notes.md
+
+    - name: Replace <<REPO>> in release-notes.md
+      shell: bash
+      run: sed -i "s/<<REPO>>/$(sed 's;\/;\\\/;g' <<< "$GITHUB_REPOSITORY")/g" release-notes.md
+
+    - name: Make library directory
+      shell: sh
+      run: mkdir "$GITHUB_WORKSPACE/library/"
+
+    - name: Download extension assets
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        path: game/bin/openvic
+        pattern: ${{ github.event.repository.name }}-*-extension
+        merge-multiple: true
+
+    - name: Export game
+      id: export_game
+      uses: ./.github/actions/openvic-export
+      with:
+        godot-executable-url: ${{ inputs.godot-executable-url}}
+        godot-templates-url: ${{ inputs.godot-templates-url }}
+        archive-output: true
+
+    - name: Zip extension assets
+      uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # v0.7.6
+      with:
+        type: "zip"
+        filename: libopenvic.zip
+        path: game/bin/openvic
+
+    - name: Create and upload asset
+      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+      with:
+        allowUpdates: true
+        artifacts: "${{ steps.export_game.outputs.archive-directory }}/*,libopenvic.zip"
+        omitNameDuringUpdate: true
+        omitBodyDuringUpdate: true
+        name: "${{ env.RELEASE_NAME || '' }}"
+        tag: "${{ env.TO_TAG || '' }}"
+        commit: "${{ format('{0}/{1}', github.repository_owner, inputs.target-repo) == github.repository && !contains(inputs.to-ref, '.') && inputs.to-ref || '' }}"
+        bodyFile: "release-notes.md"
+        makeLatest: ${{ inputs.latest }}
+        prerelease: ${{ inputs.prerelease }}
+        draft: ${{ inputs.snapshot-release == 'false' && inputs.nightly-release == 'false' }}
+        repo: "${{ inputs.target-repo }}"
+        token: ${{ env.TARGET_TOKEN }}

--- a/.github/actions/openvic-release/nightly-release-notes-configuration.json
+++ b/.github/actions/openvic-release/nightly-release-notes-configuration.json
@@ -1,0 +1,40 @@
+{
+    "base_branches": [
+        "master"
+    ],
+    "custom_placeholders": [
+        {
+            "comment": "Keep up to date with .github/workflows/nightly-releases.yml",
+            "name": "COMMIT_GENERATED_LINE",
+            "source": "TO_TAG",
+            "transformer": {
+                "method": "regexr",
+                "pattern": "([a-zA-Z0-9]{40})",
+                "target": "Generated from: <<REPO>>@$1\n"
+            }
+        }
+    ],
+    "categories": [
+        {
+            "title": "### Enhancements & Features",
+            "labels": [
+                "enhancement"
+            ],
+            "exhaustive": true,
+            "consume": true
+        },
+        {
+            "title": "### Bug Fixes",
+            "labels": [
+                "bug"
+            ],
+            "exhaustive": true,
+            "consume": true
+        }
+    ],
+    "template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n#{{COMMIT_GENERATED_LINE}}## Changelog since [<<FROM_TAG_NAME_REPLACEMENT>>](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n#{{CHANGELOG}}\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "empty_template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n#{{COMMIT_GENERATED_LINE}}### No Pull Requests since [<<FROM_TAG_NAME_REPLACEMENT>>](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 365
+}

--- a/.github/actions/openvic-release/release-notes-configuration.json
+++ b/.github/actions/openvic-release/release-notes-configuration.json
@@ -1,0 +1,35 @@
+{
+    "base_branches": [
+        "master"
+    ],
+    "tag_resolver": {
+        "method": "sort",
+        "filter": {
+            "method": "regexr",
+            "pattern": "(\\d+\\.\\d+(?:\\.\\d+)?)(?:-((alpha|beta|rc)\\.(\\d+)))?"
+        }
+    },
+    "categories": [
+        {
+            "title": "### Enhancements & Features",
+            "labels": [
+                "enhancement"
+            ],
+            "exhaustive": true,
+            "consume": true
+        },
+        {
+            "title": "### Bug Fixes",
+            "labels": [
+                "bug"
+            ],
+            "exhaustive": true,
+            "consume": true
+        }
+    ],
+    "template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n## Changelog since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n#{{CHANGELOG}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "empty_template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n### No Pull Requests since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 365
+}

--- a/.github/actions/openvic-release/snapshot-release-notes-configuration.json
+++ b/.github/actions/openvic-release/snapshot-release-notes-configuration.json
@@ -1,0 +1,28 @@
+{
+    "base_branches": [
+        "master"
+    ],
+    "categories": [
+        {
+            "title": "### Enhancements & Features",
+            "labels": [
+                "enhancement"
+            ],
+            "exhaustive": true,
+            "consume": true
+        },
+        {
+            "title": "### Bug Fixes",
+            "labels": [
+                "bug"
+            ],
+            "exhaustive": true,
+            "consume": true
+        }
+    ],
+    "template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n## Changelog since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n#{{CHANGELOG}}\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "empty_template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n### No Pull Requests since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 365
+}

--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -1,0 +1,21 @@
+# We lack a convenient means of gathering *all* the changes when specializations are passed, so
+#  a catch-all variable is the easiest workaround.
+everything:
+  - "**"
+
+# Determines if build actions should occur after static checks are ran. Broadly speaking, these
+#  files changing would result in SCons rebuilding the engine, or are otherwise pertinent to the
+#  buildsystem itself.
+sources:
+  - .github/{actions/*,workflows}/*.yml
+  - "**/{SConstruct,SCsub,*.py}"
+  - "**/*.{hpp,cpp,inc,gd,tscn,scn,tres,res}"
+  - "**/*.{cfg,godot,gdextension,uid,import}"
+  - "**/*.{svg,ico,icns,png,ogv,ogg,mp3,csv,xml}"
+  - scripts
+  - godot-cpp
+  - extension/deps/**
+
+# Determines which files are appropriate for running clangd-tidy checks on.
+clangd:
+  - "**/*.{hpp,cpp,inc}"

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,0 +1,73 @@
+name: 🔢 Build Matrix
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-matrix:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: windows-debug
+            os: windows-latest
+            name: 🏁 Windows Debug
+            target: template_debug
+            platform: windows
+            arch: x86_64
+
+          - identifier: windows-release
+            os: windows-latest
+            name: 🏁 Windows Release
+            target: template_release
+            platform: windows
+            arch: x86_64
+
+          - identifier: macos-debug
+            os: macos-latest
+            name: 🍎 macOS (universal) Debug
+            target: template_debug
+            platform: macos
+            arch: universal
+
+          - identifier: macos-release
+            os: macos-latest
+            name: 🍎 macOS (universal) Release
+            target: template_release
+            platform: macos
+            arch: universal
+
+          - identifier: linux-debug
+            os: ubuntu-22.04
+            name: 🐧 Linux Debug
+            target: template_debug
+            platform: linux
+            arch: x86_64
+
+          - identifier: linux-release
+            os: ubuntu-22.04
+            name: 🐧 Linux Release
+            target: template_release
+            platform: linux
+            arch: x86_64
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build
+        uses: ./.github/actions/openvic-build
+        with:
+          identifier: ${{ matrix.identifier }}
+          target: ${{ matrix.target }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,327 +2,156 @@ name: 🖥️ Builds
 
 on:
   push:
-    paths-ignore:
-      - '.vscode/**'
-      - 'docs/**'
-      - 'LICENSE-EXCEPTIONS.md'
-      - 'LICENSE.md'
-      - 'README.md'
+    branches: ["master"]
   pull_request:
-    paths-ignore:
-      - '.vscode/**'
-      - 'docs/**'
-      - 'LICENSE-EXCEPTIONS.md'
-      - 'LICENSE.md'
-      - 'README.md'
   merge_group:
-    paths-ignore:
-      - '.vscode/**'
-      - 'docs/**'
-      - 'LICENSE-EXCEPTIONS.md'
-      - 'LICENSE.md'
-      - 'README.md'
-
-env:
-  GODOT_BASE_DOWNLOAD_URL: https://github.com/godotengine/godot
-  GODOT_VERSION: 4.6
-  GODOT_VERSION_TYPE: stable
-  OPENVIC_BASE_BRANCH: master
+  workflow_dispatch:
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
-  cancel-in-progress: true
+  group: ${{ github.workflow }}|${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
 
 jobs:
-  static-checks:
-    name: Code style, file formatting, and docs
-    runs-on: ubuntu-24.04
+  static-checks-builds:
+    name: 📊 Code style, file formatting, and docs
+    runs-on: ubuntu-latest
+    if: github.run_attempt > 1 || github.event_name == 'workflow_dispatch' || !vars.DISABLE_BUILDS
+    outputs:
+      changed-files: '"${{ steps.changed-files.outputs.clangd_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+      sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}
+      godot-executable-url: ${{ steps.godot-env.outputs.godot-linux-url }}
+      godot-templates-url: ${{ steps.godot-env.outputs.godot-template-url }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2
+          submodules: recursive
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
+
+      - name: Setup Godot variables
+        id: godot-env
+        uses: ./.github/actions/godot-env
 
       - name: Install APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
         with:
           packages: libxml2-utils
 
       - name: Get changed files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config diff.wsErrorHighlight all
-          if [ "${{ github.event_name }}" == "pull_request" -o "${{ github.event.forced }}" == "true" -o "${{ github.event.created }}" == "true" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
-          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
-          fi
-          echo "$files" >> changed.txt
-          cat changed.txt
-          files=$(echo "$files" | xargs -I {} sh -c 'echo "\"./{}\""' | tr '\n' ' ')
-          echo "CHANGED_FILES=$files" >> $GITHUB_ENV
-
-      - name: Style checks via pre-commit
-        uses: pre-commit/action@v3.0.1
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          extra_args: --files ${{ env.CHANGED_FILES }}
+          safe_output: false # Output passed to environment variable to avoid command injection.
+          separator: '" "' # To account for paths with spaces, ensure our items are split by quotes internally.
+          skip_initial_fetch: true
+          files_yaml_from_source_file: .github/changed-files.yml
+
+      - name: Style checks via prek
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+        env:
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators
+        with:
+          extra-args: --files ${{ env.CHANGED_FILES }}
 
       - name: Class reference schema checks
-        run: |
-          xmllint --noout --schema extension/doc_tools/class.xsd extension/doc_classes/*.xml
+        run: xmllint --noout --schema extension/doc_tools/class.xsd extension/doc_classes/*.xml
 
-  build:
-    runs-on: ${{matrix.os}}
-    name: ${{matrix.name}}
-    needs: static-checks
-    permissions: write-all
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - identifier: windows-debug
-            os: windows-latest
-            name: 🏁 Windows Debug
-            target: template_debug
-            platform: windows
-            arch: x86_64
-          - identifier: windows-release
-            os: windows-latest
-            name: 🏁 Windows Release
-            target: template_release
-            platform: windows
-            arch: x86_64
-          - identifier: macos-debug
-            os: macos-latest
-            name: 🍎 macOS (universal) Debug
-            target: template_debug
-            platform: macos
-            arch: universal
-          - identifier: macos-release
-            os: macos-latest
-            name: 🍎 macOS (universal) Release
-            target: template_release
-            platform: macos
-            arch: universal
-          - identifier: linux-debug
-            os: ubuntu-latest
-            name: 🐧 Linux Debug
-            runner: ubuntu-20.04
-            target: template_debug
-            platform: linux
-            arch: x86_64
-          - identifier: linux-release
-            os: ubuntu-latest
-            name: 🐧 Linux Release
-            runner: ubuntu-20.04
-            target: template_release
-            platform: linux
-            arch: x86_64
-
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v4.1.1
-        with:
-          submodules: recursive
-
-      - name: Setup OpenVic build cache
-        uses: OpenVicProject/openvic-cache@master
-        with:
-          cache-name: ${{ matrix.identifier }}
-          base-branch: ${{ env.OPENVIC_BASE_BRANCH }}
-        continue-on-error: true
-
-      - name: Setup Environment
-        uses: OpenVicProject/openvic-env@master
-
-      - name: Set up Python
-        uses: actions/setup-python@v5.0.0
-        with:
-          python-version: "3.x"
-
-      - name: Set up SCons
-        shell: bash
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons==4.7.0
-          scons --version
-
-      - name: Linux dependencies
-        if: ${{ matrix.platform == 'linux' }}
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qqq build-essential pkg-config libtbb-dev
-          g++ --version
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
-          sudo update-alternatives --set g++ /usr/bin/g++-12
-          g++ --version
-
-      - name: Setup MinGW for Windows/MinGW build
-        if: ${{ matrix.platform == 'windows' }}
-        uses: OpenVicProject/mingw-cache@master
-
-      - name: Compile Extension
-        uses: OpenVicProject/openvic-build@master
-        with:
-          platform: ${{ matrix.platform }}
-          target: ${{ matrix.target }}
-          bin-dir: "game/bin/"
-          sconsflags: arch=${{ matrix.arch }}
-
-      - name: Delete compilation files
-        if: ${{ matrix.platform == 'windows' }}
-        run: |
-          Remove-Item game/bin/openvic/* -Include *.exp,*.lib,*.pdb -Force
-
-      - name: Upload extension artifact
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: ${{ github.event.repository.name }}-${{ matrix.identifier }}-extension
-          path: |
-            ${{ github.workspace }}/game/bin/openvic/*
+  build-master:
+    name: 🛠️ Build
+    needs: static-checks-builds
+    if: needs.static-checks-builds.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-matrix.yml
 
   godot-debug-checks:
     runs-on: ubuntu-latest
-    needs: [build]
-
-    name: Perform Godot Debug Checks
+    needs: [static-checks-builds, build-master]
+    name: 🔍 Perform Godot Debug Checks
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.1
-
-      - name: Setup Environment
-        uses: OpenVicProject/openvic-env@master
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: game/bin/openvic
-          pattern: ${{ github.event.repository.name }}-*-extension
-          merge-multiple: true
+          submodules: recursive
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
 
-      - name: Export pack file
+      - name: Export game
         id: export_game
-        uses: Spartan322/godot-export@master
+        uses: ./.github/actions/openvic-export
         with:
-          godot_executable_download_url: ${{env.GODOT_LINUX_URL}}
-          godot_export_templates_download_url: ${{env.GODOT_TEMPLATE_URL}}
-          relative_project_path: ./game
-          export_as_pack: true
-          export_debug: true
-          cache: true
-          relative_export_path: ./game/export
-
-      - run: mv "./game/export/LinuxX11 x86_64/OpenVic.x86_64.pck" ./game/export/${{ github.event.repository.name }}.pck
+          godot-executable-url: ${{ needs.static-checks-builds.outputs.godot-executable-url }}
+          godot-templates-url: ${{ needs.static-checks-builds.outputs.godot-templates-url }}
+          export-as-pack: true
+          export-debug: true
+          relative-export-path: ./game/export
 
       - name: Check for class reference updates
+        env:
+          EXPORT_GAME_OUTPUTS_EXECUTABLE_PATH: ${{ steps.export_game.outputs.executable_path }}
         run: |
           echo "Running --doctool to see if this changes the public API without updating the documentation."
           echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
           cd game
-          ${{ steps.export_game.outputs.executable_path }} --doctool --headless ../extension --gdextension-docs 2>&1 > /dev/null || true
+          $EXPORT_GAME_OUTPUTS_EXECUTABLE_PATH --doctool --headless ../extension --gdextension-docs 2>&1 > /dev/null || true
           cd ..
           git diff --color --exit-code -- '*.xml' && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
-      - name: Upload pack artifact
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: ${{ github.event.repository.name }}-debug-pck
-          compression-level: 9
-          path: |
-            ./game/export/${{ github.event.repository.name }}.pck
-
-  export:
+  export-master:
     runs-on: ubuntu-latest
-    needs: [build]
-    permissions: write-all
-
-    name: Export
+    needs:  [static-checks-builds, build-master]
+    name: 📦 Export
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v4.1.1
-
-      - name: Setup Environment
-        uses: OpenVicProject/openvic-env@master
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+      - name: Shallow clone
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: game/bin/openvic
-          pattern: ${{ github.event.repository.name }}-*-extension
-          merge-multiple: true
-
-      - name: Install WINE
-        id: wine_install
-        run: |
-          sudo apt update
-          sudo apt install --fix-missing wine64
-          echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
+          submodules: recursive
+          fetch-depth: 1 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
 
       - name: Export game
         id: export_game
-        uses: Spartan322/godot-export@master
+        uses: ./.github/actions/openvic-export
         with:
-          godot_executable_download_url: ${{env.GODOT_LINUX_URL}}
-          godot_export_templates_download_url: ${{env.GODOT_TEMPLATE_URL}}
-          relative_project_path: ./game
-          archive_output: true
-          cache: true
-          wine_path: ${{ steps.wine_install.outputs.WINE_PATH }}
-
-      - name: Create release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: ncipollo/release-action@v1.13.0
-        with:
-          allowUpdates: true
-          omitNameDuringUpdate: true
-          omitBodyDuringUpdate: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: ${{ steps.export_game.outputs.archive_directory }}/*
+          godot-executable-url: ${{ needs.static-checks-builds.outputs.godot-executable-url }}
+          godot-templates-url: ${{ needs.static-checks-builds.outputs.godot-templates-url }}
+          archive-output: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}
           retention-days: 30
           compression-level: 9
+          if-no-files-found: error
           path: |
-            ${{ steps.export_game.outputs.archive_directory }}
+            ${{ steps.export_game.outputs.archive-directory }}
 
-  merge-files:
+  merge-library-files:
+    name: 📚 Merge Library Files
     runs-on: ubuntu-latest
-    needs: [export]
-    name: 📚 Merge Files
+    needs: [godot-debug-checks, export-master]
     steps:
-      - name: Download extension artifacts
-        uses: actions/download-artifact@v4.1.7
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        with:
-          path: artifacts
-          pattern: ${{ github.event.repository.name }}-*-extension
-          merge-multiple: true
-
-      - name: Merge extension artifacts
-        uses: actions/upload-artifact/merge@v4.3.0
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           delete-merged: true
           name: ${{ github.event.repository.name }}-extension
           pattern: ${{ github.event.repository.name }}-*-extension
 
-      - name: Archive release
-        uses: thedoctor0/zip-release@0.7.6
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  validate-master:
+    name: ✅ Validate Success
+    if: always()
+    needs: [static-checks-builds, build-master, godot-debug-checks, export-master, merge-library-files]
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Check
+        uses: re-actors/alls-green@a638d6464689bbb24c325bb3fe9404d63a913030
         with:
-          type: "zip"
-          filename: "release/libopenvic.zip"
-          directory: "${{ github.workspace }}/artifacts"
-
-      - name: Upload extension release asset
-        uses: ncipollo/release-action@v1.13.0
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        with:
-          allowUpdates: true
-          omitNameDuringUpdate: true
-          omitBodyDuringUpdate: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: release/*
+          allowed-skips: static-checks-builds, build-master, godot-debug-checks, export-master, merge-library-files
+          jobs: ${{ toJson(needs) }}

--- a/.github/workflows/nightly-releases.yml
+++ b/.github/workflows/nightly-releases.yml
@@ -1,0 +1,298 @@
+name: 🌘 Nightly Releases
+
+on:
+  schedule:
+    - cron: "23 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  SHA_REGEX: ^[0-9a-fA-F]{40}$
+
+jobs:
+  nightly-check:
+    name: Check for new commits
+    if: github.event_name == 'workflow_dispatch' || !vars.DISABLE_NIGHTLY_RELEASES
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.check_for_new_commits.outputs.commit }}
+      godot-executable-url: ${{ steps.godot-env.outputs.godot-linux-url }}
+      godot-templates-url: ${{ steps.godot-env.outputs.godot-template-url }}
+      latest-tag: ${{ steps.default-values.outputs.latest-tag || steps.master-values.outputs.latest-tag || steps.nightly-values.outputs.latest-tag }}
+      commit-hash: ${{ steps.default-values.outputs.commit-hash || steps.master-values.outputs.commit-hash || steps.nightly-values.outputs.commit-hash }}
+      from-ref: ${{ steps.default-values.outputs.from-ref || steps.master-values.outputs.from-ref || steps.nightly-values.outputs.from-ref }}
+      tag-name: ${{ steps.tag-name.outputs.tag-name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Godot variables
+        id: godot-env
+        uses: ./.github/actions/godot-env
+
+      - name: Validate repository variables
+        env:
+          VARS_VERSION_CORE: ${{ vars.NIGHTLY_VERSION_CORE }}
+          VARS_NIGHTLY_REPOSITORY: ${{ vars.NIGHTLY_REPOSITORY }}
+          SECRETS_NIGHTLY_REPOSITORY_TOKEN: ${{ secrets.NIGHTLY_REPOSITORY_TOKEN }}
+          VAR_DEFAULT_COMMIT_HASH: ${{ vars.DEFAULT_COMMIT_HASH }}
+        run: |
+          # Can report error for every validation check
+          EXIT_STATUS=0
+
+          validate_non_empty () {
+            [[ -n ${1-} ]] && return
+            echo "::error::${2-parameter} is empty."
+            EXIT_STATUS=1
+            false
+          }
+
+          if validate_non_empty "$VARS_VERSION_CORE" "vars.NIGHTLY_VERSION_CORE"; then
+            if [[ ! $VARS_VERSION_CORE =~ ^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){1,2}$ ]]; then
+              echo "::error::vars.NIGHTLY_VERSION_CORE should be set to 'MAJOR.MINOR', with an optional '.PATCH'."
+              EXIT_STATUS=1
+            fi
+          fi
+
+          if validate_non_empty "$VARS_NIGHTLY_REPOSITORY" "vars.NIGHTLY_REPOSITORY"; then
+            if [[ $VARS_NIGHTLY_REPOSITORY == */* ]]; then
+              echo "::error::vars.NIGHTLY_REPOSITORY cannot be set with a forward slash, that is an invalid repository name."
+              EXIT_STATUS=1
+            fi
+          fi
+
+          validate_non_empty "$SECRETS_NIGHTLY_REPOSITORY_TOKEN" "secrets.NIGHTLY_REPOSITORY_TOKEN"
+
+          if validate_non_empty "$VAR_DEFAULT_COMMIT_HASH" "vars.DEFAULT_COMMIT_HASH"; then
+            if [[ ! $VAR_DEFAULT_COMMIT_HASH =~ $SHA_REGEX ]]; then
+              echo "::error::vars.DEFAULT_COMMIT_HASH is not set to a full Git commit SHA."
+              EXIT_STATUS=1
+            fi
+          fi
+
+          exit $EXIT_STATUS
+
+      - name: Retrieve HEAD commit hash
+        id: head
+        shell: bash
+        run: echo "head=$(git rev-parse HEAD)" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Cache nightly commit hash
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+        with:
+          path: .nightly_commit_hash
+          key: release-nightly-${{ steps.head.outputs.head }}
+          restore-keys: |
+            release-nightly-
+
+      - name: Check for new commits
+        id: check_for_new_commits
+        shell: bash
+        run: |
+          relevant_files=(
+            "extension/deps/*"
+            "scripts"
+            "godot-cpp"
+            "extension/src/*.hpp"
+            "extension/src/*.cpp"
+            "game/*"
+            ':!extension/src/openvic-extension/pch.hpp'
+            ':!extension/src/openvic-extension/pch.cpp'
+            "pyproject.toml"
+            "SConstruct"
+            ".github/workflows/builds.yml"
+            ".github/actions/openvic-build/action.yml"
+            ".github/actions/openvic-release/action.yml"
+            ".github/actions/openvic-export/action.yml"
+            ".github/workflows/nightly-releases.yml"
+            ".github/actions/openvic-release/action.yml"
+            ".github/actions/openvic-release/nightly-release-notes-configuration.json"
+          )
+          if [[ -f .nightly_commit_hash ]]; then
+            limit_args=(
+              "$(cat .nightly_commit_hash)..HEAD"
+            )
+          else
+            limit_args=(
+              --since="24 hours ago"
+            )
+          fi
+          echo "commit=$(git log --format=%H -1 "${limit_args[@]}" -- "${relevant_files[@]}")" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Record new nightly commit hash
+        env:
+          HEAD: ${{ steps.head.outputs.head }}
+        shell: bash
+        run: echo "${HEAD}" | tee .nightly_commit_hash
+
+      - name: Retrieve master/nightly release tag info
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "LAST_MASTER_TAG_INFO=$(gh release list -L 1 --json tagName,publishedAt --jq '.[0]')" >> $GITHUB_ENV
+          echo "LAST_NIGHTLY_TAG_INFO=$(gh release list -L 1 -R $GITHUB_REPOSITORY_OWNER/$VARS_NIGHTLY_REPOSITORY --json tagName,publishedAt --jq '.[0]')" >> $GITHUB_ENV
+
+      - name: Query master/nightly release tag info for dates
+        run: |
+          echo "LAST_MASTER_TAG_PUB_DATE=$(jq -r ".publishedAt" <<< "$LAST_MASTER_TAG_INFO")" >> $GITHUB_ENV
+          echo "LAST_NIGHTLY_TAG_PUB_DATE=$(jq -r ".publishedAt" <<< "$LAST_NIGHTLY_TAG_INFO")" >> $GITHUB_ENV
+
+      - name: Process master/nightly release tag dates
+        run: |
+          if [[ ! -z $LAST_NIGHTLY_TAG_PUB_DATE ]]; then
+            echo "LAST_MASTER_TAG_PUB_SEC=$(date -d $LAST_MASTER_TAG_PUB_DATE +%s)" >> $GITHUB_ENV
+          else
+            echo "LAST_MASTER_TAG_PUB_SEC=0" >> $GITHUB_ENV
+          fi
+
+          if [[ ! -z $LAST_NIGHTLY_TAG_PUB_DATE ]]; then
+            echo "LAST_NIGHTLY_TAG_PUB_SEC=$(date -d $LAST_NIGHTLY_TAG_PUB_DATE +%s)" >> $GITHUB_ENV
+          else
+            echo "LAST_NIGHTLY_TAG_PUB_SEC=0" >> $GITHUB_ENV
+          fi
+
+      - name: Use default values for LATEST_TAG, FROM_REF, and COMMIT_HASH
+        id: default-values
+        if: env.LAST_MASTER_TAG_PUB_SEC == 0 && env.LAST_MASTER_TAG_PUB_SEC == env.LAST_NIGHTLY_TAG_PUB_SEC
+        env:
+          VAR_DEFAULT_COMMIT_HASH: ${{ vars.DEFAULT_COMMIT_HASH }}
+        run: |
+          echo "latest-tag=" >> $GITHUB_OUTPUT
+          echo "commit-hash=$VAR_DEFAULT_COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "from-ref=$VAR_DEFAULT_COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Get FROM_REF, LATEST_TAG, and COMMIT_HASH from latest master release
+        id: master-values
+        if: env.LAST_MASTER_TAG_PUB_SEC > env.LAST_NIGHTLY_TAG_PUB_SEC
+        run: |
+          LATEST_TAG=$(jq -r '.tagName' <<< "$LAST_MASTER_TAG_INFO")
+          echo "::debug::LATEST_TAG=$LATEST_TAG"
+
+          COMMIT_HASH=$(git rev-parse --verify -q $LATEST_TAG)
+          echo "::debug::COMMIT_HASH=$COMMIT_HASH"
+
+          echo "latest-tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "from-ref=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Get FROM_REF, LATEST_TAG, and COMMIT_HASH from latest nightly release
+        id: nightly-values
+        if: env.LAST_MASTER_TAG_PUB_SEC < env.LAST_NIGHTLY_TAG_PUB_SEC
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST_TAG=$(jq -r '.tagName' <<< "$LAST_NIGHTLY_TAG_INFO")
+          echo "::debug::LATEST_TAG=$LATEST_TAG"
+
+          LATEST_RELEASE_BODY=$(gh release view $LATEST_TAG -R $GITHUB_REPOSITORY_OWNER/$VARS_NIGHTLY_REPOSITORY --json body --jq '.body')
+          echo "::debug::LATEST_RELEASE_BODY=$LATEST_RELEASE_BODY"
+
+          # Keep up to date with .github/actions/openvic-release/nightly-release-notes-configuration.json
+          HASH_OF_TAG=$(grep -oP "Generated from: $GITHUB_REPOSITORY@\K[a-zA-Z0-9]+" <<< "$LATEST_RELEASE_BODY")
+          echo "::debug::HASH_OF_TAG=$HASH_OF_TAG"
+
+          COMMIT_HASH=$(git rev-parse --verify -q $HASH_OF_TAG)
+          echo "::debug::COMMIT_HASH=$COMMIT_HASH"
+
+          if [[ -z $COMMIT_HASH ]]; then
+            echo "::error::Could not find commit for hash $HASH_OF_TAG."
+            exit 1
+          fi
+
+          echo "latest-tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "from-ref=$COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Generate TAG_NAME from vars.NIGHTLY_VERSION_CORE
+        id: tag-name
+        env:
+          VARS_VERSION_CORE: ${{ vars.NIGHTLY_VERSION_CORE }}
+        run: echo "tag-name=v${VARS_VERSION_CORE}-nightly.$(date +%Y.%m.%d)+${GITHUB_SHA}" >> $GITHUB_OUTPUT
+
+  nightly-build:
+    name: Build ${{ matrix.name }}
+    needs: nightly-check
+    if: needs.nightly-check.outputs.commit
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: windows-release
+            os: windows-latest
+            name: 🏁 Windows Release
+            target: template_release
+            platform: windows
+            arch: x86_64
+            scons-flags: ""
+
+          - identifier: macos-release
+            os: macos-latest
+            name: 🍎 macOS (universal) Release
+            target: template_release
+            platform: macos
+            arch: universal
+            scons-flags: "lto=full"
+
+          - identifier: linux-release
+            os: ubuntu-latest
+            name: 🐧 Linux Release
+            runner: ubuntu-22.04
+            target: template_release
+            platform: linux
+            arch: x86_64
+            scons-flags: "lto=full use_static_cpp=yes"
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build
+        uses: ./.github/actions/openvic-build
+        with:
+          identifier: ${{ matrix.identifier }}
+          target: ${{ matrix.target }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          tag-name: ${{ needs.nightly-check.outputs.tag-name }}
+          disable-cache: true
+          scons-flags: use_hot_reload=no debug_symbols=yes optimize=speed_trace ${{ matrix.scons-flags }}
+
+  publish-nightly-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: [nightly-check, nightly-build]
+    permissions:
+      contents: write # May be needed to publish release
+    steps:
+      - name: Shallow Clone
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Publish Nightly Release
+        uses: ./.github/actions/openvic-release
+        with:
+          godot-executable-url: ${{ needs.nightly-check.outputs.godot-executable-url }}
+          godot-templates-url: ${{ needs.nightly-check.outputs.godot-templates-url }}
+          latest: ${{ github.ref_name == 'master' }}
+          nightly-release: true
+          tag-name: ${{ needs.nightly-check.outputs.tag-name }}
+          from-ref: ${{ needs.nightly-check.outputs.from-ref }}
+          from-tag: ${{ needs.nightly-check.outputs.latest-tag}}
+          to-ref: ${{ github.sha }}
+          target-repo: ${{ vars.NIGHTLY_REPOSITORY }}
+          src-token: ${{ secrets.GITHUB_TOKEN }}
+          target-token: ${{ secrets.NIGHTLY_REPOSITORY_TOKEN }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,175 @@
+name: 🚀 Releases
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions: {}
+
+env:
+  SEMVER_REGEX: ^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})(-(alpha|beta|rc)\.([1-9][0-9]*))?$
+  SEMVER_STABLE_REGEX: ^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})$
+  SEMVER_SNAPSHOT_REGEX: ^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})-(snapshot|snapshot\.dev)\.([1-9][0-9]*)\+([0-9a-fA-F]{40})$
+
+jobs:
+  static-checks-release:
+    name: 📊 Code style, file formatting, and docs
+    if: vars.DISABLE_TAG_RELEASES != true
+    runs-on: ubuntu-latest
+    outputs:
+      release-name: ${{ steps.get_release_name.outputs.release-name }}
+      godot-executable-url: ${{ steps.godot-env.outputs.godot-linux-url }}
+      godot-templates-url: ${{ steps.godot-env.outputs.godot-template-url }}
+    env:
+      GITHUB_REF_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
+
+      - name: Setup Godot variables
+        id: godot-env
+        uses: ./.github/actions/godot-env
+
+      - name: Validate tag
+        run: |
+          EXIT_STATUS=0
+
+          validate_version () {
+            [[ $1 =~ $SEMVER_REGEX ]] && return
+            [[ $1 =~ $SEMVER_SNAPSHOT_REGEX ]] && return
+
+            echo "::error::${2:-parameter} is not a valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', and 'snapshot.dev'. A count value must follow all prerelease tags, starting from 1. 'snapshot' and 'snapshot.dev' must include the full commit SHA as a build string"
+            false
+          }
+
+          validate_version "$GITHUB_REF_NAME" "github.ref (tag)"
+
+          if [[ $(git cat-file -t "$GITHUB_REF_NAME") != 'tag' ]]; then
+            echo "::error::$GITHUB_REF_NAME is not an annotated tag, use 'git tag $GITHUB_REF_NAME -m \"\"' to tag release."
+            EXIT_STATUS=1
+          fi
+
+          exit $EXIT_STATUS
+
+      - name: Get release name from tag annotation
+        id: get_release_name
+        run: |
+          RELEASE_NAME="$(git tag -l  --format='%(contents:subject)' "$GITHUB_REF_NAME")"
+          if [[ -z $RELEASE_NAME ]]; then
+            if [[ $GITHUB_REF_NAME =~ $SEMVER_STABLE_REGEX ]]; then
+              echo "::error::$GITHUB_REF_NAME is an annotated tag with an empty message, stable releases must be named, use 'git tag $GITHUB_REF_NAME -m \"<release-name>\"' to name release."
+              exit 1
+            fi
+
+            RELEASE_NAME=""
+          fi
+
+          echo "release-name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Install APT dependencies
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        with:
+          packages: libxml2-utils
+
+      - name: Style checks via prek
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+
+  build-release:
+    name: ${{ matrix.name }} Release
+    needs: static-checks-release
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: windows-release
+            os: windows-latest
+            name: 🏁 Build Windows
+            target: template_release
+            platform: windows
+            arch: x86_64
+            scons-flags: ''
+
+          - identifier: macos-release
+            os: macos-latest
+            name: 🍎 Build macOS
+            target: template_release
+            platform: macos
+            arch: universal
+            scons-flags: lto=full
+
+          - identifier: linux-release
+            os: ubuntu-latest
+            name: 🐧 Build Linux
+            runner: ubuntu-22.04
+            target: template_release
+            platform: linux
+            arch: x86_64
+            scons-flags: lto=full use_static_cpp=yes
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build
+        uses: ./.github/actions/openvic-build
+        with:
+          identifier: ${{ matrix.identifier }}
+          target: ${{ matrix.target }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          tag-name: ${{ github.ref_name }}
+          release-name: ${{ needs.static-checks-release.outputs.release-name }}
+          disable-cache: true
+          scons-flags: ${{ matrix.scons-flags }}
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: [static-checks-release, build-release]
+    permissions:
+      contents: write  # May be needed to publish release
+    env:
+      IS_PRERELEASE: ${{
+          contains(github.ref, '-alpha') ||
+          contains(github.ref, '-beta') ||
+          contains(github.ref, '-rc') ||
+          contains(github.ref, '-snapshot')
+        }}
+      IS_SNAPSHOT: ${{ contains(github.ref, '-snapshot') }}
+    steps:
+      - name: Shallow Clone
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
+
+      - name: Get FROM_REF
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXCLUDE_PRE_RELEASES: ${{ !env.IS_PRERELEASE && '--exclude-pre-releases' || '' }}
+          EXCLUDE_SNAPSHOTS: ${{ !env.IS_SNAPSHOT && '| select(.tagName | contains("-snapshot") | not)' || '' }}
+        run:
+          echo "FROM_REF=$(gh release list $EXCLUDE_PRE_RELEASES --json tagName --jq "[.[] $EXCLUDE_SNAPSHOTS.tagName][0]")" >> $GITHUB_ENV
+
+      - name: Publish Release
+        uses: ./.github/actions/openvic-release
+        with:
+          godot-executable-url: ${{ needs.static-checks-release.outputs.godot-executable-url }}
+          godot-templates-url: ${{ needs.static-checks-release.outputs.godot-templates-url }}
+          latest: ${{ !env.IS_PRERELEASE && !env.IS_SNAPSHOT }}
+          prerelease: ${{ env.IS_PRERELEASE }}
+          snapshot-release: ${{ env.IS_SNAPSHOT }}
+          from-ref: ${{ env.FROM_REF || vars.DEFAULT_COMMIT_HASH }}
+          src-token: ${{ secrets.GITHUB_TOKEN }}
+          release-name: ${{ needs.static-checks-release.outputs.release-name }}
+


### PR DESCRIPTION
- Fixes #664 

Add validate-master as required CI job
Extract build matrix to build-matrix.yml workflow
Add build workflow action
Add release workflow action
Add export workflow action
Update ubuntu runner to 22.04
Move pre-commit checks to prek
Pin workflow actions to commits
Remove non-master push builds
Update ubuntu builds to use GCC 13
Remove WINE install for export

Requires the Github variable `NIGHTLY_REPOSITORY` to be set to the nightly release repository's name. (Already set to [`OpenVic-nightly-builds`](https://github.com/OpenVicProject/OpenVic-nightly-builds))
Requires the Github secret `NIGHTLY_REPOSITORY_TOKEN` to be set.
Requires the Github variable `NIGHTLY_VERSION_CORE` to be set. (Already set to `0.3`)
Requires the Github variable `DEFAULT_COMMIT_HASH` to an existing repository hash. (Already set to [`59490e18b0bf28b7967503ea9afe26373ac64299`](https://github.com/OpenVicProject/OpenVic/commit/59490e18b0bf28b7967503ea9afe26373ac64299))

These templates follow [semver](https://semver.org/):

- Template for alpha releases: `MAJOR.MINOR.PATCH-alpha.COUNT`.
- Template for beta releases: `MAJOR.MINOR.PATCH-beta.COUNT`.
- Template for release candidate releases: `MAJOR.MINOR.PATCH-rc.COUNT`.
- Template for full releases: `MAJOR.MINOR.PATCH`.
- Template for snapshot releases: `MAJOR.MINOR.PATCH-snapshot.COUNT+SHA`.
- Template for dev snapshot releases: `MAJOR.MINOR.PATCH-snapshot.dev.COUNT+SHA`.
- Automatically generates nightly releases: `MAJOR.MINOR.PATCH-nightly.YYYY.MM.DD+SHA`.

`.PATCH` is optional.
`COUNT` refers to how many of this release type there is with the release, so the first alpha for 0.1 would be `0.1-alpha.1`, `COUNT` should be reset on the next major, minor, or patch change.

Tags must be annotated tags. Stable release tags (tags without prerelease types) are expected to be annotated tags with message whose first line contains a name for the release. (like "Primum Mobile" or "Mappa Mundi") To make an annotated tag you can run `git tag v0.3 -m "Third Version Name"`, for prereleases an empty message can be tagged as `git tag v0.3-alpha.1 -m ""`

Tags must be pushed in this form for all except for nightly releases. The releases automatically generate the release notes with PRs since the last update. Full releases only consider the difference between non-prerelease releases. Alphas, betas, and release candidates don't consider snapshots or nightly releases. Snapshots don't consider nightly releases. And nightly releases consider every release.

Nightly releases will build their release notes based on the publish date of the releases of the last nightly build compared to the master's latest published release. (not github's latest, prereleases are included)
Nightly releases retrieve the `MAJOR.MINOR.PATCH` from `NIGHTLY_CORE_VERSION`.
Nightly releases only publish if a new commit (since the last nightly) which changes the output binary is found.

To disable nightly releases you can set the Github variable `DISABLE_NIGHTLY_RELEASES` to true.
To disable trigger releases via tags you can set the Github variable `DISABLE_TAG_RELEASES` to true.
To disable PR and master commit builds you can set the Github variable `DISABLE_BUILDS` to true.