### PR TITLE
Fix OptionsMenu consuming ui_cancel event

### DIFF
--- a/game/src/UI/GameMenu/OptionMenu/OptionsMenu.gd
+++ b/game/src/UI/GameMenu/OptionMenu/OptionsMenu.gd
@@ -77,6 +77,7 @@ func _setup_settings_section(app_setting: AppSettings, section_index: int, secti
 func _notification(what : int) -> void:
 	match what:
 		NOTIFICATION_VISIBILITY_CHANGED:
+			if not is_node_ready(): await ready
 			set_process_input(is_visible_in_tree())
 		NOTIFICATION_CRASH, NOTIFICATION_WM_CLOSE_REQUEST:
 			_on_window_close_requested()

--- a/game/src/UI/Session/Menubar.gd
+++ b/game/src/UI/Session/Menubar.gd
@@ -98,6 +98,7 @@ func _ready() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("menu_pause"):
 		_menu_button.pressed.emit()
+		accept_event()
 
 # REQUIREMENTS:
 # * UIFUN-10


### PR DESCRIPTION
Add consuming menu_pause event to MenuBar

This fixes the bug where inputs associated with the ui_cancel event can never be activated, instead of only being consumed when the OptionsMenu is visible.