### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,22 @@ repos:
     hooks:
       - id: clang-tidy
         files: \.(c|h|cpp|hpp|inc)$
-        args: [--fix, --quiet, --use-color]
+        args:
+          [
+            --fix,
+            --quiet,
+            --use-color,
+            -p=compile_commands.json,
+            -extra-arg=-Wno-unknown-warning-option,
+            -checks=-modernize-use-bool-literals,
+          ]
         types_or: [text]
-        additional_dependencies: [clang-tidy==19.1.0]
+        additional_dependencies: [clang-tidy==22.1.8]
         require_serial: true
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -42,7 +50,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         files: \.py$
@@ -60,7 +68,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.29.4
+    rev: v1.48.0
     hooks:
       - id: typos
         exclude: |
@@ -69,21 +77,21 @@ repos:
             game/addons/.*
           )
 
-
   - repo: local
     hooks:
       - id: make-rst
         name: make-rst
         language: python
         entry: python extension/doc_tools/make_rst.py
-        args: [
-          extension/doc_tools/cache/engine/godot/doc/classes,
-          extension/doc_tools/cache/engine/godot/modules,
-          extension/doc_tools/cache/engine/godot/platform,
-          extension/doc_classes,
-          --dry-run,
-          --color
-        ]
+        args:
+          [
+            extension/doc_tools/cache/engine/godot/doc/classes,
+            extension/doc_tools/cache/engine/godot/modules,
+            extension/doc_tools/cache/engine/godot/platform,
+            extension/doc_classes,
+            --dry-run,
+            --color,
+          ]
         pass_filenames: false
         files: ^(extension/doc_classes)/.*\.xml$
 

--- a/docs/contribution/run-build-and-export.md
+++ b/docs/contribution/run-build-and-export.md
@@ -8,7 +8,7 @@ With the project installed and system requirements ready:
 
 1. Run `scons` in the project root.
     * Ensure a `game/bin/openvic/libopenvic` file is produced for your platform (windows, linux, macos)
-2. Open Godot, click import, naivgate to the `game` directory and click `Import and Edit`.
+2. Open Godot, click import, navigate to the `game` directory and click `Import and Edit`.
     * Wait for the import to finish, close the editor without saving, then reopen the project in Godot.
 3. Press the play button at the top right of the editor.
 

--- a/docs/contribution/system-requirements.md
+++ b/docs/contribution/system-requirements.md
@@ -14,7 +14,7 @@ With Python 3.6+ installed, you can install Scons through pip:
 ```sh
 python -m pip install scons
 ```
-If you get `Defaulting to user installation because normal site-packages is not writeable` then open a command prompt as Administrator and run the command again. When finished call:
+If you get `Defaulting to user installation because normal site-packages is not writable` then open a command prompt as Administrator and run the command again. When finished call:
 ```
 scons --version
 ```

--- a/extension/src/openvic-extension/classes/GUILabel.cpp
+++ b/extension/src/openvic-extension/classes/GUILabel.cpp
@@ -222,7 +222,7 @@ void GUILabel::_notification(int what) {
 	}
 }
 
-GUILabel::GUILabel() : font_size { DEFAULT_FONT_SIZE } {}
+GUILabel::GUILabel() {}
 
 void GUILabel::clear() {
 	gui_text = nullptr;

--- a/extension/src/openvic-extension/classes/GUILabel.hpp
+++ b/extension/src/openvic-extension/classes/GUILabel.hpp
@@ -20,6 +20,10 @@ namespace OpenVic {
 	class GUILabel : public godot::Control {
 		GDCLASS(GUILabel, godot::Control)
 
+	public:
+		static constexpr int32_t DEFAULT_FONT_SIZE = 16;
+
+	private:
 		GUI_TOOLTIP_DEFINITIONS
 
 		using colour_instructions_t = std::vector<std::pair<int64_t, char>>;
@@ -35,7 +39,7 @@ namespace OpenVic {
 		bool PROPERTY_CUSTOM_PREFIX(auto_adjust_to_content_size, will, false);
 
 		godot::Ref<godot::Font> font;
-		int32_t PROPERTY(font_size);
+		int32_t PROPERTY(font_size, DEFAULT_FONT_SIZE);
 		godot::Color PROPERTY(default_colour);
 		GFX::Font::colour_codes_t const* colour_codes = nullptr;
 		godot::Ref<GFXSpriteTexture> currency_texture;

--- a/extension/src/openvic-extension/classes/GUIPieChart.hpp
+++ b/extension/src/openvic-extension/classes/GUIPieChart.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <godot_cpp/classes/input_event.hpp>
 #include <godot_cpp/classes/texture_rect.hpp>
 
 #include <openvic-simulation/interface/GFXSprite.hpp>

--- a/extension/src/openvic-extension/classes/GUIScrollbar.hpp
+++ b/extension/src/openvic-extension/classes/GUIScrollbar.hpp
@@ -136,7 +136,7 @@ namespace OpenVic {
 			ReadOnlyClampedValue& slider_value
 		);
 
-		/* Override the main dimension of gui_scollbar's size with the specified length. */
+		/* Override the main dimension of gui_scrollbar's size with the specified length. */
 		void set_length_override(real_t new_length_override);
 	};
 }

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -116,7 +116,7 @@ GameSingleton::GameSingleton()
 		std::bind(&GameSingleton::_on_gamestate_updated, this),
 		std::bind(&Time::get_ticks_usec, Time::get_singleton()),
 		std::bind(&Time::get_ticks_msec, Time::get_singleton())
-	}, mapmode { &Mapmode::ERROR_MAPMODE } {
+	} {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 }
@@ -220,7 +220,7 @@ Error GameSingleton::setup_game(int32_t bookmark_index) {
 	// TODO - remove this temporary crime assignment
 	InstanceManager* instance_manager = get_instance_manager();
 	ERR_FAIL_NULL_V_MSG(instance_manager, FAILED, "Failed to setup instance manager!");
-	
+
 	CrimeManager const& crime_manager = definition_manager.get_crime_manager();
 	for (ProvinceInstance& province : instance_manager->get_map_instance().get_province_instances()) {
 		const crime_index_t crime_index = crime_index_t(type_safe::get(province.index) % crime_manager.get_crime_modifier_count());

--- a/extension/src/openvic-extension/singletons/GameSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.hpp
@@ -27,7 +27,8 @@ namespace OpenVic {
 		godot::Ref<godot::Texture2DArray> province_shape_texture;
 		godot::Ref<godot::Image> province_colour_image;
 		godot::Ref<godot::ImageTexture> province_colour_texture;
-		Mapmode const* mapmode; // This should never be null, if no mapmode is set then it'll point to Mapmode::ERROR_MAPMODE
+		Mapmode const* mapmode = &Mapmode::ERROR_MAPMODE; // This should never be null, if no mapmode is set then it'll point to
+														  // Mapmode::ERROR_MAPMODE
 		godot::Ref<godot::Texture2DArray> terrain_texture;
 
 		inline static const godot::Vector2i PROPERTY(flag_dims, { 128, 64 }); /* The size in pixels of an individual flag. */

--- a/extension/src/openvic-extension/singletons/MenuSingleton.hpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.hpp
@@ -75,7 +75,7 @@ namespace OpenVic {
 
 			struct pop_filter_t {
 				pop_size_t count, promotion_demotion_change;
-				bool selected;
+				bool selected = false;
 			};
 			ordered_map<PopType const*, pop_filter_t> pop_filters;
 

--- a/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
+++ b/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
@@ -391,19 +391,19 @@ Dictionary MenuSingleton::get_military_menu_info() {
 		war_exhaustion_template_string, war_exhaustion_string, max_war_exhaustion_string
 	);
 
-	static const StringName war_exhaution_localisation_key = "MILITARY_WAR_EXHAUSTION_TOOLTIP";
-	static const StringName max_war_exhaution_localisation_key = "MILITARY_MAX_WAR_EXHAUSTION_TOOLTIP";
+	static const StringName war_exhaustion_localisation_key = "MILITARY_WAR_EXHAUSTION_TOOLTIP";
+	static const StringName max_war_exhaustion_localisation_key = "MILITARY_MAX_WAR_EXHAUSTION_TOOLTIP";
 	static const String current_effects_localisation_key = "WEX_EFFECTS";
 	static const String war_exhaustion_tooltip_template_string = "%s%s\n\n%s%s" + get_tooltip_separator() + "%s%s";
 
 	ret[military_info_war_exhaustion_tooltip_key] = Utilities::format(
 		war_exhaustion_tooltip_template_string,
-		tr(war_exhaution_localisation_key).replace(
+		tr(war_exhaustion_localisation_key).replace(
 			Utilities::get_long_value_placeholder(),
 			war_exhaustion_string
 		),
 		_make_modifier_effect_contributions_tooltip(*country, *modifier_effect_cache.get_war_exhaustion_monthly()),
-		tr(max_war_exhaution_localisation_key).replace(
+		tr(max_war_exhaustion_localisation_key).replace(
 			Utilities::get_long_value_placeholder(),
 			max_war_exhaustion_string
 		),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,20 @@ default.extend-ignore-re = [
 	"id=\"[^\"]+\"",                                                     # Ignore scene ids
 	"ExtResource\\(\"[^\"]+\"\\)",                                       # Ignore scene ids
 ]
-type.xml.locale = "en-us"
-type.xml.check-filename = false
-type.xml.extend-ignore-re = [
+
+[tool.typos.type.xml]
+locale = "en-us"
+check-filename = false
+extend-ignore-re = [
 	'<.* name="[^"]+".*>',
 	'\[(param|member|method)?.+\]',
 ]
+
+[tool.typos.type.skip_names]
+extend-glob = ["AUTHORS.md", "COPYRIGHT", "CODE_OF_CONDUCT.md", "credits.csv"]
+
+[tool.typos.type.skip_names.extend-identifiers]
+Catylist = "Catylist"
+
 [tool.typos.default.extend-identifiers]
 PNGs = "PNGs"


### PR DESCRIPTION
Update ruff-check/ruff-format to v0.15.22
Update mypy to v2.3.0
Update typos to v1.48.0
Update clang-tidy dependency to 22.1.8
Apply clang-tidy fixes

- Leaving the gdstyle hook up to #700 