### PR TITLE
Add prek CI all files run on pre-commit config changes

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -22,6 +22,10 @@ pre-commit:
   - '!godot-cpp/**'
   - '!extension/deps/*/**'
 
+# .pre-commit-config.yaml changing can change every file, not just the changed ones.
+pre-commit-config:
+  - ".pre-commit-config.yaml"
+
 # Determines which files are appropriate for running clangd-tidy checks on.
 clangd:
   - "**/*.{hpp,cpp,inc}"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,11 +52,16 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
       - name: Style checks via prek
+        if: steps.changed-files.outputs.pre-commit-config_any_changed != 'true'
         uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
         env:
           CHANGED_FILES: '"${{ steps.changed-files.outputs.pre-commit_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators
         with:
           extra-args: --files ${{ env.CHANGED_FILES }}
+
+      - name: Style checks via prek for all files
+        if: steps.changed-files.outputs.pre-commit-config_any_changed == 'true'
+        uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
 
       - name: Class reference schema checks
         run: xmllint --noout --schema extension/doc_tools/class.xsd extension/doc_classes/*.xml


### PR DESCRIPTION
This fixes the case that .pre-commit-config.yaml changes may demand source file changes but can pass the CI anyway