### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,19 +1,28 @@
 Checks:
   - -*
+  - bugprone-use-after-move
   - cppcoreguidelines-pro-type-member-init
+  - modernize-deprecated-headers
   - modernize-redundant-void-arg
   - modernize-use-bool-literals
   - modernize-use-default-member-init
   - modernize-use-nullptr
+  - performance-move-const-arg
   - readability-braces-around-statements
+  - readability-identifier-naming
+  - readability-operators-representation
   - readability-redundant-member-init
-HeaderFileExtensions: ['', h, hh, hpp, hxx, inc]
+HeaderFileExtensions: ["", h, hh, hpp, hxx, inc]
 ImplementationFileExtensions: [c, cc, cpp, cxx]
 HeaderFilterRegex: (extension/src/openvic-extension)/
 FormatStyle: file
 CheckOptions:
   cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
+  modernize-deprecated-headers.CheckHeaderFile: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
+  readability-identifier-naming.ParameterCase: lower_case
+  readability-operators-representation.BinaryOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="
+  readability-operators-representation.OverloadedOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,9 +29,8 @@ repos:
             --fix,
             --quiet,
             --use-color,
-            -p=compile_commands.json,
+            -p=out/build,
             -extra-arg=-Wno-unknown-warning-option,
-            -checks=-modernize-use-bool-literals,
           ]
         types_or: [text]
         additional_dependencies: [clang-tidy==22.1.8]

--- a/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
+++ b/extension/src/openvic-extension/classes/GFXPieChartTexture.hpp
@@ -142,11 +142,11 @@ namespace OpenVic {
 				godot::Dictionary sub_dict;
 
 				sub_dict[_slice_tooltip_key()] = make_tooltip(key, identifier, value, total_weight);
-				sub_dict[_slice_identifier_key()] = std::move(identifier);
+				sub_dict[_slice_identifier_key()] = identifier;
 				sub_dict[_slice_colour_key()] = convert_to<godot::Color>(key.get_colour());
 				sub_dict[_slice_weight_key()] = value;
 
-				array[index] = std::move(sub_dict);
+				array[index] = sub_dict;
 			}
 			return array;
 		}

--- a/extension/src/openvic-extension/classes/MapMesh.cpp
+++ b/extension/src/openvic-extension/classes/MapMesh.cpp
@@ -151,11 +151,11 @@ Array MapMesh::_create_mesh_array() const {
 		thisrow = point_index;
 	}
 
-	arr[Mesh::ARRAY_VERTEX] = std::move(points);
-	arr[Mesh::ARRAY_NORMAL] = std::move(normals);
-	arr[Mesh::ARRAY_TANGENT] = std::move(tangents);
-	arr[Mesh::ARRAY_TEX_UV] = std::move(uvs);
-	arr[Mesh::ARRAY_INDEX] = std::move(indices);
+	arr[Mesh::ARRAY_VERTEX] = points;
+	arr[Mesh::ARRAY_NORMAL] = normals;
+	arr[Mesh::ARRAY_TANGENT] = tangents;
+	arr[Mesh::ARRAY_TEX_UV] = uvs;
+	arr[Mesh::ARRAY_INDEX] = indices;
 
 	return arr;
 }

--- a/extension/src/openvic-extension/components/budget/abstract/BudgetExpenseComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/abstract/BudgetExpenseComponent.cpp
@@ -1,5 +1,7 @@
 #include "BudgetExpenseComponent.hpp"
 
+#include <openvic-simulation/core/object/FixedPoint.hpp>
+
 #include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;

--- a/extension/src/openvic-extension/components/budget/abstract/BudgetIncomeComponent.cpp
+++ b/extension/src/openvic-extension/components/budget/abstract/BudgetIncomeComponent.cpp
@@ -1,5 +1,7 @@
 #include "BudgetIncomeComponent.hpp"
 
+#include <openvic-simulation/core/object/FixedPoint.hpp>
+
 #include "openvic-extension/utility/Utilities.hpp"
 
 using namespace OpenVic;

--- a/extension/src/openvic-extension/core/ArgumentParser.cpp
+++ b/extension/src/openvic-extension/core/ArgumentParser.cpp
@@ -729,7 +729,7 @@ Error ArgumentParser::parse_arguments(PackedStringArray const& p_args, bool p_er
 		}
 
 		key = arg.substr(1);
-		if (key.length() > 1 && key[0] != U'-' and key[1] != U'=') {
+		if (key.length() > 1 && key[0] != U'-' && key[1] != U'=') {
 			for (const Ref<ArgumentOption> opt : _parse_argument_bool_list(key)) {
 				arguments[opt->get_name()] = true;
 			}

--- a/extension/src/openvic-extension/singletons/GameSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/GameSingleton.cpp
@@ -180,7 +180,7 @@ TypedArray<Dictionary> GameSingleton::get_mod_info() const {
 		}();
 
 		mod_info_dictionary[is_loaded_key] = ranges::contains(loaded_mods, mod);
-		results.push_back(std::move(mod_info_dictionary));
+		results.push_back(mod_info_dictionary);
 	}
 
 	return results;
@@ -201,7 +201,7 @@ TypedArray<Dictionary> GameSingleton::get_bookmark_info() const {
 		bookmark_info[bookmark_info_name_key] = convert_to<String>(bookmark.get_name());
 		bookmark_info[bookmark_info_date_key] = Utilities::date_to_formatted_string(bookmark.date, false);
 
-		results.push_back(std::move(bookmark_info));
+		results.push_back(bookmark_info);
 	}
 
 	return results;
@@ -440,7 +440,7 @@ TypedArray<Dictionary> GameSingleton::get_province_names() const {
 			province_dict[scale_key] = scale;
 		}
 
-		ret[static_cast<uint64_t>(type_safe::get(province.index))] = std::move(province_dict);
+		ret[static_cast<uint64_t>(type_safe::get(province.index))] = province_dict;
 	}
 
 	return ret;

--- a/extension/src/openvic-extension/singletons/MenuSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/MenuSingleton.cpp
@@ -417,7 +417,7 @@ static TypedArray<Dictionary> _make_buildings_dict_array(ProvinceInstance const*
 			building_dict[building_info_end_date_key] = Utilities::date_to_string(building.get_end_date());
 			building_dict[building_info_expansion_progress_key] = static_cast<real_t>(building.get_expansion_progress());
 
-			buildings_array[idx] = std::move(building_dict);
+			buildings_array[idx] = building_dict;
 		}
 	} else {
 		UtilityFunctions::push_error(
@@ -498,7 +498,7 @@ Dictionary MenuSingleton::get_province_info_from_number(int32_t province_number)
 		    _make_modifier_effects_tooltip(*terrain_type)
 		);
 
-		ret[province_info_terrain_type_key] = std::move(terrain_type_string);
+		ret[province_info_terrain_type_key] = terrain_type_string;
 	}
 
 	ret[province_info_life_rating_key] = type_safe::get(province->get_life_rating());
@@ -913,7 +913,7 @@ Dictionary MenuSingleton::get_province_info_from_number(int32_t province_number)
 	        GameSingleton::get_singleton()->get_pop_types(), province->get_population_by_type(), make_pie_chart_tooltip
 	    );
 	if (!pop_types.is_empty()) {
-		ret[province_info_pop_types_key] = std::move(pop_types);
+		ret[province_info_pop_types_key] = pop_types;
 	}
 
 	GFXPieChartTexture::godot_pie_chart_data_t ideologies =
@@ -923,14 +923,14 @@ Dictionary MenuSingleton::get_province_info_from_number(int32_t province_number)
 	        make_pie_chart_tooltip
 	    );
 	if (!ideologies.is_empty()) {
-		ret[province_info_pop_ideologies_key] = std::move(ideologies);
+		ret[province_info_pop_ideologies_key] = ideologies;
 	}
 
 	GFXPieChartTexture::godot_pie_chart_data_t cultures = GFXPieChartTexture::distribution_to_slices_array(
 	    province->get_population_by_culture(), make_pie_chart_tooltip
 	);
 	if (!cultures.is_empty()) {
-		ret[province_info_pop_cultures_key] = std::move(cultures);
+		ret[province_info_pop_cultures_key] = cultures;
 	}
 
 	ordered_set<CountryInstance*> const& cores = province->get_cores();
@@ -940,7 +940,7 @@ Dictionary MenuSingleton::get_province_info_from_number(int32_t province_number)
 			for (size_t idx = 0; idx < cores.size(); ++idx) {
 				cores_array[idx] = convert_to<String>(cores.data()[idx]->get_identifier());
 			}
-			ret[province_info_cores_key] = std::move(cores_array);
+			ret[province_info_cores_key] = cores_array;
 		} else {
 			UtilityFunctions::push_error(
 			    "Failed to resize cores array to the correct size (",
@@ -953,7 +953,7 @@ Dictionary MenuSingleton::get_province_info_from_number(int32_t province_number)
 
 	TypedArray<Dictionary> building_dict_array = _make_buildings_dict_array(province);
 	if (!building_dict_array.is_empty()) {
-		ret[province_info_buildings_key] = std::move(building_dict_array);
+		ret[province_info_buildings_key] = building_dict_array;
 	}
 
 	return ret;
@@ -1080,7 +1080,7 @@ Dictionary MenuSingleton::get_topbar_info() const {
 			            cost_replace_key, String::num_uint64(country.get_current_research_cost_untracked().truncate<int64_t>())
 			        );
 
-			ret[research_key] = std::move(current_tech_localised);
+			ret[research_key] = current_tech_localised;
 
 			ret[research_progress_key] = static_cast<real_t>(country.research_progress.get_untracked());
 		} else if (country.is_civilised()) {
@@ -1188,7 +1188,7 @@ Dictionary MenuSingleton::get_topbar_info() const {
 		            Utilities::fixed_point_to_string_dp(country.get_research_point_stockpile_untracked(), 1)
 		        );
 
-		ret[research_points_tooltip_key] = std::move(research_points_tooltip);
+		ret[research_points_tooltip_key] = research_points_tooltip;
 	}
 
 	// Politics
@@ -1297,7 +1297,7 @@ Dictionary MenuSingleton::get_topbar_info() const {
 			        .replace(max_replace_key, Utilities::fixed_point_to_string_dp(max_leadership_point_stockpile, 1));
 		}
 
-		ret[leadership_tooltip_key] = std::move(leadership_tooltip);
+		ret[leadership_tooltip_key] = leadership_tooltip;
 	}
 
 	return ret;

--- a/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
+++ b/extension/src/openvic-extension/singletons/MilitaryMenu.cpp
@@ -109,7 +109,7 @@ Dictionary MenuSingleton::make_leader_dict(LeaderInstance const& leader) {
 
 		tooltip += leader_name_prefix + leader_name + leader_name_suffix;
 
-		leader_dict[military_info_leader_name_key] = std::move(leader_name);
+		leader_dict[military_info_leader_name_key] = leader_name;
 	}
 
 	{
@@ -157,7 +157,7 @@ Dictionary MenuSingleton::make_leader_dict(LeaderInstance const& leader) {
 		        );
 
 		leader_dict[military_info_leader_prestige_key] = static_cast<real_t>(prestige);
-		leader_dict[military_info_leader_prestige_tooltip_key] = std::move(prestige_tooltip);
+		leader_dict[military_info_leader_prestige_tooltip_key] = prestige_tooltip;
 	}
 
 	{
@@ -177,7 +177,7 @@ Dictionary MenuSingleton::make_leader_dict(LeaderInstance const& leader) {
 
 		tooltip += "\n" + tr(background_localisation_key).replace(background_replace_key, background);
 
-		leader_dict[military_info_leader_background_key] = std::move(background);
+		leader_dict[military_info_leader_background_key] = background;
 	}
 
 	{
@@ -197,12 +197,12 @@ Dictionary MenuSingleton::make_leader_dict(LeaderInstance const& leader) {
 
 		tooltip += "\n" + tr(personality_localisation_key).replace(personality_replace_key, personality);
 
-		leader_dict[military_info_leader_personality_key] = std::move(personality);
+		leader_dict[military_info_leader_personality_key] = personality;
 	}
 
 	tooltip += _make_modifier_effects_tooltip(modifier_value);
 
-	leader_dict[military_info_leader_tooltip_key] = std::move(tooltip);
+	leader_dict[military_info_leader_tooltip_key] = tooltip;
 
 	cached_leader_dicts.emplace(&leader, leader_dict);
 
@@ -438,7 +438,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 		organisation_regain_tooltip += _make_modifier_effect_contributions_tooltip(
 		    *country, *modifier_effect_cache.get_org_regain()
 		);
-		ret[military_info_organisation_regain_tooltip_key] = std::move(organisation_regain_tooltip);
+		ret[military_info_organisation_regain_tooltip_key] = organisation_regain_tooltip;
 	}
 
 	ret[military_info_land_organisation_key] = static_cast<real_t>(country->get_land_organisation());
@@ -477,7 +477,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 			unit_start_experience_tooltip += "\n";
 		}
 		unit_start_experience_tooltip += naval_unit_start_experience_tooltip;
-		ret[military_info_unit_start_experience_tooltip_key] = std::move(unit_start_experience_tooltip);
+		ret[military_info_unit_start_experience_tooltip_key] = unit_start_experience_tooltip;
 	}
 
 	ret[military_info_recruit_time_key] = static_cast<real_t>(country->get_recruit_time());
@@ -503,7 +503,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 			combat_width_tooltip += from_technology_tooltip + GUILabel::get_colour_marker() + "G" +
 			                        String::num_int64(combat_width.truncate<int64_t>());
 		}
-		ret[military_info_combat_width_tooltip_key] = std::move(combat_width_tooltip);
+		ret[military_info_combat_width_tooltip_key] = combat_width_tooltip;
 	}
 
 	ret[military_info_dig_in_cap_key] = country->get_dig_in_cap();
@@ -559,7 +559,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 		    *country, *modifier_effect_cache.get_mobilisation_size_country()
 		);
 
-		ret[military_info_mobilisation_size_tooltip_key] = std::move(military_info_mobilisation_size_tooltip);
+		ret[military_info_mobilisation_size_tooltip_key] = military_info_mobilisation_size_tooltip;
 	}
 
 	if (!country->is_mobilised()) {
@@ -637,7 +637,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 				leaders[general_count + index] = make_leader_dict(country->get_admirals()[index]);
 			}
 
-			ret[military_info_leaders_list_key] = std::move(leaders);
+			ret[military_info_leaders_list_key] = leaders;
 		} else {
 			UtilityFunctions::push_error(
 			    "Failed to resize military menu leaders array to the correct size (",
@@ -668,7 +668,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 				armies[index] = make_unit_group_dict(country->get_armies()[index].get());
 			}
 
-			ret[military_info_armies_key] = std::move(armies);
+			ret[military_info_armies_key] = armies;
 		} else {
 			UtilityFunctions::push_error(
 			    "Failed to resize military menu armies array to the correct size (",
@@ -698,7 +698,7 @@ Dictionary MenuSingleton::get_military_menu_info() {
 				navies[index] = make_unit_group_dict(country->get_navies()[index].get());
 			}
 
-			ret[military_info_navies_key] = std::move(navies);
+			ret[military_info_navies_key] = navies;
 		} else {
 			UtilityFunctions::push_error(
 			    "Failed to resize military menu navies array to the correct size (",

--- a/extension/src/openvic-extension/singletons/ModelSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/ModelSingleton.cpp
@@ -180,11 +180,11 @@ Dictionary ModelSingleton::get_model_dict(GFX::Actor const& actor) {
 				attachment_dict[attachment_node_key] = convert_to<String>(attachment.get_attach_node());
 				attachment_dict[attachment_model_key] = get_model_dict(*attachment_actor);
 
-				attachments_array[idx] = std::move(attachment_dict);
+				attachments_array[idx] = attachment_dict;
 			}
 
 			if (!attachments_array.is_empty()) {
-				dict[attachments_key] = std::move(attachments_array);
+				dict[attachments_key] = attachments_array;
 			}
 
 		} else {

--- a/extension/src/openvic-extension/singletons/PopulationMenu.cpp
+++ b/extension/src/openvic-extension/singletons/PopulationMenu.cpp
@@ -963,7 +963,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_rows(int32_t start
 		pop_dict[pop_size_change_key] = type_safe::get(pop.get_total_change());
 		pop_dict[pop_literacy_key] = static_cast<real_t>(pop.get_literacy());
 
-		array[idx] = std::move(pop_dict);
+		array[idx] = pop_dict;
 	}
 
 	return array;
@@ -1018,7 +1018,7 @@ TypedArray<Dictionary> MenuSingleton::get_population_menu_pop_filter_info() cons
 		filter_dict[pop_filter_change_key] = type_safe::get(filter.promotion_demotion_change);
 		filter_dict[pop_filter_selected_key] = filter.selected;
 
-		array[idx] = std::move(filter_dict);
+		array[idx] = filter_dict;
 	}
 
 	return array;

--- a/extension/src/openvic-extension/singletons/SoundSingleton.cpp
+++ b/extension/src/openvic-extension/singletons/SoundSingleton.cpp
@@ -80,7 +80,7 @@ Ref<AudioStreamMP3> SoundSingleton::get_song(String const& path) {
 	const Ref<AudioStreamMP3> song = AudioStreamMP3::load_from_file(path);
 
 	ERR_FAIL_NULL_V_MSG(song, Ref<AudioStreamMP3>(), Utilities::format("Failed to load music file: %s", path));
-	tracks.insert(std::move(name), song);
+	tracks.insert(name, song);
 
 	return song;
 }
@@ -177,7 +177,7 @@ Ref<AudioStreamWAV> SoundSingleton::get_sound(String const& path) {
 	    sound, Ref<AudioStreamMP3>(), Utilities::format("Failed to load sound file %s", path) // named %s, path
 	);
 
-	sfx.insert(std::move(name), sound);
+	sfx.insert(name, sound);
 	return sound;
 }
 

--- a/extension/src/openvic-extension/singletons/TradeMenu.cpp
+++ b/extension/src/openvic-extension/singletons/TradeMenu.cpp
@@ -110,7 +110,7 @@ Dictionary MenuSingleton::get_trade_menu_good_categories_info() const {
 			array.push_back(good_dict);
 		}
 
-		ret[convert_to<String>(good_category.get_identifier())] = std::move(array);
+		ret[convert_to<String>(good_category.get_identifier())] = array;
 	}
 
 	return ret;
@@ -159,7 +159,7 @@ Dictionary MenuSingleton::get_trade_menu_trade_details_info(
 				price_history[idx] = static_cast<real_t>(good_price_history[idx]);
 			}
 
-			ret[trade_detail_price_history_key] = std::move(price_history);
+			ret[trade_detail_price_history_key] = price_history;
 		} else {
 			UtilityFunctions::push_error(
 			    "Failed to resize price history array to the correct size (",
@@ -238,7 +238,7 @@ Dictionary MenuSingleton::get_trade_menu_tables_info() const {
 
 		good_producers_tooltips.push_back(tooltip);
 	}
-	ret[good_producers_tooltips_key] = std::move(good_producers_tooltips);
+	ret[good_producers_tooltips_key] = good_producers_tooltips;
 
 	CountryInstance const* country_ptr = PlayerSingleton::get_singleton()->get_player_country();
 	if (unlikely(country_ptr == nullptr)) {
@@ -311,13 +311,13 @@ Dictionary MenuSingleton::get_trade_menu_tables_info() const {
 		common_market.push_back({ good_index, good_index * 100, -good_index, good_index * 10 });
 	}
 
-	ret[good_trading_yesterday_tooltips_key] = std::move(good_trading_yesterday_tooltips);
-	ret[government_needs_key] = std::move(government_needs);
-	ret[factory_needs_key] = std::move(factory_needs);
-	ret[pop_needs_key] = std::move(pop_needs);
-	ret[market_activity_key] = std::move(market_activity);
-	ret[stockpile_key] = std::move(stockpile);
-	ret[common_market_key] = std::move(common_market);
+	ret[good_trading_yesterday_tooltips_key] = good_trading_yesterday_tooltips;
+	ret[government_needs_key] = government_needs;
+	ret[factory_needs_key] = factory_needs;
+	ret[pop_needs_key] = pop_needs;
+	ret[market_activity_key] = market_activity;
+	ret[stockpile_key] = stockpile;
+	ret[common_market_key] = common_market;
 
 	return ret;
 }

--- a/extension/src/openvic-extension/utility/Utilities.hpp
+++ b/extension/src/openvic-extension/utility/Utilities.hpp
@@ -1,24 +1,33 @@
 #pragma once
 
 #include <concepts>
+#include <cstdint>
 
 #include <godot_cpp/classes/file_access.hpp>
-#include <godot_cpp/classes/font_file.hpp>
-#include <godot_cpp/classes/image_texture.hpp>
+#include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/core/math_defs.hpp>
+#include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
 #include <openvic-simulation/core/memory/Vector.hpp>
-#include <openvic-simulation/core/object/Colour.hpp>
-#include <openvic-simulation/core/object/Date.hpp>
-#include <openvic-simulation/core/object/Vector.hpp>
+
+#include <fmt/base.h>
 
 #define ERR(x) ((x) ? OK : FAILED)
 
 namespace godot {
-	struct Object;
+	class Object;
+	class StringName;
+	class Color;
+	class Resource;
+	class ImageTexture;
+	class FontFile;
 }
 
 namespace OpenVic {
+	class fixed_point_t;
+	class Date;
 	struct CountryInstance;
 	struct ModifierEffect;
 	struct State;
@@ -51,8 +60,8 @@ namespace OpenVic::Utilities {
 	godot::String cash_to_string_dp_dynamic(fixed_point_t val);
 	godot::String format_with_currency(godot::String const& text);
 
-	constexpr real_t to_real_t(std::floating_point auto val) {
-		return static_cast<real_t>(val);
+	constexpr godot::real_t to_real_t(std::floating_point auto val) {
+		return static_cast<godot::real_t>(val);
 	}
 
 	godot::String date_to_string(Date date);
@@ -168,7 +177,7 @@ namespace OpenVic::Utilities {
 	}
 
 	namespace literals {
-		constexpr real_t operator""_real(long double val) {
+		constexpr godot::real_t operator""_real(long double val) {
 			return to_real_t(val);
 		}
 	}


### PR DESCRIPTION
Fix .pre-commit-config.yaml clang-tidy hook arguments
Add checks to .clang-tidy:
- bugprone-use-after-move
- modernize-deprecated-headers
- performance-move-const-arg
- readability-identifier-naming
- readability-operators-representation