### PR TITLE
Change COPYRIGHT's Expat license name to MIT

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -6,7 +6,7 @@ Source: https://github.com/OpenVicProject/OpenVic
 Files: *
 Comment: OpenVic Game
 Copyright: 2023-present OpenVic Game contributors
-License: Expat
+License: MIT
 
 Files: game/assets/OpenVic.svg
  game/assets/OpenVic.ico
@@ -18,22 +18,22 @@ License: CC-BY-SA-4.0
 Files: extension/deps/gli/*
 Comment: gli
 Copyright: 2010-2020 G-Truc Creation
-License: Expat
+License: MIT
 
 Files: extension/deps/openvic-simulation/*
 Comment: OpenVic Simulation
 Copyright: 2023-present OpenVic Simulation contributors
-License: Expat
+License: MIT
 
 Files: godot-cpp/*
 Comment: Godot Engine C++ Bindings
 Copyright: 2017-present Godot Engine contributors
-License: Expat
+License: MIT
 
 Files: game/addons/keychain/*
 Comment: Keychain Godot Plugin
 Copyright: 2022-present Orama Interactive
-License: Expat
+License: MIT
 
 Files: game/addons/kenney_ui_audio/*
 Comment: Kenney's UI Audio Pack
@@ -43,17 +43,17 @@ License: CC0-1.0
 Files: game/addons/kenyoni/app_settings/*
 Comment: AppSettings Godot Plugin
 Copyright: 2022-present Iceflower S (iceflower@gmx.de)
-License: Expat
+License: MIT
 
 Files: game/addons/MusicMetadata/*
 Comment: MusicMetadata Godot Plugin
 Copyright: 2024 Aiden Olsen, James Wilcock, NovaDC
-License: Expat
+License: MIT
 
 Files: game/addons/quick_licenses/*
 Comment: Quick Licenses Godot Plugin
 Copyright: 2025 ProgrammerOnCoffee
-License: Expat
+License: MIT
 
 Files: game/assets/audio/music/*.mp3
 Comment: OpenVic Game music
@@ -625,7 +625,7 @@ License: CC-BY-SA-4.0
  Creative Commons may be contacted at creativecommons.org.
 
 
-License: Expat
+License: MIT
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the
  "Software"), to deal in the Software without restriction, including

--- a/game/addons/quick_licenses/quick_licenses.gd
+++ b/game/addons/quick_licenses/quick_licenses.gd
@@ -250,6 +250,10 @@ func _on_component_button_pressed(component) -> void:
 				if license == "BSD-3-Clause":
 					license = "BSD-3-clause"
 
+				# Ensures MIT/Expat license is called MIT and only referenced once
+				if license == "Expat":
+					license = "MIT"
+
 				if license in engine_licenses or license in game_licenses or license in sim_licenses:
 					var button := Button.new()
 					button.theme_type_variation = theme_type_small_button


### PR DESCRIPTION
- Depends on #717

Unify MIT/Expat license name for quick_licenses