### PR TITLE
Fix erroneous CI pre-commit submodule checks

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -1,6 +1,6 @@
 # We lack a convenient means of gathering *all* the changes when specializations are passed, so
 #  a catch-all variable is the easiest workaround.
-everything:
+everything: &everything
   - "**"
 
 # Determines if build actions should occur after static checks are ran. Broadly speaking, these
@@ -15,6 +15,12 @@ sources:
   - scripts
   - godot-cpp
   - extension/deps/**
+
+pre-commit:
+  - *everything
+  - '!scripts/**'
+  - '!godot-cpp/**'
+  - '!extension/deps/*/**'
 
 # Determines which files are appropriate for running clangd-tidy checks on.
 clangd:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Style checks via prek
         uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
         env:
-          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.pre-commit_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators
         with:
           extra-args: --files ${{ env.CHANGED_FILES }}
 


### PR DESCRIPTION
Add pre-commit changed-files set

Introduce a reusable "everything" anchor and a pre-commit file set in .github/changed-files.yml to exclude scripts, godot-cpp, and extension/deps submodules from pre-commit checks. Update .github/workflows/builds.yml to pass the pre-commit changed-files output to the prek style-check action (CHANGED_FILES uses pre-commit_all_changed_files). This scopes style checks to the intended files and avoids running them on excluded submodules.