### PR TITLE
Simplify dependabot-labels workflow

### DIFF
--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Label
 on:
   pull_request:
-    types: [opened, labeled]
+    types: opened
     branches: [master]
     paths:
       - extension/deps/openvic-simulation
@@ -9,7 +9,6 @@ on:
 
 permissions:
   pull-requests: write
-  issues: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
Update Dependabot Auto-Label workflow to only trigger on opened pull requests (remove 'labeled' event) and remove the 'issues: write' permission. This limits runs to new PRs and reduces granted permissions for the workflow.