### PR TITLE
Make minor version 0 default for non-game version info

### DIFF
--- a/extension/src/openvic-extension/core/config/OVDataloader.cpp
+++ b/extension/src/openvic-extension/core/config/OVDataloader.cpp
@@ -118,7 +118,7 @@ Dictionary OVDataloader::get_version_info() {
 		}
 	} else {
 		major = 0;
-		minor = 2;
+		minor = 0;
 		patch = 0;
 		prerelease_type = "unknown";
 		prerelease_count = 0;

--- a/extension/src/openvic-extension/core/config/OVLexyVDF.cpp
+++ b/extension/src/openvic-extension/core/config/OVLexyVDF.cpp
@@ -117,7 +117,7 @@ Dictionary OVLexyVDF::get_version_info() {
 		}
 	} else {
 		major = 0;
-		minor = 2;
+		minor = 0;
 		patch = 0;
 		prerelease_type = "unknown";
 		prerelease_count = 0;

--- a/extension/src/openvic-extension/core/config/OVSimulation.cpp
+++ b/extension/src/openvic-extension/core/config/OVSimulation.cpp
@@ -119,7 +119,7 @@ Dictionary OVSimulation::get_version_info() {
 		}
 	} else {
 		major = 0;
-		minor = 2;
+		minor = 0;
 		patch = 0;
 		prerelease_type = "unknown";
 		prerelease_count = 0;


### PR DESCRIPTION
Since we don't use this or care about this information yet, I see no reason to let the information remain incorrect. The minor version being 2 was specifically to resolve the empty case for OVGame since that was the furthest the game was tagged for, (which I decided should not have special detection methods just for the two tagged versions) it was a bug to leave it for the other component modules which were never tagged.